### PR TITLE
Issue #58: Change MetricsHub groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a multi-module project:
 
 * **/**: The root (parent of all submodules)
 * **metricshub-engine**: The brain, the heart of this project. It houses the core logic and essential functionalities that power the entire system.
-* **hardware**: Hardware Energy and Sustainability module, dedicated to managing and monitoring hardware-related metrics, focusing on energy consumption and sustainability aspects.
+* **metricshub-hardware**: Hardware Energy and Sustainability module, dedicated to managing and monitoring hardware-related metrics, focusing on energy consumption and sustainability aspects.
 * **metricshub-agent**: The MetricsHub Agent module includes a Command-Line Interface (CLI) and is responsible for interacting with the MetricsHub engine. It acts as an entry point, collecting and transmitting data to the OpenTelemetry Collector.
 * **metricshub-windows**: Builds the `.zip` package for MetricsHub on Windows platforms.
 * **metricshub-linux**: Builds the `.tar.gz` package of MetricsHub on Linux platforms.

--- a/metricshub-agent/pom.xml
+++ b/metricshub-agent/pom.xml
@@ -34,7 +34,7 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- Hardware -->
+		<!-- MetricsHub Hardware -->
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>metricshub-hardware</artifactId>


### PR DESCRIPTION
* Replaced all `Hardware` occurrences by `MetricsHub-hardware`