### PR TITLE
Issue #124: Invalid connector no longer results in an empty Connector…

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/parser/ConnectorLibraryParser.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/parser/ConnectorLibraryParser.java
@@ -87,8 +87,7 @@ public class ConnectorLibraryParser {
 				connectorsMap.put(filename.substring(0, filename.lastIndexOf('.')), connector);
 			} catch (Exception e) {
 				log.error("Error while parsing connector {}", filename);
-				log.trace("Error while parsing connector {}: {}", filename, e.getMessage());
-				return FileVisitResult.CONTINUE;
+				log.debug("Error while parsing connector {}: {}", filename, e.getMessage());
 			}
 
 			return FileVisitResult.CONTINUE;
@@ -133,10 +132,11 @@ public class ConnectorLibraryParser {
 									final Connector connector;
 									try {
 										connector = connectorParser.parse(Files.newInputStream(path), connectorFolderUri, fileName);
-									} catch (IOException e) {
-										throw new IllegalStateException(e);
+										connectorsMap.put(fileName.substring(0, fileName.lastIndexOf('.')), connector);
+									} catch (Exception e) {
+										log.error("Error while parsing connector {}", fileName);
+										log.debug("Error while parsing connector {}: {}", fileName, e.getMessage());
 									}
-									connectorsMap.put(fileName.substring(0, fileName.lastIndexOf('.')), connector);
 								}
 							);
 

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/parser/ConnectorLibraryParser.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/parser/ConnectorLibraryParser.java
@@ -82,8 +82,14 @@ public class ConnectorLibraryParser {
 			}
 			final ConnectorParser connectorParser = ConnectorParser.withNodeProcessorAndUpdateChain(file.getParent());
 
-			final Connector connector = connectorParser.parse(file.toFile());
-			connectorsMap.put(filename.substring(0, filename.lastIndexOf('.')), connector);
+			try {
+				final Connector connector = connectorParser.parse(file.toFile());
+				connectorsMap.put(filename.substring(0, filename.lastIndexOf('.')), connector);
+			} catch (Exception e) {
+				log.error("Error while parsing connector {}", filename);
+				log.trace("Error while parsing connector {}: {}", filename, e.getMessage());
+				return FileVisitResult.CONTINUE;
+			}
 
 			return FileVisitResult.CONTINUE;
 		}

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/parser/ConnectorLibraryParser.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/parser/ConnectorLibraryParser.java
@@ -46,6 +46,8 @@ import org.sentrysoftware.metricshub.engine.connector.model.Connector;
 @Slf4j
 public class ConnectorLibraryParser {
 
+	public static final String CONNECTOR_PARSING_ERROR = "Error while parsing connector {}: {}";
+
 	/**
 	 * The ObjectMapper instance for handling YAML files.
 	 */
@@ -86,8 +88,8 @@ public class ConnectorLibraryParser {
 				final Connector connector = connectorParser.parse(file.toFile());
 				connectorsMap.put(filename.substring(0, filename.lastIndexOf('.')), connector);
 			} catch (Exception e) {
-				log.error("Error while parsing connector {}", filename);
-				log.debug("Error while parsing connector {}: {}", filename, e.getMessage());
+				log.error(CONNECTOR_PARSING_ERROR, filename, e.getMessage());
+				log.debug(CONNECTOR_PARSING_ERROR, filename, e);
 			}
 
 			return FileVisitResult.CONTINUE;
@@ -134,8 +136,8 @@ public class ConnectorLibraryParser {
 										connector = connectorParser.parse(Files.newInputStream(path), connectorFolderUri, fileName);
 										connectorsMap.put(fileName.substring(0, fileName.lastIndexOf('.')), connector);
 									} catch (Exception e) {
-										log.error("Error while parsing connector {}", fileName);
-										log.debug("Error while parsing connector {}: {}", fileName, e.getMessage());
+										log.error(CONNECTOR_PARSING_ERROR, fileName, e.getMessage());
+										log.debug(CONNECTOR_PARSING_ERROR, fileName, e);
 									}
 								}
 							);

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/parser/ConnectorLibraryParser.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/parser/ConnectorLibraryParser.java
@@ -89,7 +89,7 @@ public class ConnectorLibraryParser {
 				connectorsMap.put(filename.substring(0, filename.lastIndexOf('.')), connector);
 			} catch (Exception e) {
 				log.error(CONNECTOR_PARSING_ERROR, filename, e.getMessage());
-				log.debug(CONNECTOR_PARSING_ERROR, filename, e);
+				log.debug("Exception: ", e);
 			}
 
 			return FileVisitResult.CONTINUE;
@@ -137,7 +137,7 @@ public class ConnectorLibraryParser {
 										connectorsMap.put(fileName.substring(0, fileName.lastIndexOf('.')), connector);
 									} catch (Exception e) {
 										log.error(CONNECTOR_PARSING_ERROR, fileName, e.getMessage());
-										log.debug(CONNECTOR_PARSING_ERROR, fileName, e);
+										log.debug("Exception: ", e);
 									}
 								}
 							);


### PR DESCRIPTION
- Invalid connector no longer results in an empty ConnectorStore
- Additional logging added for clarity

Default logging (Error):
![image](https://github.com/sentrysoftware/metricshub/assets/64595296/893efbd3-22ff-4ad3-a9d2-8a25d5d2310d)

Trace logging:
![image](https://github.com/sentrysoftware/metricshub/assets/64595296/d95ef9b2-0dc0-49d5-abe3-da238925e892)
