### PR TITLE
Issue #258: Remove Community from SNMP v3 configuration

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpV3ConfigCli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpV3ConfigCli.java
@@ -50,15 +50,6 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 	private boolean useSnmpv3;
 
 	@Option(
-		names = "--snmpv3-community",
-		order = 2,
-		paramLabel = "COMMUNITY",
-		defaultValue = "public",
-		description = "Community string for SNMP version 3"
-	)
-	private char[] community;
-
-	@Option(
 		names = "--snmpv3-privacy",
 		order = 3,
 		paramLabel = "DES|AES",
@@ -157,9 +148,6 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 		final char[] finalPassword = username == null ? defaultPassword : password;
 		if (finalPassword != null) {
 			configuration.set("password", new TextNode(String.valueOf(finalPassword)));
-		}
-		if (community != null) {
-			configuration.set("community", new TextNode((String.valueOf(community))));
 		}
 		configuration.set("privacy", new TextNode(privacy));
 		if (privacyPassword != null) {

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpV3ConfigCli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpV3ConfigCli.java
@@ -51,7 +51,7 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 
 	@Option(
 		names = "--snmpv3-privacy",
-		order = 3,
+		order = 2,
 		paramLabel = "DES|AES",
 		description = "Privacy (encryption type) for SNMP version 3 (DES, AES, or none)"
 	)
@@ -59,7 +59,7 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 
 	@Option(
 		names = "--snmpv3-privacy-password",
-		order = 4,
+		order = 3,
 		paramLabel = "PRIVACY-PASSWORD",
 		description = "Privacy (encryption) password for SNMP version 3"
 	)
@@ -67,7 +67,7 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 
 	@Option(
 		names = "--snmpv3-auth",
-		order = 5,
+		order = 4,
 		paramLabel = "SHA|MD5",
 		description = "Authentication type for SNMP version 3 (SHA, MD5 or NO_AUTH)"
 	)
@@ -75,7 +75,7 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 
 	@Option(
 		names = "--snmpv3-username",
-		order = 6,
+		order = 5,
 		paramLabel = "USERNAME",
 		description = "Username for SNMP version 3 with MD5 or SHA"
 	)
@@ -83,7 +83,7 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 
 	@Option(
 		names = "--snmpv3-password",
-		order = 7,
+		order = 6,
 		paramLabel = "PASSWORD",
 		description = "Password for SNMP version 3 with MD5 or SHA"
 	)
@@ -91,7 +91,7 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 
 	@Option(
 		names = "--snmpv3-context-name",
-		order = 8,
+		order = 7,
 		paramLabel = "CONTEXT-NAME",
 		description = "Context name for SNMP version 3"
 	)
@@ -99,7 +99,7 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 
 	@Option(
 		names = "--snmpv3-timeout",
-		order = 9,
+		order = 8,
 		paramLabel = "TIMEOUT",
 		defaultValue = "" + DEFAULT_TIMEOUT,
 		description = "Timeout in seconds for SNMP version 3 operations (default: ${DEFAULT-VALUE} s)"
@@ -108,7 +108,7 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 
 	@Option(
 		names = "--snmpv3-port",
-		order = 10,
+		order = 9,
 		paramLabel = "PORT",
 		defaultValue = "161",
 		description = "Port of the SNMP version 3 agent (default: ${DEFAULT-VALUE})"
@@ -117,7 +117,7 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 
 	@Option(
 		names = "--snmpv3-retryIntervals",
-		order = 11,
+		order = 10,
 		paramLabel = "RETRY INTERVALS",
 		split = ",",
 		description = "Comma-separated retry intervals in milliseconds for SNMP version 3 operations"

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpV3ConfigCliTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpV3ConfigCliTest.java
@@ -18,8 +18,6 @@ class SnmpV3ConfigCliTest {
 	@Test
 	void testToProtocol() throws Exception {
 		final SnmpV3ConfigCli snmpV3ConfigCli = new SnmpV3ConfigCli();
-		final char[] community = "community".toCharArray();
-		snmpV3ConfigCli.setCommunity(community);
 		snmpV3ConfigCli.setPrivacy("AES");
 		final int[] retryIntervals = { 20, 30, 50 };
 		snmpV3ConfigCli.setRetryIntervals(retryIntervals);

--- a/metricshub-doc/src/site/markdown/configuration/configure-agent.md
+++ b/metricshub-doc/src/site/markdown/configuration/configure-agent.md
@@ -335,7 +335,6 @@ Use the parameters below to configure the SNMP version 3 protocol:
 | ---------------- | ---------------------------------------------------------------------------------------------------- |
 | snmpv3           | Protocol used to access the host using SNMP version 3.                                               |
 | timeout          | How long until the SNMP request times out (Default: 120s).                                           |
-| community        | The SNMP Community string (Default: public).                                                         |
 | port             | The SNMP port number used to perform SNMP version 3 queries (Default: 161).                          |
 | contextName      | The name of the SNMP version 3 context, used to identify the collection of management information.   |
 | authType         | The SNMP version 3 authentication protocol (MD5, SHA or NoAuth) to ensure message authenticity.      |
@@ -358,7 +357,6 @@ resourceGroups:
         protocols:
           snmpv3:
             version: 3
-            community: public
             port: 161
             timeout: 120s
             contextName: myContext

--- a/metricshub-doc/src/site/markdown/troubleshooting/cli.md
+++ b/metricshub-doc/src/site/markdown/troubleshooting/cli.md
@@ -113,8 +113,6 @@ $ metricshub STOR02 -t storage --snmpv3 --snmpv3-auth SHA --snmpv3-username USER
 
 This command will connect to the `STOR02` storage system (`storage`) using `SNMP` version `3`.
 
-> Note: If no SNMP version 3 community is specified, **public** is assumed by default.
-
 ### Windows, WMI and SNMP v2c
 
 ```batch

--- a/metricshub-linux/src/main/resources/jpackage/metricshub/config/metricshub-example.yaml
+++ b/metricshub-linux/src/main/resources/jpackage/metricshub/config/metricshub-example.yaml
@@ -270,7 +270,6 @@ resourceGroups:
       #     host.type: linux
       #   protocols:
       #     snmpv3:
-      #       community: public
       #       port: 161
       #       timeout: 120s
       #       contextName: <snmp-v3-context>

--- a/metricshub-snmp-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/snmp/ISnmpConfiguration.java
+++ b/metricshub-snmp-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/snmp/ISnmpConfiguration.java
@@ -36,13 +36,6 @@ public interface ISnmpConfiguration extends IConfiguration {
 	Long getTimeout();
 
 	/**
-	 * Gets the community for the SNMP protocol.
-	 *
-	 * @return The community as a character array.
-	 */
-	char[] getCommunity();
-
-	/**
 	 * Gets the version for the SNMP protocol
 	 *
 	 * @return The version as a int value.

--- a/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpRequestExecutor.java
+++ b/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpRequestExecutor.java
@@ -199,7 +199,7 @@ public class SnmpRequestExecutor implements ISnmpRequestExecutor {
 					protocol.getPort(),
 					protocol.getIntVersion(),
 					null,
-					new String(protocol.getCommunity()),
+					new String(((SnmpConfiguration) protocol).getCommunity()),
 					null,
 					null,
 					null,

--- a/metricshub-snmpv3-extension/pom.xml
+++ b/metricshub-snmpv3-extension/pom.xml
@@ -144,7 +144,7 @@
 										<limit>
 											<counter>COMPLEXITY</counter>
 											<value>COVEREDRATIO</value>
-											<minimum>0.43</minimum>
+											<minimum>0.42</minimum>
 										</limit>
 									</limits>
 								</rule>

--- a/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Configuration.java
+++ b/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Configuration.java
@@ -39,7 +39,7 @@ import org.sentrysoftware.metricshub.extension.snmp.ISnmpConfiguration;
 /**
  * The SnmpV3Configuration class represents the configuration for SNMP v3 in the
  * MetricsHub engine. It implements the ISnmpConfiguration interface and
- * includes settings such as SNMP version, community, port, timeout, context
+ * includes settings such as SNMP version, port, timeout, context
  * name, authentication type, privacy, privacy password, username, and password.
  */
 @Data
@@ -51,10 +51,6 @@ public class SnmpV3Configuration implements ISnmpConfiguration {
 	private static final int V3 = 3;
 	private static final String INVALID_AUTH_TYPE_EXCEPTION_MESSAGE = "Invalid authentication type: ";
 	private static final String INVALID_PRIVACY_VALUE_EXCEPTION_MESSAGE = "Invalid privacy value: ";
-
-	@Default
-	@JsonSetter(nulls = SKIP)
-	private char[] community = new char[] { 'p', 'u', 'b', 'l', 'i', 'c' };
 
 	@Default
 	@JsonSetter(nulls = SKIP)
@@ -92,17 +88,6 @@ public class SnmpV3Configuration implements ISnmpConfiguration {
 
 	@Override
 	public void validateConfiguration(final String resourceKey) throws InvalidConfigurationException {
-		StringHelper.validateConfigurationAttribute(
-			community,
-			attr -> attr == null || attr.length == 0,
-			() ->
-				String.format(
-					"Resource %s - No community string configured for %s. This resource will not be monitored.",
-					resourceKey,
-					community
-				)
-		);
-
 		StringHelper.validateConfigurationAttribute(
 			port,
 			attr -> attr == null || attr < 1 || attr > 65535,

--- a/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Extension.java
+++ b/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Extension.java
@@ -196,13 +196,8 @@ public class SnmpV3Extension implements IProtocolExtension {
 				.treeToValue(jsonNode, SnmpV3Configuration.class);
 
 			if (decrypt != null) {
-				char[] community = snmpV3Configuration.getCommunity();
 				char[] password = snmpV3Configuration.getPassword();
 				char[] privacyPassword = snmpV3Configuration.getPrivacyPassword();
-				if (community != null) {
-					// Decrypt the community
-					snmpV3Configuration.setCommunity(decrypt.apply(community));
-				}
 				if (password != null) {
 					// Decrypt the password
 					snmpV3Configuration.setPassword(decrypt.apply(password));

--- a/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3RequestExecutor.java
+++ b/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3RequestExecutor.java
@@ -220,7 +220,7 @@ public class SnmpV3RequestExecutor implements ISnmpRequestExecutor {
 					protocol.getPort(),
 					protocol.getIntVersion(),
 					protocol.getRetryIntervals(),
-					new String(protocol.getCommunity()),
+					null,
 					protocol.getAuthType().toString(),
 					protocol.getUsername(),
 					new String(protocol.getPassword()),

--- a/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ConfigurationTest.java
+++ b/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ConfigurationTest.java
@@ -14,42 +14,10 @@ class SnmpV3ConfigurationTest {
 	void testValidateConfiguration() {
 		final String resourceKey = "resourceKey";
 
-		final char[] community = "public".toCharArray();
-		final char[] emptyCommunity = new char[] {};
-
-		// Test when community is empty
-		{
-			final SnmpV3Configuration snmpV3Config = SnmpV3Configuration
-				.builder()
-				.community(emptyCommunity)
-				.port(1234)
-				.timeout(60L)
-				.authType(AuthType.NO_AUTH)
-				.privacy(Privacy.NO_ENCRYPTION)
-				.build();
-
-			assertThrows(InvalidConfigurationException.class, () -> snmpV3Config.validateConfiguration(resourceKey));
-		}
-
-		// Test when community is null
-		{
-			final SnmpV3Configuration snmpV3Config = SnmpV3Configuration
-				.builder()
-				.community(null)
-				.port(1234)
-				.timeout(60L)
-				.authType(AuthType.NO_AUTH)
-				.privacy(Privacy.NO_ENCRYPTION)
-				.build();
-
-			assertThrows(InvalidConfigurationException.class, () -> snmpV3Config.validateConfiguration(resourceKey));
-		}
-
 		// Test when port is negative
 		{
 			final SnmpV3Configuration snmpV3Config = SnmpV3Configuration
 				.builder()
-				.community(community)
 				.port(-1)
 				.timeout(60L)
 				.authType(AuthType.NO_AUTH)
@@ -63,7 +31,6 @@ class SnmpV3ConfigurationTest {
 		{
 			final SnmpV3Configuration snmpConfig = SnmpV3Configuration
 				.builder()
-				.community(community)
 				.port(66666)
 				.timeout(60L)
 				.authType(AuthType.NO_AUTH)
@@ -77,7 +44,6 @@ class SnmpV3ConfigurationTest {
 		{
 			final SnmpV3Configuration snmpV3Config = SnmpV3Configuration
 				.builder()
-				.community(community)
 				.port(null)
 				.timeout(60L)
 				.authType(AuthType.NO_AUTH)
@@ -91,7 +57,6 @@ class SnmpV3ConfigurationTest {
 		{
 			final SnmpV3Configuration snmpV3Config = SnmpV3Configuration
 				.builder()
-				.community(community)
 				.port(1234)
 				.timeout(-60L)
 				.authType(AuthType.NO_AUTH)
@@ -105,7 +70,6 @@ class SnmpV3ConfigurationTest {
 		{
 			final SnmpV3Configuration snmpV3Config = SnmpV3Configuration
 				.builder()
-				.community(community)
 				.port(1234)
 				.timeout(null)
 				.authType(AuthType.NO_AUTH)
@@ -119,7 +83,6 @@ class SnmpV3ConfigurationTest {
 		{
 			final SnmpV3Configuration snmpV3Config = SnmpV3Configuration
 				.builder()
-				.community(community)
 				.port(1234)
 				.timeout(60L)
 				.authType(AuthType.NO_AUTH)
@@ -134,7 +97,6 @@ class SnmpV3ConfigurationTest {
 		{
 			final SnmpV3Configuration snmpV3Config = SnmpV3Configuration
 				.builder()
-				.community(community)
 				.port(1234)
 				.timeout(0L)
 				.authType(AuthType.NO_AUTH)
@@ -148,7 +110,6 @@ class SnmpV3ConfigurationTest {
 		{
 			final SnmpV3Configuration snmpV3Config = SnmpV3Configuration
 				.builder()
-				.community(community)
 				.port(1234)
 				.timeout(60L)
 				.authType(AuthType.SHA)
@@ -163,7 +124,6 @@ class SnmpV3ConfigurationTest {
 		{
 			final SnmpV3Configuration snmpV3Config = SnmpV3Configuration
 				.builder()
-				.community(community)
 				.port(1234)
 				.timeout(60L)
 				.authType(null)

--- a/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ExtensionTest.java
+++ b/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ExtensionTest.java
@@ -70,7 +70,6 @@ class SnmpV3ExtensionTest {
 
 		final SnmpV3Configuration snmpV3Configuration = SnmpV3Configuration
 			.builder()
-			.community("public".toCharArray())
 			.port(161)
 			.timeout(120L)
 			.username("username")
@@ -556,7 +555,6 @@ class SnmpV3ExtensionTest {
 		assertEquals(
 			SnmpV3Configuration
 				.builder()
-				.community("public".toCharArray())
 				.password("passwordTest".toCharArray())
 				.privacyPassword("privacyPasswordTest".toCharArray())
 				.port(161)
@@ -568,7 +566,6 @@ class SnmpV3ExtensionTest {
 		assertEquals(
 			SnmpV3Configuration
 				.builder()
-				.community("public".toCharArray())
 				.password("passwordTest".toCharArray())
 				.privacyPassword("privacyPasswordTest".toCharArray())
 				.port(161)

--- a/metricshub-windows/src/main/resources/jpackage/MetricsHub/config/metricshub-example.yaml
+++ b/metricshub-windows/src/main/resources/jpackage/MetricsHub/config/metricshub-example.yaml
@@ -270,7 +270,6 @@ resourceGroups:
       #     host.type: linux
       #   protocols:
       #     snmpv3:
-      #       community: public
       #       port: 161
       #       timeout: 120s
       #       contextName: <snmp-v3-context>


### PR DESCRIPTION
Updated configure-agent.md,
cli.md,
metricshub-example.yaml,
ISnmpConfiguration,
SnmpV3Configuration,
SnmpV3Extension,
SnmpV3RequestExecutor,
SnmpV3ConfigCliTest,
SnmpRequestExecutor,
SnmpV3ConfigurationTest,
 and SnmpV3ExtensionTest
Tested the SNMPV3 protocol using the engine and the agent.
Reduced JaCoCo coverage in Metricshub SNMPV3 Project.
