### PR TITLE
Issue #161: Fixed IPv6 failures for WBEM queries

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/client/ClientsExecutor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/client/ClientsExecutor.java
@@ -30,7 +30,6 @@ import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -772,9 +771,7 @@ public class ClientsExecutor {
 		final String namespace
 	) throws ClientException {
 		try {
-			String urlSpec = String.format("%s://%s:%d", wbemConfig.getProtocol().toString(), hostname, wbemConfig.getPort());
-
-			final URL url = new URI(urlSpec).toURL();
+			final URL url = NetworkHelper.createUrl(wbemConfig.getProtocol().toString(), hostname, wbemConfig.getPort());
 
 			trace(() ->
 				log.trace(

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/common/helpers/NetworkHelperTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/common/helpers/NetworkHelperTest.java
@@ -4,14 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.WHITE_SPACE;
 
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.URL;
+import java.net.UnknownHostException;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -87,5 +91,90 @@ class NetworkHelperTest {
 		// hostname can be resolved
 		hostname = "localhost";
 		assertNotNull(NetworkHelper.resolveDns(hostname));
+	}
+
+	@Test
+	void testCreateUrlWithLocalhostIPv4() throws Exception {
+		final URL url = NetworkHelper.createUrl("http", "127.0.0.1", 8080);
+		assertEquals("http://127.0.0.1:8080", url.toString());
+	}
+
+	@Test
+	void testCreateUrlWithLocalhostIPv6() throws Exception {
+		{
+			final URL url = NetworkHelper.createUrl("https", "::1", 443);
+			assertEquals("https://[::1]:443", url.toString());
+		}
+		{
+			final URL url = NetworkHelper.createUrl("https", "0:0:0:0:0:0:0:1", 443);
+			assertEquals("https://[0:0:0:0:0:0:0:1]:443", url.toString());
+		}
+		{
+			final URL url = NetworkHelper.createUrl("https", "0000:0000:0000:0000:0000:0000:0000:0001", 443);
+			assertEquals("https://[0000:0000:0000:0000:0000:0000:0000:0001]:443", url.toString());
+		}
+	}
+
+	@Test
+	void testCreateUrlWithIPv6() throws Exception {
+		final URL url = NetworkHelper.createUrl("https", "2001:db8::ff00:42:8329", 443);
+		assertEquals("https://[2001:db8::ff00:42:8329]:443", url.toString());
+		assertEquals("[2001:db8::ff00:42:8329]", url.getHost());
+	}
+
+	@Test
+	void testCreateUrlWithIPv6AlreadyWrapped() throws Exception {
+		final URL url = NetworkHelper.createUrl("https", "[2001:db8::ff00:42:8329]", 443);
+		assertEquals("https://[2001:db8::ff00:42:8329]:443", url.toString());
+		assertEquals("[2001:db8::ff00:42:8329]", url.getHost());
+	}
+
+	@Test
+	void testCreateUrlWithIPv4() throws Exception {
+		final URL url = NetworkHelper.createUrl("http", "192.168.1.1", 80);
+		assertEquals("http://192.168.1.1:80", url.toString());
+	}
+
+	@Test
+	void testCreateUrlWithNonStandardPort() throws Exception {
+		final URL url = NetworkHelper.createUrl("ftp", "192.168.1.1", 2121);
+		assertEquals("ftp://192.168.1.1:2121", url.toString());
+	}
+
+	@Test
+	void testCreateUrlWithDefaultHttpPort() throws Exception {
+		final URL url = NetworkHelper.createUrl("http", "example.com", 80);
+		assertEquals("http://example.com:80", url.toString());
+	}
+
+	@Test
+	void testCreateUrlWithDefaultHttpsPort() throws Exception {
+		final URL url = NetworkHelper.createUrl("https", "example.com", 443);
+		assertEquals("https://example.com:443", url.toString());
+	}
+
+	@Test
+	void testCreateUrlWithoutPort() throws Exception {
+		assertThrows(IllegalArgumentException.class, () -> NetworkHelper.createUrl("http", "example.com", null));
+	}
+
+	@Test
+	void testCreateUrlWithoutHostnameOrIp() throws Exception {
+		assertThrows(IllegalArgumentException.class, () -> NetworkHelper.createUrl("http", null, 80));
+	}
+
+	@Test
+	void testCreateUrlWithoutProtocol() throws Exception {
+		assertThrows(IllegalArgumentException.class, () -> NetworkHelper.createUrl(null, "example.com", 80));
+	}
+
+	@Test
+	void testCreateUrlWithInvalidProtocol() throws Exception {
+		assertThrows(MalformedURLException.class, () -> NetworkHelper.createUrl("htp", "example.com", 80));
+	}
+
+	@Test
+	void testCreateUrlWithInvalidIp() throws Exception {
+		assertThrows(UnknownHostException.class, () -> NetworkHelper.createUrl("http", "999.999.999.999", 80));
 	}
 }


### PR DESCRIPTION
* Developed NetworkHelper#createUrl to detect and protect IPv6 before building the Java URL object.