### PR TITLE
Issue #215: Removed vcenter dependency from the engine

### DIFF
--- a/metricshub-engine/pom.xml
+++ b/metricshub-engine/pom.xml
@@ -112,10 +112,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.sentrysoftware</groupId>
-			<artifactId>vcenter</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>io.opentelemetry.instrumentation</groupId>
 			<artifactId>opentelemetry-instrumentation-annotations</artifactId>
 		</dependency>

--- a/metricshub-wbem-extension/pom.xml
+++ b/metricshub-wbem-extension/pom.xml
@@ -53,6 +53,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.sentrysoftware</groupId>
+			<artifactId>vcenter</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
@@ -173,6 +177,8 @@
 							<artifactSet>
 								<includes>
 									<include>org.sentrysoftware:wbem</include>
+									<include>org.sentrysoftware:vcenter</include>
+									<include>com.vmware:vijava</include>
 									<include>org.sentrysoftware:metricshub-wbem-extension</include>
 								</includes>
 								<excludes>


### PR DESCRIPTION
* Removed vcenter dependency from engine's POM and moved to metricshub-wbem-extension.