### PR TITLE
Issue #193: Use Community Connectors 1.0.02

### DIFF
--- a/metricshub-doc/pom.xml
+++ b/metricshub-doc/pom.xml
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.sentrysoftware.maven</groupId>
 				<artifactId>metricshub-connector-maven-plugin</artifactId>
-				<version>1.0.01</version>
+				<version>1.0.02</version>
 				<configuration>
 					<sourceDirectory>${project.basedir}/../metricshub-agent/target/connectors</sourceDirectory>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 	</developers>
 
 	<properties>
-		<community-connectors.version>1.0.01</community-connectors.version>
+		<community-connectors.version>1.0.02</community-connectors.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>
 		<hwgraf.version>4</hwgraf.version>


### PR DESCRIPTION
* Updated the main POM to use Community Connectors v1.0.02.
* Updated metricshub-doc POM to use MetricsHub Connector Maven Plugin v1.0.02.