### PR TITLE
Issue #82: Enhance the collect of `metricshub.connector.status`

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/PrettyPrinterService.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/PrettyPrinterService.java
@@ -206,13 +206,13 @@ public class PrettyPrinterService {
 		// spaces, resulting in the final format string: %-25s
 		final String metricNameFormat = String.format("%%-%ds", metricMaxLength + 5);
 
-		final Optional<Map<String, MetricDefinition>> maybeMetricDefinitions;
+		final Map<String, MetricDefinition> metricDefinitions;
 		// Get host monitor's metric definitions
 		if (monitor.isEndpointHost()) {
-			maybeMetricDefinitions = Optional.ofNullable(hostMetricDefinitions.metrics());
+			metricDefinitions = hostMetricDefinitions.metrics();
 		} else {
 			// Retrieves the metric definitions for any other monitor
-			maybeMetricDefinitions =
+			metricDefinitions =
 				ConfigHelper.fetchMetricDefinitions(
 					telemetryManager.getConnectorStore(),
 					monitor.getAttribute(MONITOR_ATTRIBUTE_CONNECTOR_ID)
@@ -237,7 +237,7 @@ public class PrettyPrinterService {
 				addMargin(indentation);
 
 				if (metric instanceof NumberMetric numberMetric) {
-					final Optional<String> maybeUnit = fetchUnit(MetricFactory.extractName(metricName), maybeMetricDefinitions);
+					final Optional<String> maybeUnit = fetchUnit(MetricFactory.extractName(metricName), metricDefinitions);
 					// Handle NumberMetric
 					printNumberMetric(formattedMetricName, numberMetric, maybeUnit);
 				} else if (metric instanceof StateSetMetric stateSetMetric) {
@@ -417,17 +417,14 @@ public class PrettyPrinterService {
 	/**
 	 * Retrieves the unit associated with the specified metric name from the provided metric definition map.
 	 *
-	 * @param metricName               The name of the metric, e.g., "hw.energy"
-	 * @param maybeMetricDefinitionMap Optional {@link Map} containing metric definitions
+	 * @param metricName          The name of the metric, e.g., "hw.energy".
+	 * @param metricDefinitionMap {@link Map} containing metric definitions.
 	 * @return An {@link Optional} of {@link String} representing the unit of the metric;
 	 *         an empty optional if the metric definition is absent, the metric is not found, or the unit is blank.
 	 */
-	static Optional<String> fetchUnit(
-		final String metricName,
-		final Optional<Map<String, MetricDefinition>> maybeMetricDefinitionMap
-	) {
-		return maybeMetricDefinitionMap
-			.map(map -> map.get(metricName))
+	static Optional<String> fetchUnit(final String metricName, final Map<String, MetricDefinition> metricDefinitionMap) {
+		return Optional
+			.ofNullable(metricDefinitionMap.get(metricName))
 			.filter(Objects::nonNull)
 			.map(MetricDefinition::getUnit)
 			.filter(unit -> Objects.nonNull(unit) && !unit.isBlank());

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/PrettyPrinterService.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/PrettyPrinterService.java
@@ -425,7 +425,6 @@ public class PrettyPrinterService {
 	static Optional<String> fetchUnit(final String metricName, final Map<String, MetricDefinition> metricDefinitionMap) {
 		return Optional
 			.ofNullable(metricDefinitionMap.get(metricName))
-			.filter(Objects::nonNull)
 			.map(MetricDefinition::getUnit)
 			.filter(unit -> Objects.nonNull(unit) && !unit.isBlank());
 	}

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelperTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelperTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -526,22 +527,28 @@ class ConfigHelperTest {
 	@Test
 	void testFetchMetricDefinitions() {
 		final ConnectorStore connectorStore = new ConnectorStore();
-		final Map<String, MetricDefinition> metricDefintionsMap = Map.of(
+		final Map<String, MetricDefinition> metricDefintionMap = Map.of(
 			"metric",
 			MetricDefinition.builder().unit("unit").build()
 		);
 		connectorStore.setStore(
-			Map.of(PURE_STORAGE_REST_CONNECTOR_ID, Connector.builder().metrics(metricDefintionsMap).build())
+			Map.of(PURE_STORAGE_REST_CONNECTOR_ID, Connector.builder().metrics(metricDefintionMap).build())
 		);
 
-		assertEquals(
-			Optional.of(metricDefintionsMap),
-			ConfigHelper.fetchMetricDefinitions(connectorStore, PURE_STORAGE_REST_CONNECTOR_ID)
+		final Map<String, MetricDefinition> defaultMetricDefinitionMap = Map.of(
+			MetricsHubConstants.CONNECTOR_STATUS_METRIC_KEY,
+			MetricsHubConstants.CONNECTOR_STATUS_METRIC_DEFINITION
 		);
-		assertTrue(ConfigHelper.fetchMetricDefinitions(connectorStore, "other").isEmpty());
-		assertTrue(ConfigHelper.fetchMetricDefinitions(null, null).isEmpty());
-		assertTrue(ConfigHelper.fetchMetricDefinitions(null, PURE_STORAGE_REST_CONNECTOR_ID).isEmpty());
-		assertTrue(ConfigHelper.fetchMetricDefinitions(connectorStore, null).isEmpty());
+
+		final Map<String, MetricDefinition> expected = new HashMap<>();
+		expected.putAll(metricDefintionMap);
+		expected.putAll(defaultMetricDefinitionMap);
+
+		assertEquals(expected, ConfigHelper.fetchMetricDefinitions(connectorStore, PURE_STORAGE_REST_CONNECTOR_ID));
+		assertEquals(defaultMetricDefinitionMap, ConfigHelper.fetchMetricDefinitions(connectorStore, "other"));
+		assertEquals(defaultMetricDefinitionMap, ConfigHelper.fetchMetricDefinitions(null, null));
+		assertEquals(defaultMetricDefinitionMap, ConfigHelper.fetchMetricDefinitions(null, PURE_STORAGE_REST_CONNECTOR_ID));
+		assertEquals(defaultMetricDefinitionMap, ConfigHelper.fetchMetricDefinitions(connectorStore, null));
 	}
 
 	@Test

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/task/MonitoringTaskTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/task/MonitoringTaskTest.java
@@ -33,7 +33,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -233,8 +232,9 @@ class MonitoringTaskTest {
 			final String expectedDescription = "description";
 
 			// Create metric definition map that defines the expected unit and description for the hw.temperature.limit metric
-			final Optional<Map<String, MetricDefinition>> metricDefinitionMapOpt = Optional.of(
-				Map.of(metricName, MetricDefinition.builder().unit(expectedUnit).description(expectedDescription).build())
+			final Map<String, MetricDefinition> metricDefinitionMap = Map.of(
+				metricName,
+				MetricDefinition.builder().unit(expectedUnit).description(expectedDescription).build()
 			);
 
 			// Create a mock metric entry
@@ -250,7 +250,7 @@ class MonitoringTaskTest {
 			);
 
 			// Initialize the metric observer
-			monitoringTask.initMetricObserver(monitor, metricDefinitionMapOpt, metricEntry);
+			monitoringTask.initMetricObserver(monitor, metricDefinitionMap, metricEntry);
 
 			// Collect metrics from the in-memory reader and perform assertions
 			final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/cli/service/MetricsHubCliServiceTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/cli/service/MetricsHubCliServiceTest.java
@@ -13,7 +13,6 @@ import org.sentrysoftware.metricshub.cli.helper.StringBuilderWriter;
 import org.sentrysoftware.metricshub.cli.service.MetricsHubCliService.CliPasswordReader;
 import org.sentrysoftware.metricshub.cli.service.protocol.HttpConfigCli;
 import org.sentrysoftware.metricshub.cli.service.protocol.IpmiConfigCli;
-import org.sentrysoftware.metricshub.cli.service.protocol.SnmpConfigCli;
 import org.sentrysoftware.metricshub.cli.service.protocol.SshConfigCli;
 import org.sentrysoftware.metricshub.cli.service.protocol.WbemConfigCli;
 import org.sentrysoftware.metricshub.cli.service.protocol.WinRmConfigCli;

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/cli/service/PrettyPrinterServiceTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/cli/service/PrettyPrinterServiceTest.java
@@ -310,13 +310,13 @@ class PrettyPrinterServiceTest {
 	@Test
 	void testFetchUnit() {
 		final String energyMetric = "hw.energy";
-		assertTrue(PrettyPrinterService.fetchUnit(energyMetric, Optional.empty()).isEmpty());
+		assertTrue(PrettyPrinterService.fetchUnit(energyMetric, Map.of()).isEmpty());
 		final String unit = "J";
 
 		final Map<String, MetricDefinition> metricDefintionsMap = Map.of(
 			energyMetric,
 			MetricDefinition.builder().unit(unit).build()
 		);
-		assertEquals(Optional.of(unit), PrettyPrinterService.fetchUnit(energyMetric, Optional.of(metricDefintionsMap)));
+		assertEquals(Optional.of(unit), PrettyPrinterService.fetchUnit(energyMetric, metricDefintionsMap));
 	}
 }

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/MetricsHubConstants.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/MetricsHubConstants.java
@@ -31,10 +31,13 @@ import static org.sentrysoftware.metricshub.engine.connector.model.common.Device
 import static org.sentrysoftware.metricshub.engine.connector.model.common.DeviceKind.WINDOWS;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.connector.model.common.DeviceKind;
+import org.sentrysoftware.metricshub.engine.connector.model.metric.MetricDefinition;
+import org.sentrysoftware.metricshub.engine.connector.model.metric.StateSet;
 
 /**
  * The MetricsHubConstants class provides constants used in the MetricsHub engine.
@@ -297,6 +300,15 @@ public class MetricsHubConstants {
 	 * StateSet Metric Failed
 	 */
 	public static final String STATE_SET_METRIC_FAILED = "failed";
+
+	/**
+	 * Connector Status Metric Definition
+	 **/
+	public static final MetricDefinition CONNECTOR_STATUS_METRIC_DEFINITION = MetricDefinition
+		.builder()
+		.description("Connector operational status.")
+		.type(StateSet.builder().set(Set.of(STATE_SET_METRIC_OK, STATE_SET_METRIC_FAILED)).build())
+		.build();
 
 	/**
 	 * LocalHost

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/telemetry/MetricFactory.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/telemetry/MetricFactory.java
@@ -22,7 +22,6 @@ package org.sentrysoftware.metricshub.engine.telemetry;
  */
 
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.COMMA;
-import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.CONNECTOR_STATUS_METRIC_KEY;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.EMPTY;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_ID;
 
@@ -40,7 +39,6 @@ import org.sentrysoftware.metricshub.engine.connector.model.Connector;
 import org.sentrysoftware.metricshub.engine.connector.model.metric.MetricDefinition;
 import org.sentrysoftware.metricshub.engine.connector.model.metric.MetricType;
 import org.sentrysoftware.metricshub.engine.connector.model.metric.StateSet;
-import org.sentrysoftware.metricshub.engine.strategy.detection.ConnectorTestResult;
 import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
 import org.sentrysoftware.metricshub.engine.telemetry.metric.NumberMetric;
 import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
@@ -195,28 +193,6 @@ public class MetricFactory {
 			);
 			return null;
 		}
-	}
-
-	/**
-	 * Collects the connector status metric as a number.
-	 *
-	 * @param connectorTestResult  Information about connector tests.
-	 * @param monitor              The monitor to collect the metric for.
-	 * @param strategyTime         Strategy time.
-	 * @return {@code true} if the connector test was successful, {@code false} otherwise.
-	 */
-	public boolean collectConnectorStatusNumberMetric(
-		final ConnectorTestResult connectorTestResult,
-		final Monitor monitor,
-		final long strategyTime
-	) {
-		final MetricFactory metricFactory = new MetricFactory(hostname);
-		if (connectorTestResult.isSuccess()) {
-			metricFactory.collectNumberMetric(monitor, CONNECTOR_STATUS_METRIC_KEY, 1.0, strategyTime);
-			return true;
-		}
-		metricFactory.collectNumberMetric(monitor, CONNECTOR_STATUS_METRIC_KEY, 0.0, strategyTime);
-		return false;
 	}
 
 	/**

--- a/metricshub-hardware/src/it/resources/os/SuperConnectorOsIT/expected/expected.json
+++ b/metricshub-hardware/src/it/resources/os/SuperConnectorOsIT/expected/expected.json
@@ -388,7 +388,6 @@
     "attributes" : {
       "name" : "SuperConnectorOS",
       "connector_id" : "SuperConnectorOS",
-      "description" : "This connector provides super power connector.",
       "applies_to_os" : "aix,hpux,linux,oob,solaris,storage,tru64,vms,windows",
       "parent.id" : "localhost",
       "id" : "SuperConnectorOS"

--- a/metricshub-hardware/src/it/resources/snmp/DellOpenManageIT/expected/expected.json
+++ b/metricshub-hardware/src/it/resources/snmp/DellOpenManageIT/expected/expected.json
@@ -83,7 +83,6 @@
       "parent.id" : "localhost",
       "name" : "DellOpenManage",
       "connector_id" : "DellOpenManage",
-      "description" : "This connector provides hardware monitoring through the Dell OpenManage Server Administrator SNMP agent which supports almost all Dell PowerEdge servers.",
       "applies_to_os" : "linux,windows",
       "id" : "DellOpenManage"
     },


### PR DESCRIPTION
* Removed the description attribute from the connector monitor.
* The engine collects `metricshub.connector.status` as state set metric.
* The agent forces a definition for `metricshub.connector.status`.
* Added unit tests.