### PR TITLE
Issue #242:  NPE thrown by the ComputeProcessor due to a null SourceTable.table

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractStrategy.java
@@ -150,9 +150,9 @@ public abstract class AbstractStrategy implements IStrategy {
 				.build()
 				.run(() -> runSource(connectorId, attributes, source, previousSourceTable));
 
-			if (sourceTable == null) {
+			if (sourceTable == null || sourceTable.isEmpty()) {
 				log.warn(
-					"Hostname {} - Received null source table for Source key {} - Connector {} - Monitor {}.",
+					"Hostname {} - Received null or empty source table for Source key {} - Connector {} - Monitor {}.",
 					hostname,
 					sourceKey,
 					connectorId,


### PR DESCRIPTION
Add a test to check if the source table is empty before starting the computes.