### PR TITLE
Issue #229: Bad THREAD_TIMEOUT value in MetricsHubConstant

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/MetricsHubConstants.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/MetricsHubConstants.java
@@ -170,7 +170,7 @@ public class MetricsHubConstants {
 	/**
 	 * Thread Timeout
 	 */
-	public static final long THREAD_TIMEOUT = 15 * 60L; // 15 minutes
+	public static final long THREAD_TIMEOUT = 2 * 60L; // 2 minutes
 
 	// MetricsHub / OpenTelemetry mappings
 


### PR DESCRIPTION
* Set THREAD_TIMEOUT to 2 minutes