### PR TITLE
Issue #228:  Add connector display name as attribute of metricshub.connector.status

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
@@ -875,9 +875,16 @@ public class ConfigHelper {
 			// Create a unique connector identifier based on resource keys
 			final ConnectorIdentity identity = configuredConnector.getOrCreateConnectorIdentity();
 			final String connectorId = String.format("MetricsHub-Configured-Connector-%s-%s", resourceGroupKey, resourceKey);
+			final String connectorName = String.format(
+				"Configured Connector on resource %s (Group %s)",
+				resourceGroupKey,
+				resourceKey
+			);
 
 			// Set the compiled filename of the connector to the unique identifier
 			identity.setCompiledFilename(connectorId);
+
+			identity.setDisplayName(connectorName);
 		}
 	}
 
@@ -965,6 +972,7 @@ public class ConfigHelper {
 			hostType = detectHostTypeFromAttribute(hostTypeAttribute);
 		}
 
+		String configuredConnectorName = null;
 		String configuredConnectorId = null;
 		// Retrieve the connector specified by the user in the metricshub.yaml configuration
 		final Connector configuredConnector = resourceConfig.getConnector();
@@ -972,6 +980,7 @@ public class ConfigHelper {
 		if (configuredConnector != null) {
 			// The custom connector is considered a selected connector from the engine's perspective
 			configuredConnectorId = configuredConnector.getCompiledFilename();
+			configuredConnectorName = configuredConnector.getConnectorIdentity().getDisplayName();
 		}
 
 		return HostConfiguration
@@ -984,6 +993,7 @@ public class ConfigHelper {
 			.hostType(hostType)
 			.sequential(Boolean.TRUE.equals(resourceConfig.getSequential()))
 			.configuredConnectorId(configuredConnectorId)
+			.configuredConnectorName(configuredConnectorName)
 			.build();
 	}
 

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
@@ -877,8 +877,8 @@ public class ConfigHelper {
 			final String connectorId = String.format("MetricsHub-Configured-Connector-%s-%s", resourceGroupKey, resourceKey);
 			final String connectorName = String.format(
 				"Configured Connector on resource %s (Group %s)",
-				resourceGroupKey,
-				resourceKey
+				resourceKey,
+				resourceGroupKey
 			);
 
 			// Set the compiled filename of the connector to the unique identifier

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
@@ -883,7 +883,7 @@ public class ConfigHelper {
 
 			// Set the compiled filename of the connector to the unique identifier
 			identity.setCompiledFilename(connectorId);
-
+			// Set the display name of the connector
 			identity.setDisplayName(connectorName);
 		}
 	}

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
@@ -972,7 +972,6 @@ public class ConfigHelper {
 			hostType = detectHostTypeFromAttribute(hostTypeAttribute);
 		}
 
-		String configuredConnectorName = null;
 		String configuredConnectorId = null;
 		// Retrieve the connector specified by the user in the metricshub.yaml configuration
 		final Connector configuredConnector = resourceConfig.getConnector();
@@ -980,7 +979,6 @@ public class ConfigHelper {
 		if (configuredConnector != null) {
 			// The custom connector is considered a selected connector from the engine's perspective
 			configuredConnectorId = configuredConnector.getCompiledFilename();
-			configuredConnectorName = configuredConnector.getConnectorIdentity().getDisplayName();
 		}
 
 		return HostConfiguration
@@ -993,7 +991,6 @@ public class ConfigHelper {
 			.hostType(hostType)
 			.sequential(Boolean.TRUE.equals(resourceConfig.getSequential()))
 			.configuredConnectorId(configuredConnectorId)
-			.configuredConnectorName(configuredConnectorName)
 			.build();
 	}
 

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/HostConfiguration.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/HostConfiguration.java
@@ -1,12 +1,5 @@
 package org.sentrysoftware.metricshub.engine.configuration;
 
-import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.DEFAULT_JOB_TIMEOUT;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * MetricsHub Engine
@@ -27,6 +20,13 @@ import java.util.stream.Collectors;
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
+import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.DEFAULT_JOB_TIMEOUT;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Builder.Default;
@@ -67,7 +67,7 @@ public class HostConfiguration {
 
 	private String configuredConnectorId;
 	private String configuredConnectorName;
-	
+
 	/**
 	 * Determine the accepted sources that can be executed using the current engine configuration
 	 *

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/HostConfiguration.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/HostConfiguration.java
@@ -67,6 +67,8 @@ public class HostConfiguration {
 
 	private String configuredConnectorId;
 
+	private String configuredConnectorName;
+
 	/**
 	 * Determine the accepted sources that can be executed using the current engine configuration
 	 *

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/HostConfiguration.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/HostConfiguration.java
@@ -66,9 +66,8 @@ public class HostConfiguration {
 	private Map<Class<? extends IConfiguration>, IConfiguration> configurations = new HashMap<>();
 
 	private String configuredConnectorId;
-
 	private String configuredConnectorName;
-
+	
 	/**
 	 * Determine the accepted sources that can be executed using the current engine configuration
 	 *

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/HostConfiguration.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/HostConfiguration.java
@@ -66,7 +66,6 @@ public class HostConfiguration {
 	private Map<Class<? extends IConfiguration>, IConfiguration> configurations = new HashMap<>();
 
 	private String configuredConnectorId;
-	private String configuredConnectorName;
 
 	/**
 	 * Determine the accepted sources that can be executed using the current engine configuration

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategy.java
@@ -235,9 +235,11 @@ public class DetectionStrategy extends AbstractStrategy {
 		final Map<String, String> monitorAttributes = new HashMap<>();
 		final String hostId = telemetryManager.getHostConfiguration().getHostId();
 		final String connectorId = connector.getCompiledFilename();
+		final String connectorName = connector.getConnectorIdentity().getDisplayName();
 
 		monitorAttributes.put(MONITOR_ATTRIBUTE_ID, connectorId);
-		monitorAttributes.put(MONITOR_ATTRIBUTE_NAME, connectorId);
+		monitorAttributes.put(MONITOR_ATTRIBUTE_NAME, connectorName);
+		monitorAttributes.put("filename", connectorName + ".yaml");
 
 		monitorAttributes.put(
 			MONITOR_ATTRIBUTE_APPLIES_TO_OS,

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategy.java
@@ -117,6 +117,9 @@ public class DetectionStrategy extends AbstractStrategy {
 		// Get the configured connector
 		final String configuredConnectorId = hostConfiguration.getConfiguredConnectorId();
 
+		// Get the configured connector
+		final String configuredConnectorName = hostConfiguration.getConfiguredConnectorName();
+
 		// Initialize a new manager to stage connectors
 		final ConnectorStagingManager connectorStagingManager = new ConnectorStagingManager(hostname);
 
@@ -168,15 +171,16 @@ public class DetectionStrategy extends AbstractStrategy {
 		createConnectorMonitors(connectorTestResults);
 
 		// Create configured connector monitor
-		createConfiguredConnectorMonitor(configuredConnectorId);
+		createConfiguredConnectorMonitor(configuredConnectorId, configuredConnectorName);
 	}
 
 	/**
 	 * Create a new connector monitor for the configured connector
 	 *
-	 * @param configuredConnectorId unique identifier of the connector
+	 * @param configuredConnectorId the unique identifier of the connector
+	 * @param configuredConnectorName  the name of the connector
 	 */
-	void createConfiguredConnectorMonitor(final String configuredConnectorId) {
+	void createConfiguredConnectorMonitor(final String configuredConnectorId, final String configuredConnectorName) {
 		if (configuredConnectorId == null) {
 			return;
 		}
@@ -186,7 +190,7 @@ public class DetectionStrategy extends AbstractStrategy {
 		// Set monitor attributes
 		final Map<String, String> monitorAttributes = new HashMap<>();
 		monitorAttributes.put(MONITOR_ATTRIBUTE_ID, configuredConnectorId);
-		monitorAttributes.put(MONITOR_ATTRIBUTE_NAME, configuredConnectorId);
+		monitorAttributes.put(MONITOR_ATTRIBUTE_NAME, configuredConnectorName);
 		monitorAttributes.put(MONITOR_ATTRIBUTE_PARENT_ID, hostId);
 
 		// Create the monitor factory
@@ -239,7 +243,7 @@ public class DetectionStrategy extends AbstractStrategy {
 
 		monitorAttributes.put(MONITOR_ATTRIBUTE_ID, connectorId);
 		monitorAttributes.put(MONITOR_ATTRIBUTE_NAME, connectorName);
-		monitorAttributes.put("filename", connectorName + ".yaml");
+		monitorAttributes.put("filename", connectorId + ".yaml");
 
 		monitorAttributes.put(
 			MONITOR_ATTRIBUTE_APPLIES_TO_OS,

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategy.java
@@ -117,9 +117,6 @@ public class DetectionStrategy extends AbstractStrategy {
 		// Get the configured connector
 		final String configuredConnectorId = hostConfiguration.getConfiguredConnectorId();
 
-		// Get the configured connector
-		final String configuredConnectorName = hostConfiguration.getConfiguredConnectorName();
-
 		// Initialize a new manager to stage connectors
 		final ConnectorStagingManager connectorStagingManager = new ConnectorStagingManager(hostname);
 
@@ -171,16 +168,15 @@ public class DetectionStrategy extends AbstractStrategy {
 		createConnectorMonitors(connectorTestResults);
 
 		// Create configured connector monitor
-		createConfiguredConnectorMonitor(configuredConnectorId, configuredConnectorName);
+		createConfiguredConnectorMonitor(configuredConnectorId);
 	}
 
 	/**
 	 * Create a new connector monitor for the configured connector
 	 *
 	 * @param configuredConnectorId the unique identifier of the connector
-	 * @param configuredConnectorName  the name of the connector
 	 */
-	void createConfiguredConnectorMonitor(final String configuredConnectorId, final String configuredConnectorName) {
+	void createConfiguredConnectorMonitor(final String configuredConnectorId) {
 		if (configuredConnectorId == null) {
 			return;
 		}
@@ -190,7 +186,10 @@ public class DetectionStrategy extends AbstractStrategy {
 		// Set monitor attributes
 		final Map<String, String> monitorAttributes = new HashMap<>();
 		monitorAttributes.put(MONITOR_ATTRIBUTE_ID, configuredConnectorId);
-		monitorAttributes.put(MONITOR_ATTRIBUTE_NAME, configuredConnectorName);
+		monitorAttributes.put(
+			MONITOR_ATTRIBUTE_NAME,
+			telemetryManager.getConnectorStore().getStore().get(configuredConnectorId).getConnectorIdentity().getDisplayName()
+		);
 		monitorAttributes.put(MONITOR_ATTRIBUTE_PARENT_ID, hostId);
 
 		// Create the monitor factory

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/constants/Constants.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/constants/Constants.java
@@ -116,6 +116,7 @@ public class Constants {
 
 	// Yaml test files
 	public static final String AAC_CONNECTOR_ID = "AAC";
+	public static final String AAC_CONNECTOR_NAME = "Adaptec Storage Manager Web Edition (AAC)";
 	public static final String TEST_CONNECTOR_ID = "TestConnector";
 
 	// Host information

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/constants/Constants.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/constants/Constants.java
@@ -132,7 +132,7 @@ public class Constants {
 		"HostConfiguration(hostname=localhost, hostId=localhost," +
 		" hostType=LINUX, strategyTimeout=100, connectors=null," +
 		" sequential=false, alertTrigger=null," +
-		" retryDelay=30, connectorVariables=null, configurations={}, configuredConnectorId=null)";
+		" retryDelay=30, connectorVariables=null, configurations={}, configuredConnectorId=null, configuredConnectorName=null)";
 	public static final String IPMI_CONNECTION_SUCCESS_WITH_IMPI_OVER_LAN_MESSAGE =
 		"Successfully connected to the IPMI BMC chip with the IPMI-over-LAN " + "interface.";
 	public static final String TWGIPC = "TWGIPC";

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/constants/Constants.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/constants/Constants.java
@@ -132,7 +132,7 @@ public class Constants {
 		"HostConfiguration(hostname=localhost, hostId=localhost," +
 		" hostType=LINUX, strategyTimeout=100, connectors=null," +
 		" sequential=false, alertTrigger=null," +
-		" retryDelay=30, connectorVariables=null, configurations={}, configuredConnectorId=null, configuredConnectorName=null)";
+		" retryDelay=30, connectorVariables=null, configurations={}, configuredConnectorId=null)";
 	public static final String IPMI_CONNECTION_SUCCESS_WITH_IMPI_OVER_LAN_MESSAGE =
 		"Successfully connected to the IPMI BMC chip with the IPMI-over-LAN " + "interface.";
 	public static final String TWGIPC = "TWGIPC";

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/AutomaticDetectionTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/AutomaticDetectionTest.java
@@ -107,7 +107,6 @@ class AutomaticDetectionTest {
 			0,
 			null,
 			configurations,
-			null,
 			null
 		);
 
@@ -158,7 +157,6 @@ class AutomaticDetectionTest {
 			0,
 			null,
 			configurations,
-			null,
 			null
 		);
 
@@ -224,7 +222,6 @@ class AutomaticDetectionTest {
 			0,
 			null,
 			configurations,
-			null,
 			null
 		);
 
@@ -290,7 +287,6 @@ class AutomaticDetectionTest {
 			0,
 			null,
 			configurations,
-			null,
 			null
 		);
 
@@ -356,7 +352,6 @@ class AutomaticDetectionTest {
 			0,
 			null,
 			configurations,
-			null,
 			null
 		);
 

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/AutomaticDetectionTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/AutomaticDetectionTest.java
@@ -107,6 +107,7 @@ class AutomaticDetectionTest {
 			0,
 			null,
 			configurations,
+			null,
 			null
 		);
 
@@ -157,6 +158,7 @@ class AutomaticDetectionTest {
 			0,
 			null,
 			configurations,
+			null,
 			null
 		);
 
@@ -222,6 +224,7 @@ class AutomaticDetectionTest {
 			0,
 			null,
 			configurations,
+			null,
 			null
 		);
 
@@ -287,6 +290,7 @@ class AutomaticDetectionTest {
 			0,
 			null,
 			configurations,
+			null,
 			null
 		);
 
@@ -352,6 +356,7 @@ class AutomaticDetectionTest {
 			0,
 			null,
 			configurations,
+			null,
 			null
 		);
 

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
@@ -14,6 +14,7 @@ import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubCons
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.STATE_SET_METRIC_FAILED;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.STATE_SET_METRIC_OK;
 import static org.sentrysoftware.metricshub.engine.constants.Constants.AAC_CONNECTOR_ID;
+import static org.sentrysoftware.metricshub.engine.constants.Constants.AAC_CONNECTOR_NAME;
 import static org.sentrysoftware.metricshub.engine.constants.Constants.HOSTNAME;
 import static org.sentrysoftware.metricshub.engine.constants.Constants.HOST_ID;
 import static org.sentrysoftware.metricshub.engine.constants.Constants.LOCALHOST;
@@ -135,7 +136,7 @@ class DetectionStrategyTest {
 				.get(MONITOR_ATTRIBUTE_ID)
 		);
 		assertEquals(
-			AAC_CONNECTOR_ID,
+			AAC_CONNECTOR_NAME,
 			telemetryManager
 				.getMonitors()
 				.get(KnownMonitorType.CONNECTOR.getKey())

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
@@ -287,7 +287,6 @@ class DetectionStrategyTest {
 			"connector_" + METRICS_HUB_CONFIGURED_CONNECTOR_ID
 		);
 
-		assertNotNull(telemetryManager);
 		assertNotNull(configuredConnectorMonitor);
 		assertEquals(METRICS_HUB_CONFIGURED_CONNECTOR_ID, configuredConnectorMonitor.getAttribute(MONITOR_ATTRIBUTE_ID));
 		assertEquals(

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
@@ -271,7 +271,7 @@ class DetectionStrategyTest {
 					.build()
 			)
 			.connectorStore(connectorStore)
-		        .build();
+			.build();
 
 		// Create detectionStrategy with the previously created telemetryManager
 		new DetectionStrategy(

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
@@ -57,6 +57,7 @@ import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
 class DetectionStrategyTest {
 
 	private static final String METRICS_HUB_CONFIGURED_CONNECTOR_ID = "MetricsHub-Configured-Connector";
+	private static final String METRICS_HUB_CONFIGURED_CONNECTOR_NAME = "MetricsHub-Configured-Connector-Name";
 	private static final long CURRENT_TIME_MILLIS = System.currentTimeMillis();
 
 	Connector getConnector() throws IOException {
@@ -260,6 +261,7 @@ class DetectionStrategyTest {
 					.hostType(DeviceKind.LINUX)
 					.hostname(LOCALHOST)
 					.configuredConnectorId(METRICS_HUB_CONFIGURED_CONNECTOR_ID)
+					.configuredConnectorName(METRICS_HUB_CONFIGURED_CONNECTOR_NAME)
 					.configurations(Map.of(TestConfiguration.class, TestConfiguration.builder().build()))
 					.build()
 			)
@@ -280,15 +282,13 @@ class DetectionStrategyTest {
 			"connector_" + METRICS_HUB_CONFIGURED_CONNECTOR_ID
 		);
 
-		// Debugging outputs
-		System.out.println("Configured Connector Monitor: " + configuredConnectorMonitor);
-		// Debugging outputs
-		System.out.println("Configuredtelemor: " + telemetryManager);
-
 		assertNotNull(telemetryManager);
 		assertNotNull(configuredConnectorMonitor);
 		assertEquals(METRICS_HUB_CONFIGURED_CONNECTOR_ID, configuredConnectorMonitor.getAttribute(MONITOR_ATTRIBUTE_ID));
-		assertEquals("tst", configuredConnectorMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME));
+		assertEquals(
+			METRICS_HUB_CONFIGURED_CONNECTOR_NAME,
+			configuredConnectorMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME)
+		);
 		assertEquals(HOST_ID, configuredConnectorMonitor.getAttribute(MONITOR_ATTRIBUTE_PARENT_ID));
 		assertTrue(
 			telemetryManager.getHostProperties().getConnectorNamespace(METRICS_HUB_CONFIGURED_CONNECTOR_ID).isStatusOk()

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
@@ -279,9 +279,16 @@ class DetectionStrategyTest {
 			KnownMonitorType.CONNECTOR.getKey(),
 			"connector_" + METRICS_HUB_CONFIGURED_CONNECTOR_ID
 		);
+
+		// Debugging outputs
+		System.out.println("Configured Connector Monitor: " + configuredConnectorMonitor);
+		// Debugging outputs
+		System.out.println("Configuredtelemor: " + telemetryManager);
+
+		assertNotNull(telemetryManager);
 		assertNotNull(configuredConnectorMonitor);
 		assertEquals(METRICS_HUB_CONFIGURED_CONNECTOR_ID, configuredConnectorMonitor.getAttribute(MONITOR_ATTRIBUTE_ID));
-		assertEquals(METRICS_HUB_CONFIGURED_CONNECTOR_ID, configuredConnectorMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME));
+		assertEquals("tst", configuredConnectorMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME));
 		assertEquals(HOST_ID, configuredConnectorMonitor.getAttribute(MONITOR_ATTRIBUTE_PARENT_ID));
 		assertTrue(
 			telemetryManager.getHostProperties().getConnectorNamespace(METRICS_HUB_CONFIGURED_CONNECTOR_ID).isStatusOk()

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategyTest.java
@@ -251,6 +251,12 @@ class DetectionStrategyTest {
 
 	@Test
 	void testCreateConfiguredConnectorMonitor() {
+		final Connector connector = new Connector();
+		final ConnectorIdentity identity = new ConnectorIdentity();
+		identity.setDisplayName(METRICS_HUB_CONFIGURED_CONNECTOR_NAME);
+		connector.setConnectorIdentity(identity);
+		final ConnectorStore connectorStore = new ConnectorStore();
+		connectorStore.setStore(Map.of(METRICS_HUB_CONFIGURED_CONNECTOR_ID, connector));
 		// Initiate telemetryManager with host configuration
 		final TelemetryManager telemetryManager = TelemetryManager
 			.builder()
@@ -261,12 +267,11 @@ class DetectionStrategyTest {
 					.hostType(DeviceKind.LINUX)
 					.hostname(LOCALHOST)
 					.configuredConnectorId(METRICS_HUB_CONFIGURED_CONNECTOR_ID)
-					.configuredConnectorName(METRICS_HUB_CONFIGURED_CONNECTOR_NAME)
 					.configurations(Map.of(TestConfiguration.class, TestConfiguration.builder().build()))
 					.build()
 			)
-			.connectorStore(new ConnectorStore())
-			.build();
+			.connectorStore(connectorStore)
+		        .build();
 
 		// Create detectionStrategy with the previously created telemetryManager
 		new DetectionStrategy(

--- a/metricshub-hardware/src/it/resources/os/SuperConnectorOsIT/expected/expected.json
+++ b/metricshub-hardware/src/it/resources/os/SuperConnectorOsIT/expected/expected.json
@@ -381,7 +381,7 @@
       }
     },
     "attributes" : {
-      "name" : "SuperConnectorOS",
+      "name" : "SuperConnector Test OS",
       "connector_id" : "SuperConnectorOS",
       "applies_to_os" : "aix,hpux,linux,oob,solaris,storage,tru64,vms,windows",
       "parent.id" : "localhost",

--- a/metricshub-hardware/src/it/resources/snmp/DellOpenManageIT/expected/expected.json
+++ b/metricshub-hardware/src/it/resources/snmp/DellOpenManageIT/expected/expected.json
@@ -80,7 +80,7 @@
       }
     },
     "attributes" : {
-      "name" : "DellOpenManage",
+      "name" : "Dell OpenManage Server Administrator",
       "connector_id" : "DellOpenManage",
       "applies_to_os" : "linux,windows",
       "parent.id" : "localhost",

--- a/metricshub-oscommand-extension/src/it/resources/os/SuperConnectorOsIT/expected/expected.json
+++ b/metricshub-oscommand-extension/src/it/resources/os/SuperConnectorOsIT/expected/expected.json
@@ -297,7 +297,7 @@
       }
     },
     "attributes" : {
-      "name" : "SuperConnectorOS",
+      "name" : "SuperConnector Test OS",
       "connector_id" : "SuperConnectorOS",
       "applies_to_os" : "aix,hpux,linux,oob,solaris,storage,tru64,vms,windows",
       "parent.id" : "localhost",

--- a/metricshub-snmp-extension/src/it/resources/snmp/DellOpenManageIT/expected/expected.json
+++ b/metricshub-snmp-extension/src/it/resources/snmp/DellOpenManageIT/expected/expected.json
@@ -52,7 +52,7 @@
       }
     },
     "attributes" : {
-      "name" : "DellOpenManage",
+      "name" : "Dell OpenManage Server Administrator",
       "connector_id" : "DellOpenManage",
       "applies_to_os" : "linux,windows",
       "parent.id" : "localhost",


### PR DESCRIPTION
- Updated  DetectionStrategy,
 DetectionStrategyTest,
 ConfigHelper,
HostConfiguration,
Constants,
expected.json in metricshub-oscommand-extension,
expected.json in metricshub-snmp-extension and
expected.json in metricshub-hardware
