### PR TITLE
Issue #241: missing skip null annotation on port field leads to configuration issues

### DIFF
--- a/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiConfiguration.java
+++ b/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiConfiguration.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
@@ -44,7 +45,7 @@ import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 @NoArgsConstructor
 public class IpmiConfiguration implements IConfiguration {
 
-	@Builder.Default
+	@Default
 	@JsonSetter(nulls = SKIP)
 	@JsonDeserialize(using = TimeDeserializer.class)
 	private final Long timeout = 120L;

--- a/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfiguration.java
+++ b/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfiguration.java
@@ -50,8 +50,8 @@ public class SnmpConfiguration implements ISnmpConfiguration {
 	private static final String INVALID_SNMP_VERSION_EXCEPTION_MESSAGE = "Invalid SNMP version: ";
 
 	@Default
-	@JsonDeserialize(using = SnmpVersionDeserializer.class)
 	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = SnmpVersionDeserializer.class)
 	private final SnmpVersion version = SnmpVersion.V1;
 
 	@Default

--- a/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Configuration.java
+++ b/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Configuration.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -51,15 +52,15 @@ public class SnmpV3Configuration implements ISnmpConfiguration {
 	private static final String INVALID_AUTH_TYPE_EXCEPTION_MESSAGE = "Invalid authentication type: ";
 	private static final String INVALID_PRIVACY_VALUE_EXCEPTION_MESSAGE = "Invalid privacy value: ";
 
-	@Builder.Default
+	@Default
 	@JsonSetter(nulls = SKIP)
 	private char[] community = new char[] { 'p', 'u', 'b', 'l', 'i', 'c' };
 
-	@Builder.Default
+	@Default
 	@JsonSetter(nulls = SKIP)
 	private Integer port = 161;
 
-	@Builder.Default
+	@Default
 	@JsonSetter(nulls = SKIP)
 	@JsonDeserialize(using = TimeDeserializer.class)
 	private Long timeout = 120L;

--- a/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfiguration.java
+++ b/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfiguration.java
@@ -21,9 +21,13 @@ package org.sentrysoftware.metricshub.extension.wbem;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import static com.fasterxml.jackson.annotation.Nulls.SKIP;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
@@ -41,15 +45,18 @@ import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 @NoArgsConstructor
 public class WbemConfiguration implements IConfiguration {
 
-	@Builder.Default
+	@Default
+	@JsonSetter(nulls = SKIP)
 	private final TransportProtocols protocol = TransportProtocols.HTTPS;
 
-	@Builder.Default
+	@Default
+	@JsonSetter(nulls = SKIP)
 	private final Integer port = 5989;
 
 	private String namespace;
 
-	@Builder.Default
+	@Default
+	@JsonSetter(nulls = SKIP)
 	@JsonDeserialize(using = TimeDeserializer.class)
 	private final Long timeout = 120L;
 

--- a/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
+++ b/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
@@ -65,6 +65,7 @@ public class WinRmConfiguration implements IWinConfiguration {
 	private List<AuthenticationEnum> authentications;
 
 	@Default
+	@JsonSetter(nulls = SKIP)
 	@JsonDeserialize(using = TimeDeserializer.class)
 	private Long timeout = 120L;
 

--- a/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
+++ b/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
@@ -55,6 +55,7 @@ public class WinRmConfiguration implements IWinConfiguration {
 	private String namespace;
 
 	@Default
+	@JsonSetter(nulls = SKIP)
 	private Integer port = 5985;
 
 	@Default


### PR DESCRIPTION

* Added skip null annotation on Wbem port, protocol and timeout
* Added skip null annotation on WinRm port and timeout
* Replaced all @Builder.Default annotations with @default in the different protocol extension configurations.
* Tested all the changes on MetricsHub agent