### PR TITLE
Issue #239: High CPU Usage Due to Infinite Loop in IPMI `Connection.run()`

### DIFF
--- a/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiRequestExecutor.java
+++ b/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiRequestExecutor.java
@@ -105,7 +105,8 @@ public class IpmiRequestExecutor {
 			password,
 			ArrayHelper.hexToByteArray(ipmiConfiguration.getBmcKey()),
 			ipmiConfiguration.isSkipAuth(),
-			timeout
+			timeout,
+			0L // Turn off keep-alive messages sent to the remote host
 		);
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
 			<dependency>
 				<groupId>org.sentrysoftware</groupId>
 				<artifactId>ipmi</artifactId>
-				<version>1.0.01</version>
+				<version>1.1.00</version>
 			</dependency>
 			<dependency>
 				<groupId>org.sentrysoftware</groupId>


### PR DESCRIPTION
* Linked to IPMI Client library 1.1.00
* Turned off keep-alive messages sent to the remote host.