### PR TITLE
Issue #71: Include Agent Resource Attributes in metricshub.agent.info

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/context/AgentInfo.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/context/AgentInfo.java
@@ -26,9 +26,14 @@ import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_IN
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_INFO_CC_VERSION_NUMBER_ATTRIBUTE_KEY;
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_INFO_NAME_ATTRIBUTE_KEY;
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_INFO_VERSION_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_AGENT_HOST_NAME_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_HOST_ID_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_HOST_TYPE_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_OS_TYPE_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_SERVICE_NAME_ATTRIBUTE_KEY;
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.APPLICATION_YAML_FILE_NAME;
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.OBJECT_MAPPER;
-import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.HOST_NAME;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.OTEL_AIX_OS_TYPE;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.OTEL_FREE_BSD_OS_TYPE;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.OTEL_HPUX_OS_TYPE;
@@ -135,12 +140,12 @@ public class AgentInfo {
 		// @formatter:off
 		resourceAttributes =
 			Map.of(
-				"service.name", project.name(),
-				"host.id", AGENT_HOSTNAME,
-				HOST_NAME, AGENT_HOSTNAME,
-				"agent.host.name", AGENT_HOSTNAME,
-				"host.type", "compute",
-				"os.type", OTEL_LOCAL_OS_TYPE
+				AGENT_RESOURCE_SERVICE_NAME_ATTRIBUTE_KEY, project.name(),
+				AGENT_RESOURCE_HOST_ID_ATTRIBUTE_KEY, AGENT_HOSTNAME,
+				AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY, AGENT_HOSTNAME,
+				AGENT_RESOURCE_AGENT_HOST_NAME_ATTRIBUTE_KEY, AGENT_HOSTNAME,
+				AGENT_RESOURCE_HOST_TYPE_ATTRIBUTE_KEY, "compute",
+				AGENT_RESOURCE_OS_TYPE_ATTRIBUTE_KEY, OTEL_LOCAL_OS_TYPE
 			);
 		// @formatter:on
 	}

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/AgentConstants.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/AgentConstants.java
@@ -34,12 +34,14 @@ import lombok.NoArgsConstructor;
 public class AgentConstants {
 
 	// Application YAML properties
+
 	/**
 	 * Application YAML file name
 	 */
 	public static final String APPLICATION_YAML_FILE_NAME = "application.yaml";
 
 	// Configuration file
+
 	/**
 	 * Product code
 	 */
@@ -86,30 +88,66 @@ public class AgentConstants {
 	public static final String FILE_PATH_FORMAT = "%s/%s";
 
 	// Agent attribute information constants
+
 	/**
 	 * Agent info community connectors version number attribute key
 	 */
 	public static final String AGENT_INFO_CC_VERSION_NUMBER_ATTRIBUTE_KEY = "cc_version";
+
 	/**
 	 * Agent info build date number attribute key
 	 */
 	public static final String AGENT_INFO_BUILD_DATE_NUMBER_ATTRIBUTE_KEY = "build_date";
+
 	/**
 	 * Agent info build number attribute key
 	 */
 	public static final String AGENT_INFO_BUILD_NUMBER_ATTRIBUTE_KEY = "build_number";
+
 	/**
 	 * Agent info version attribute key
 	 */
 	public static final String AGENT_INFO_VERSION_ATTRIBUTE_KEY = "version";
+
 	/**
 	 * Agent info name attribute key
 	 */
 	public static final String AGENT_INFO_NAME_ATTRIBUTE_KEY = "name";
 
-	// Object Mapper
 	/**
-	 * Object mapper
+	 *  Agent Resource operating system type attribute key
+	 */
+	public static final String AGENT_RESOURCE_OS_TYPE_ATTRIBUTE_KEY = "os.type";
+
+	/**
+	 *  Agent Resource host type attribute  key
+	 */
+	public static final String AGENT_RESOURCE_HOST_TYPE_ATTRIBUTE_KEY = "host.type";
+
+	/**
+	 *  Agent Resource agent's host name attribute key
+	 */
+	public static final String AGENT_RESOURCE_AGENT_HOST_NAME_ATTRIBUTE_KEY = "agent.host.name";
+
+	/**
+	 * Agent Resource host identifier attribute key
+	 */
+	public static final String AGENT_RESOURCE_HOST_ID_ATTRIBUTE_KEY = "host.id";
+
+	/**
+	 * Agent Resource host name attribute key
+	 */
+	public static final String AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY = "host.name";
+
+	/**
+	 * Agent Resource service name attribute key
+	 */
+	public static final String AGENT_RESOURCE_SERVICE_NAME_ATTRIBUTE_KEY = "service.name";
+
+	// Jackson Databind ObjectMapper
+
+	/**
+	 * Jackson Databind ObjectMapper
 	 */
 	public static final ObjectMapper OBJECT_MAPPER = ConfigHelper.newObjectMapper();
 }

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/scheduling/SelfObserverScheduling.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/scheduling/SelfObserverScheduling.java
@@ -113,7 +113,10 @@ public class SelfObserverScheduling extends AbstractScheduling {
 
 		final Map<String, String> attributeMap = new HashMap<>();
 
-		// Add our attributes
+		// Merge resource attributes
+		ConfigHelper.mergeAttributes(agentInfo.getResourceAttributes(), attributeMap);
+
+		// Merge metric attributes
 		ConfigHelper.mergeAttributes(agentInfo.getMetricAttributes(), attributeMap);
 
 		// Override with the user's attributes

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/scheduling/SelfObserverSchedulingTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/scheduling/SelfObserverSchedulingTest.java
@@ -14,6 +14,12 @@ import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_IN
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_INFO_CC_VERSION_NUMBER_ATTRIBUTE_KEY;
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_INFO_NAME_ATTRIBUTE_KEY;
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_INFO_VERSION_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_AGENT_HOST_NAME_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_HOST_ID_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_HOST_TYPE_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_OS_TYPE_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_SERVICE_NAME_ATTRIBUTE_KEY;
 import static org.sentrysoftware.metricshub.agent.helper.TestConstants.COMPANY_ATTRIBUTE_KEY;
 import static org.sentrysoftware.metricshub.agent.helper.TestConstants.COMPANY_ATTRIBUTE_VALUE;
 
@@ -107,6 +113,15 @@ class SelfObserverSchedulingTest {
 
 			final Attributes attributes = dataPoint.getAttributes();
 
+			// Verify resource attributes
+			assertNotNull(attributes.get(AttributeKey.stringKey(AGENT_RESOURCE_OS_TYPE_ATTRIBUTE_KEY)));
+			assertNotNull(attributes.get(AttributeKey.stringKey(AGENT_RESOURCE_HOST_TYPE_ATTRIBUTE_KEY)));
+			assertNotNull(attributes.get(AttributeKey.stringKey(AGENT_RESOURCE_AGENT_HOST_NAME_ATTRIBUTE_KEY)));
+			assertNotNull(attributes.get(AttributeKey.stringKey(AGENT_RESOURCE_HOST_ID_ATTRIBUTE_KEY)));
+			assertNotNull(attributes.get(AttributeKey.stringKey(AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY)));
+			assertNotNull(attributes.get(AttributeKey.stringKey(AGENT_RESOURCE_SERVICE_NAME_ATTRIBUTE_KEY)));
+
+			// Verify metric attributes
 			assertNotNull(attributes.get(AttributeKey.stringKey(AGENT_INFO_NAME_ATTRIBUTE_KEY)));
 			assertNotNull(attributes.get(AttributeKey.stringKey(AGENT_INFO_VERSION_ATTRIBUTE_KEY)));
 			assertNotNull(attributes.get(AttributeKey.stringKey(AGENT_INFO_BUILD_NUMBER_ATTRIBUTE_KEY)));


### PR DESCRIPTION
* Updated `SelfObserverScheduling` to include the Agent Resource attributes in the `metricshub.agent.info` metric.