### PR TITLE
Issue #158: Fixed logging and OTEL Collector executable filename

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/otel/OtelCollectorConfig.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/otel/OtelCollectorConfig.java
@@ -70,10 +70,6 @@ public class OtelCollectorConfig {
 	}
 
 	/**
-	 * Default executable name for the OpenTelemetry Collector.
-	 */
-	public static final String EXECUTABLE_NAME = "otelcol-contrib";
-	/**
 	 * Default executable output ID for the OpenTelemetry Collector.
 	 */
 	public static final String EXECUTABLE_OUTPUT_ID = "otelcol";
@@ -109,8 +105,11 @@ public class OtelCollectorConfig {
 	private static List<String> buildDefaultCommandLine() {
 		final List<String> commandLine = new ArrayList<>();
 
+		// Default executable file name for the OpenTelemetry Collector.
+		final String executableFileName = LocalOsHandler.isWindows() ? "otelcol-contrib.exe" : "otelcol-contrib";
+
 		// Executable path
-		commandLine.add(ConfigHelper.getSubPath(OTEL_DIRECTORY_NAME + "/" + EXECUTABLE_NAME).toString());
+		commandLine.add(ConfigHelper.getSubPath(OTEL_DIRECTORY_NAME + "/" + executableFileName).toString());
 
 		// Configuration path
 		commandLine.add("--config");

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/process/config/ProcessOutput.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/process/config/ProcessOutput.java
@@ -85,8 +85,8 @@ public class ProcessOutput {
 	 */
 	public static ProcessOutput log(final Logger logger) {
 		return builder()
-			.outputProcessor(ProcessorHelper.logger(logger, Slf4jLevel.DEBUG))
-			.errorProcessor(ProcessorHelper.logger(logger, Slf4jLevel.ERROR))
+			.outputProcessor(ProcessorHelper.safeLogger(logger, Slf4jLevel.DEBUG))
+			.errorProcessor(ProcessorHelper.safeLogger(logger, Slf4jLevel.ERROR))
 			.build();
 	}
 
@@ -98,6 +98,6 @@ public class ProcessOutput {
 	 * @return a new {@link ProcessOutput}
 	 */
 	public static ProcessOutput logOutput(final Logger logger) {
-		return builder().outputProcessor(ProcessorHelper.logger(logger, Slf4jLevel.DEBUG)).build();
+		return builder().outputProcessor(ProcessorHelper.safeLogger(logger, Slf4jLevel.DEBUG)).build();
 	}
 }

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/process/io/ProcessorHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/process/io/ProcessorHelper.java
@@ -94,7 +94,7 @@ public class ProcessorHelper {
 	}
 
 	/**
-	 * Create a new {@link Slf4jStreamProcessor} wrapped by the {@link NamedStreamProcessor}
+	 * Create a new {@link Slf4jSafeStreamProcessor} wrapped by the {@link NamedStreamProcessor}
 	 *
 	 * @param name    The name which each line starts with
 	 * @param logger  Slf4j {@link Logger}

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/process/io/ProcessorHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/process/io/ProcessorHelper.java
@@ -82,6 +82,18 @@ public class ProcessorHelper {
 	}
 
 	/**
+	 * Constructs a new {@link Slf4jStreamProcessor} using the specified logger to log output messages,
+	 * and then encapsulates it within a {@link Slf4jSafeStreamProcessor} for enhanced logging safety.
+	 *
+	 * @param logger Slf4j {@link Logger}
+	 * @param level  Level used to log messages
+	 * @return new {@link StreamProcessor}
+	 */
+	public static StreamProcessor safeLogger(final Logger logger, final Slf4jLevel level) {
+		return new Slf4jSafeStreamProcessor(logger(logger, level));
+	}
+
+	/**
 	 * Create a new {@link Slf4jStreamProcessor} wrapped by the {@link NamedStreamProcessor}
 	 *
 	 * @param name    The name which each line starts with
@@ -90,7 +102,7 @@ public class ProcessorHelper {
 	 * @return new {@link StreamProcessor}
 	 */
 	public static StreamProcessor namedLogger(final String name, final Logger logger, final Slf4jLevel level) {
-		return named(name, logger(logger, level));
+		return named(name, safeLogger(logger, level));
 	}
 
 	/**

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/process/io/Slf4jSafeStreamProcessor.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/process/io/Slf4jSafeStreamProcessor.java
@@ -1,0 +1,46 @@
+package org.sentrysoftware.metricshub.agent.process.io;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+/**
+ * A {@link StreamProcessor} implementation designed to safely handle logging of
+ * process output blocks through the Slf4j logger facade. This processor ensures
+ * that log messages containing placeholder tokens (like "{}") are processed
+ * correctly by escaping them to avoid accidental formatting errors during logging.
+ *
+ * This class is particularly useful when you have logs that may contain untrusted
+ * input that should not affect the log format and should be handled in a secure manner.
+ **/
+@AllArgsConstructor
+public class Slf4jSafeStreamProcessor implements StreamProcessor {
+
+	@NonNull
+	private final StreamProcessor destination;
+
+	@Override
+	public void process(String block) {
+		destination.process(block != null ? block.replace("{}", "{ }") : block);
+	}
+}

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/process/io/ProcessorHelperTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/process/io/ProcessorHelperTest.java
@@ -26,6 +26,7 @@ class ProcessorHelperTest {
 		assertEquals(ConsoleStreamProcessor.class, ProcessorHelper.console(false).getClass());
 		assertEquals(NamedStreamProcessor.class, ProcessorHelper.namedConsole("test", false).getClass());
 		assertEquals(Slf4jStreamProcessor.class, ProcessorHelper.logger(logger, Slf4jLevel.INFO).getClass());
+		assertEquals(Slf4jSafeStreamProcessor.class, ProcessorHelper.safeLogger(logger, Slf4jLevel.INFO).getClass());
 		assertEquals(NamedStreamProcessor.class, ProcessorHelper.namedLogger("test", logger, Slf4jLevel.INFO).getClass());
 	}
 

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/process/io/Slf4jSafeStreamProcessorTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/process/io/Slf4jSafeStreamProcessorTest.java
@@ -1,0 +1,48 @@
+package org.sentrysoftware.metricshub.agent.process.io;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.sentrysoftware.metricshub.agent.process.config.Slf4jLevel;
+import org.sentrysoftware.metricshub.agent.service.OtelCollectorProcessService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class Slf4jSafeStreamProcessorTest {
+
+	@Test
+	void test() {
+		final StringBuilder builder = new StringBuilder();
+		final Slf4jTestStreamProcessor destination = new Slf4jTestStreamProcessor(
+			LoggerFactory.getLogger(OtelCollectorProcessService.class),
+			Slf4jLevel.INFO,
+			builder
+		);
+		assertDoesNotThrow(() -> new Slf4jSafeStreamProcessor(destination).process(null));
+		assertEquals("null", builder.toString());
+		builder.setLength(0);
+		assertDoesNotThrow(() -> new Slf4jSafeStreamProcessor(destination).process(""));
+		assertEquals("", builder.toString());
+		builder.setLength(0);
+		assertDoesNotThrow(() -> new Slf4jSafeStreamProcessor(destination).process("{}"));
+		assertEquals("{ }", builder.toString());
+		builder.setLength(0);
+	}
+
+	class Slf4jTestStreamProcessor extends Slf4jStreamProcessor {
+
+		private StringBuilder builder;
+
+		public Slf4jTestStreamProcessor(@NonNull Logger logger, @NonNull Slf4jLevel level, StringBuilder builder) {
+			super(logger, level);
+			this.builder = builder;
+		}
+
+		@Override
+		public void process(String block) {
+			builder.append(block);
+		}
+	}
+}


### PR DESCRIPTION
* On Windows the executable filename is set to `otelcol-contrib.exe`
* Now OTEL logs are protected using `Slf4jSafeStreamProcessor`