### PR TITLE
Issue #43: Replace 'winRm' protocol name in MetricsHub agent by 'winrm'

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/protocols/ProtocolsConfig.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/protocols/ProtocolsConfig.java
@@ -61,5 +61,5 @@ public class ProtocolsConfig {
 	private OsCommandProtocolConfig osCommand;
 
 	@JsonSetter(nulls = SKIP)
-	private WinRmProtocolConfig winRm;
+	private WinRmProtocolConfig winrm;
 }

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
@@ -932,7 +932,7 @@ public class ConfigHelper {
 			return;
 		}
 
-		final WinRmProtocolConfig winRmConfig = protocolsConfig.getWinRm();
+		final WinRmProtocolConfig winRmConfig = protocolsConfig.getWinrm();
 		if (winRmConfig != null) {
 			validateWinRmInfo(resourceKey, winRmConfig.getPort(), winRmConfig.getTimeout(), winRmConfig.getUsername());
 		}
@@ -1218,7 +1218,7 @@ public class ConfigHelper {
 						protocols.getWmi(),
 						protocols.getOsCommand(),
 						protocols.getIpmi(),
-						protocols.getWinRm()
+						protocols.getWinrm()
 					)
 					.filter(Objects::nonNull)
 					.map(AbstractProtocolConfig::toConfiguration)


### PR DESCRIPTION
* Replaced 'winRm' protocol name by 'winrm' in lowercase in the agent.
* Made all the necessary changes to keep the code working.
* Test the changes using the agent.