### PR TITLE
Issue #182: Use MetricsHub Community Connectors 1.0.01

### DIFF
--- a/metricshub-doc/pom.xml
+++ b/metricshub-doc/pom.xml
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.sentrysoftware.maven</groupId>
 				<artifactId>metricshub-connector-maven-plugin</artifactId>
-				<version>1.0.00</version>
+				<version>1.0.01</version>
 				<configuration>
 					<sourceDirectory>${project.basedir}/../metricshub-agent/target/connectors</sourceDirectory>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 	</developers>
 
 	<properties>
-		<community-connectors.version>1.0.00</community-connectors.version>
+		<community-connectors.version>1.0.01</community-connectors.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>
 		<lombok.version>1.18.30</lombok.version>


### PR DESCRIPTION
* Updated Community Connectors version to 1.0.01.
* The documentation invokes the MetricsHub Connector Maven Plugin 1.0.01.