### PR TITLE
Issue #165: Remove Windows configurations and checks from OsCommandExtension

### DIFF
--- a/metricshub-engine/pom.xml
+++ b/metricshub-engine/pom.xml
@@ -93,20 +93,6 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-		<groupId>org.sentrysoftware</groupId>
-			<artifactId>http</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-simple</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>org.sentrysoftware</groupId>
 			<artifactId>jflat</artifactId>
 		</dependency>

--- a/metricshub-oscommand-extension/pom.xml
+++ b/metricshub-oscommand-extension/pom.xml
@@ -150,7 +150,7 @@
 										<limit>
 											<counter>COMPLEXITY</counter>
 											<value>COVEREDRATIO</value>
-											<minimum>0.52</minimum>
+											<minimum>0.51</minimum>
 										</limit>
 									</limits>
 								</rule>

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtensionTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtensionTest.java
@@ -975,7 +975,7 @@ class OsCommandExtensionTest {
 	}
 
 	@Test
-	void testVisitCommandLineExpectedResultEmpty() {
+	void testProcessCommandLineExpectedResultEmpty() {
 		final CommandLineCriterion commandLineCriterion = new CommandLineCriterion();
 		commandLineCriterion.setCommandLine(
 			"naviseccli -User %{USERNAME} -Password %{PASSWORD} -Address %{HOSTNAME} -Scope 1 getagent"
@@ -1005,17 +1005,20 @@ class OsCommandExtensionTest {
 	}
 
 	@Test
-	void testVisitCommandLineNull() {
+	void testProcessCommandLineNull() {
 		final CommandLineCriterion commandLineCriterion = null;
 
+		final HostConfiguration hostConfiguration = HostConfiguration.builder().hostname(HOSTNAME).build();
+		final TelemetryManager telemetryManager = TelemetryManager.builder().hostConfiguration(hostConfiguration).build();
+
 		assertThrows(
-			NullPointerException.class,
-			() -> osCommandExtension.processCriterion(commandLineCriterion, MY_CONNECTOR_1_NAME, null)
+			IllegalArgumentException.class,
+			() -> osCommandExtension.processCriterion(commandLineCriterion, MY_CONNECTOR_1_NAME, telemetryManager)
 		);
 	}
 
 	@Test
-	void testVisitCommandLineExpectedResultNull() {
+	void testProcessCommandLineExpectedResultNull() {
 		final CommandLineCriterion commandLineCriterion = new CommandLineCriterion();
 		commandLineCriterion.setCommandLine(
 			"naviseccli -User %{USERNAME} -Password %{PASSWORD} -Address %{HOSTNAME} -Scope 1 getagent"
@@ -1044,7 +1047,7 @@ class OsCommandExtensionTest {
 	}
 
 	@Test
-	void testVisitCommandLineLineEmpty() {
+	void testProcessCommandLineLineEmpty() {
 		final CommandLineCriterion commandLineCriterion = new CommandLineCriterion();
 		commandLineCriterion.setCommandLine("");
 		commandLineCriterion.setExpectedResult("Agent Rev:");
@@ -1072,7 +1075,7 @@ class OsCommandExtensionTest {
 	}
 
 	@Test
-	void testVisitCommandLineRemoteNoUser() {
+	void testProcessCommandLineRemoteNoUser() {
 		final CommandLineCriterion commandLineCriterion = new CommandLineCriterion();
 		commandLineCriterion.setCommandLine(
 			"naviseccli -User %{USERNAME} -Password %{PASSWORD} -Address %{HOSTNAME} -Scope 1 getagent"

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandHelperTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandHelperTest.java
@@ -45,7 +45,6 @@ import org.sentrysoftware.metricshub.engine.common.exception.ControlledSshExcept
 import org.sentrysoftware.metricshub.engine.common.exception.NoCredentialProvidedException;
 import org.sentrysoftware.metricshub.engine.common.helpers.LocalOsHandler;
 import org.sentrysoftware.metricshub.engine.configuration.HostConfiguration;
-import org.sentrysoftware.metricshub.engine.configuration.WmiConfiguration;
 import org.sentrysoftware.metricshub.engine.connector.model.common.DeviceKind;
 import org.sentrysoftware.metricshub.engine.connector.model.common.EmbeddedFile;
 import org.sentrysoftware.metricshub.engine.strategy.utils.EmbeddedFileHelper;
@@ -535,9 +534,6 @@ class OsCommandHelperTest {
 		final OsCommandConfiguration osCommandConfig = new OsCommandConfiguration();
 		osCommandConfig.setTimeout(2L);
 
-		final WmiConfiguration wmiConfiguration = new WmiConfiguration();
-		wmiConfiguration.setTimeout(3L);
-
 		final SshConfiguration sshConfiguration = SshConfiguration
 			.sshConfigurationBuilder()
 			.username(USERNAME)
@@ -547,11 +543,9 @@ class OsCommandHelperTest {
 
 		assertEquals(1, OsCommandService.getTimeout(1L, osCommandConfig, sshConfiguration, 5));
 		assertEquals(2, OsCommandService.getTimeout(null, osCommandConfig, sshConfiguration, 5));
-		assertEquals(3, OsCommandService.getTimeout(null, null, wmiConfiguration, 5));
 		assertEquals(4, OsCommandService.getTimeout(null, null, sshConfiguration, 5));
 		assertEquals(5, OsCommandService.getTimeout(null, null, null, 5));
 		assertEquals(30, OsCommandService.getTimeout(null, new OsCommandConfiguration(), sshConfiguration, 5));
-		assertEquals(120, OsCommandService.getTimeout(null, null, new WmiConfiguration(), 5));
 		assertEquals(
 			30,
 			OsCommandService.getTimeout(
@@ -567,15 +561,10 @@ class OsCommandHelperTest {
 	void testGetUsername() {
 		assertEquals(Optional.empty(), OsCommandService.getUsername(null));
 		assertEquals(Optional.empty(), OsCommandService.getUsername(new OsCommandConfiguration()));
-		assertEquals(Optional.empty(), OsCommandService.getUsername(new WmiConfiguration()));
 		assertEquals(
 			Optional.empty(),
 			OsCommandService.getUsername(SshConfiguration.sshConfigurationBuilder().password(PASSWORD.toCharArray()).build())
 		);
-
-		final WmiConfiguration wmiConfiguration = new WmiConfiguration();
-		wmiConfiguration.setUsername(USERNAME);
-		assertEquals(Optional.of(USERNAME), OsCommandService.getUsername(wmiConfiguration));
 
 		assertEquals(
 			Optional.of(USERNAME),
@@ -589,16 +578,12 @@ class OsCommandHelperTest {
 	void testGetPassword() {
 		assertEquals(Optional.empty(), OsCommandService.getPassword(null));
 		assertEquals(Optional.empty(), OsCommandService.getPassword(new OsCommandConfiguration()));
-		assertEquals(Optional.empty(), OsCommandService.getPassword(new WmiConfiguration()));
 		assertEquals(
 			Optional.empty(),
 			OsCommandService.getPassword(SshConfiguration.sshConfigurationBuilder().username(USERNAME).build())
 		);
 
-		final WmiConfiguration wmiConfiguration = new WmiConfiguration();
 		char[] charArrayPassword = PASSWORD.toCharArray();
-		wmiConfiguration.setPassword(charArrayPassword);
-		assertEquals(Optional.of(charArrayPassword), OsCommandService.getPassword(wmiConfiguration));
 
 		assertEquals(
 			Optional.of(charArrayPassword),
@@ -647,58 +632,6 @@ class OsCommandHelperTest {
 	}
 
 	@Test
-	void testRunOsCommandRemoteWindowsEmbeddedFilesError() {
-		final Map<String, EmbeddedFile> embeddedFiles = new HashMap<>();
-		embeddedFiles.put(EMBEDDED_FILE_1_REF, new EmbeddedFile(ECHO_OS, BAT, EMBEDDED_FILE_1_REF));
-		embeddedFiles.put(EMBEDDED_FILE_2_REF, new EmbeddedFile(ECHO_HELLO_WORLD, null, EMBEDDED_FILE_2_REF));
-
-		final WmiConfiguration wmiConfiguration = new WmiConfiguration();
-		wmiConfiguration.setUsername(USERNAME);
-		wmiConfiguration.setPassword(PWD_COMMAND.toCharArray());
-
-		final HostConfiguration hostConfiguration = HostConfiguration
-			.builder()
-			.hostId(ID)
-			.hostname(HOST)
-			.hostType(DeviceKind.WINDOWS)
-			.configurations(Map.of(wmiConfiguration.getClass(), wmiConfiguration))
-			.build();
-
-		final TelemetryManager telemetryManager = TelemetryManager.builder().hostConfiguration(hostConfiguration).build();
-
-		try (
-			final MockedStatic<OsCommandService> mockedOsCommandService = mockStatic(OsCommandService.class);
-			final MockedStatic<OsCommandHelper> mockedOsCommandHelper = mockStatic(OsCommandHelper.class);
-			final MockedStatic<EmbeddedFileHelper> mockedEmbeddedFileHelper = mockStatic(EmbeddedFileHelper.class)
-		) {
-			mockedOsCommandService.when(() -> OsCommandService.getUsername(wmiConfiguration)).thenCallRealMethod();
-			mockedOsCommandService
-				.when(() -> OsCommandService.runOsCommand(COMMAND_TO_UPDATE, telemetryManager, 120L, false, false))
-				.thenCallRealMethod();
-
-			mockedEmbeddedFileHelper
-				.when(() -> EmbeddedFileHelper.findEmbeddedFiles(anyString()))
-				.thenReturn(commandLineEmbeddedFiles);
-
-			mockedOsCommandHelper
-				.when(() ->
-					OsCommandHelper.createOsCommandEmbeddedFiles(
-						COMMAND_TO_UPDATE,
-						null,
-						commandLineEmbeddedFiles,
-						TEMP_FILE_CREATOR
-					)
-				)
-				.thenThrow(new IOException(ERROR_IN_FILE1));
-
-			assertThrows(
-				IOException.class,
-				() -> OsCommandService.runOsCommand(COMMAND_TO_UPDATE, telemetryManager, 120L, false, false)
-			);
-		}
-	}
-
-	@Test
 	@EnabledOnOs(OS.WINDOWS)
 	void testRunOsCommandWindowsError() {
 		final SshConfiguration sshConfiguration = SshConfiguration
@@ -741,16 +674,11 @@ class OsCommandHelperTest {
 	@Test
 	@EnabledOnOs(OS.WINDOWS)
 	void testRunOsCommandLocalWindows() throws Exception {
-		final WmiConfiguration wmiConfiguration = new WmiConfiguration();
-		wmiConfiguration.setUsername(USERNAME);
-		wmiConfiguration.setPassword(PWD_COMMAND.toCharArray());
-
 		final HostConfiguration hostConfiguration = HostConfiguration
 			.builder()
 			.hostId(ID)
 			.hostname(HOST)
 			.hostType(DeviceKind.WINDOWS)
-			.configurations(Map.of(wmiConfiguration.getClass(), wmiConfiguration))
 			.build();
 
 		final TelemetryManager telemetryManager = TelemetryManager.builder().hostConfiguration(hostConfiguration).build();


### PR DESCRIPTION

* Removed all remote windows checks and configurations from the OsCommandExtension since they will be handled in Wmi and WinRm extensions.
* Removed all remote windows checks and configurations from the OsCommand Extension tests.
* Remoted Http dependency from the MetricsHub engine.