### PR TITLE
Issue #218: Add a `hostname` to be used as a class member for ping

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
@@ -805,7 +805,7 @@ public class ConfigHelper {
 				resourceKey
 			);
 
-			// Validate protocols
+			// Validate protocols and update the configuration's hostname if required.
 			validateAndNormalizeProtocols(resourceKey, resourceConfig, hostConfiguration.getHostname());
 
 			addConfiguredConnector(resourceConnectorStore, resourceConfig.getConnector());
@@ -906,17 +906,19 @@ public class ConfigHelper {
 	}
 
 	/**
-	 * Validate the protocols configured under the given {@link ResourceConfig} instance
+	 * Validates the protocols configured under the given {@link ResourceConfig} instance.
+	 * Also, it normalizes the configuration's hostname by duplicating the hostname attribute on each configuration.
+	 * This duplication is done only if the configuration's hostname is null.
 	 *
 	 * @param resourceKey    Resource unique identifier
-	 * @param resourceConfig {@link ResourceConfig} instance configured by the user
-	 * @param hostname
-	 * @throws InvalidConfigurationException thrown if a configuration validation fails
+	 * @param resourceConfig {@link ResourceConfig} instance configured by the user.
+	 * @param hostname       The hostname that will be duplicated on each configuration if required.
+	 * @throws InvalidConfigurationException thrown if a configuration validation fails.
 	 */
 	private static void validateAndNormalizeProtocols(
 		@NonNull final String resourceKey,
 		final ResourceConfig resourceConfig,
-		String hostname
+		final String hostname
 	) throws InvalidConfigurationException {
 		final Map<String, IConfiguration> protocols = resourceConfig.getProtocols();
 		if (protocols == null) {

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
@@ -799,14 +799,14 @@ public class ConfigHelper {
 			// Create a new connector store for this resource configuration
 			final ConnectorStore resourceConnectorStore = connectorStore.newConnectorStore();
 
-			// Validate protocols
-			validateProtocols(resourceKey, resourceConfig);
-
 			final HostConfiguration hostConfiguration = buildHostConfiguration(
 				resourceConfig,
 				resourceConfig.getConnectors(),
 				resourceKey
 			);
+
+			// Validate protocols
+			validateAndNormalizeProtocols(resourceKey, resourceConfig, hostConfiguration.getHostname());
 
 			addConfiguredConnector(resourceConnectorStore, resourceConfig.getConnector());
 
@@ -910,10 +910,14 @@ public class ConfigHelper {
 	 *
 	 * @param resourceKey    Resource unique identifier
 	 * @param resourceConfig {@link ResourceConfig} instance configured by the user
+	 * @param hostname
 	 * @throws InvalidConfigurationException thrown if a configuration validation fails
 	 */
-	private static void validateProtocols(@NonNull final String resourceKey, final ResourceConfig resourceConfig)
-		throws InvalidConfigurationException {
+	private static void validateAndNormalizeProtocols(
+		@NonNull final String resourceKey,
+		final ResourceConfig resourceConfig,
+		String hostname
+	) throws InvalidConfigurationException {
 		final Map<String, IConfiguration> protocols = resourceConfig.getProtocols();
 		if (protocols == null) {
 			return;
@@ -923,6 +927,9 @@ public class ConfigHelper {
 			IConfiguration protocolConfig = entry.getValue();
 			if (protocolConfig != null) {
 				protocolConfig.validateConfiguration(resourceKey);
+				if (protocolConfig.getHostname() == null) {
+					protocolConfig.setHostname(hostname);
+				}
 			}
 		}
 	}

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/MetricsHubCliService.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/MetricsHubCliService.java
@@ -275,6 +275,8 @@ public class MetricsHubCliService implements Callable<Integer> {
 
 		// Set the configurations
 		final Map<Class<? extends IConfiguration>, IConfiguration> configurations = buildConfigurations();
+		// Duplicate the main hostname on each configuration. By design, the extensions retrieve the hostname from the configuration.
+		configurations.values().forEach(configuration -> configuration.setHostname(hostname));
 		hostConfiguration.setConfigurations(configurations);
 
 		// Create the TelemetryManager using the connector store and the host configuration created above.

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/IConfiguration.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/IConfiguration.java
@@ -29,6 +29,19 @@ import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfiguratio
  */
 public interface IConfiguration {
 	/**
+	 * Retrieves the declared hostname of the IConfiguration.
+	 *
+	 * @return the IConfiguration hostname value.
+	 */
+	String getHostname();
+
+	/**
+	 * Sets a hostname.
+	 *
+	 * @param hostname the hostname of the local or remote device.
+	 */
+	void setHostname(String hostname);
+	/**
 	 * Validates the current configuration for the given configured resource key. This method ensures that
 	 * the configuration meets all required criteria.
 	 * Criteria may include checking for necessary fields, verifying values against allowed ranges or formats,

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/IConfiguration.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/IConfiguration.java
@@ -36,7 +36,7 @@ public interface IConfiguration {
 	String getHostname();
 
 	/**
-	 * Sets a hostname.
+	 * Replaces the IConfiguration's hostname value by the hostname parameter's value.
 	 *
 	 * @param hostname the hostname of the local or remote device.
 	 */

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/DetectionStrategy.java
@@ -112,7 +112,15 @@ public class DetectionStrategy extends AbstractStrategy {
 		}
 
 		// Detect if we monitor localhost then set the localhost property in the HostProperties instance
-		hostProperties.setLocalhost(NetworkHelper.isLocalhost(hostname));
+		// If one configuration's hostname is not localhost, then we are dealing with a remote host for sure!
+		// This means that remote support connector will be staged for the automatic detection.
+		hostProperties.setLocalhost(
+			hostConfiguration
+				.getConfigurations()
+				.values()
+				.stream()
+				.allMatch(config -> NetworkHelper.isLocalhost(config.getHostname()))
+		);
 
 		// Get the configured connector
 		final String configuredConnectorId = hostConfiguration.getConfiguredConnectorId();

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/configuration/OsCommandTestConfiguration.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/configuration/OsCommandTestConfiguration.java
@@ -43,6 +43,8 @@ public class OsCommandTestConfiguration implements IConfiguration {
 
 	private boolean useSudo;
 
+	private String hostname;
+
 	@Default
 	private Set<String> useSudoCommands = new HashSet<>();
 

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/extension/TestConfiguration.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/extension/TestConfiguration.java
@@ -16,13 +16,9 @@ public class TestConfiguration implements IConfiguration {
 
 	@Override
 	public String getHostname() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
-	public void setHostname(String hostname) {
-		// TODO Auto-generated method stub
-
-	}
+	public void setHostname(String hostname) {}
 }

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/extension/TestConfiguration.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/extension/TestConfiguration.java
@@ -13,4 +13,16 @@ public class TestConfiguration implements IConfiguration {
 
 	@Override
 	public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+	@Override
+	public String getHostname() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void setHostname(String hostname) {
+		// TODO Auto-generated method stub
+
+	}
 }

--- a/metricshub-hardware/src/it/java/org/sentrysoftware/metricshub/hardware/it/DellOpenManageIT.java
+++ b/metricshub-hardware/src/it/java/org/sentrysoftware/metricshub/hardware/it/DellOpenManageIT.java
@@ -51,6 +51,7 @@ class DellOpenManageIT {
 	static void setUp() throws Exception {
 		final SnmpConfiguration snmpConfiguration = SnmpConfiguration
 			.builder()
+			.hostname(LOCALHOST)
 			.community("public".toCharArray())
 			.version(SnmpVersion.V1)
 			.timeout(120L)

--- a/metricshub-http-extension/src/main/java/org/sentrysoftware/metricshub/extension/http/HttpConfiguration.java
+++ b/metricshub-http-extension/src/main/java/org/sentrysoftware/metricshub/extension/http/HttpConfiguration.java
@@ -60,6 +60,8 @@ public class HttpConfiguration implements IConfiguration {
 	private String username;
 	private char[] password;
 
+	private String hostname;
+
 	@Override
 	public String toString() {
 		return String.format(

--- a/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/HttpExtensionTest.java
+++ b/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/HttpExtensionTest.java
@@ -137,6 +137,18 @@ class HttpExtensionTest {
 				new IConfiguration() {
 					@Override
 					public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+					@Override
+					public String getHostname() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+
+					@Override
+					public void setHostname(String hostname) {
+						// TODO Auto-generated method stub
+
+					}
 				}
 			)
 		);

--- a/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/HttpExtensionTest.java
+++ b/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/HttpExtensionTest.java
@@ -140,15 +140,11 @@ class HttpExtensionTest {
 
 					@Override
 					public String getHostname() {
-						// TODO Auto-generated method stub
 						return null;
 					}
 
 					@Override
-					public void setHostname(String hostname) {
-						// TODO Auto-generated method stub
-
-					}
+					public void setHostname(String hostname) {}
 				}
 			)
 		);

--- a/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiConfiguration.java
+++ b/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiConfiguration.java
@@ -55,6 +55,8 @@ public class IpmiConfiguration implements IConfiguration {
 	private boolean skipAuth;
 	private String bmcKey;
 
+	private String hostname;
+
 	@Override
 	public String toString() {
 		String description = "IPMI";

--- a/metricshub-ipmi-extension/src/test/java/org/sentrysoftware/IpmiExtensionTest.java
+++ b/metricshub-ipmi-extension/src/test/java/org/sentrysoftware/IpmiExtensionTest.java
@@ -135,6 +135,18 @@ class IpmiExtensionTest {
 				new IConfiguration() {
 					@Override
 					public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+					@Override
+					public String getHostname() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+
+					@Override
+					public void setHostname(String hostname) {
+						// TODO Auto-generated method stub
+
+					}
 				}
 			)
 		);

--- a/metricshub-ipmi-extension/src/test/java/org/sentrysoftware/IpmiExtensionTest.java
+++ b/metricshub-ipmi-extension/src/test/java/org/sentrysoftware/IpmiExtensionTest.java
@@ -138,15 +138,11 @@ class IpmiExtensionTest {
 
 					@Override
 					public String getHostname() {
-						// TODO Auto-generated method stub
 						return null;
 					}
 
 					@Override
-					public void setHostname(String hostname) {
-						// TODO Auto-generated method stub
-
-					}
+					public void setHostname(String hostname) {}
 				}
 			)
 		);

--- a/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfiguration.java
+++ b/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfiguration.java
@@ -60,6 +60,8 @@ public class OsCommandConfiguration implements IConfiguration {
 	@JsonDeserialize(using = TimeDeserializer.class)
 	Long timeout = DEFAULT_TIMEOUT;
 
+	private String hostname;
+
 	/**
 	 * Creates a new instance of OsCommandConfiguration using the provided parameters.
 	 *

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtensionTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtensionTest.java
@@ -119,6 +119,18 @@ class OsCommandExtensionTest {
 				new IConfiguration() {
 					@Override
 					public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+					@Override
+					public String getHostname() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+
+					@Override
+					public void setHostname(String hostname) {
+						// TODO Auto-generated method stub
+
+					}
 				}
 			)
 		);

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtensionTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtensionTest.java
@@ -122,15 +122,11 @@ class OsCommandExtensionTest {
 
 					@Override
 					public String getHostname() {
-						// TODO Auto-generated method stub
 						return null;
 					}
 
 					@Override
-					public void setHostname(String hostname) {
-						// TODO Auto-generated method stub
-
-					}
+					public void setHostname(String hostname) {}
 				}
 			)
 		);

--- a/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingConfiguration.java
+++ b/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingConfiguration.java
@@ -52,6 +52,8 @@ public class PingConfiguration implements IConfiguration {
 	@JsonDeserialize(using = TimeDeserializer.class)
 	private final Long timeout = 5L;
 
+	private String hostname;
+
 	@Override
 	public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {
 		StringHelper.validateConfigurationAttribute(

--- a/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingExtension.java
+++ b/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingExtension.java
@@ -92,7 +92,7 @@ public class PingExtension implements IProtocolExtension {
 			return Optional.empty();
 		}
 
-		// Retrieve the hostname
+		// Retrieve the hostname from the Ping Configuration
 		final String hostname = pingConfiguration.getHostname();
 
 		// Create and set the Ping result to null

--- a/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingExtension.java
+++ b/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingExtension.java
@@ -81,12 +81,6 @@ public class PingExtension implements IProtocolExtension {
 
 	@Override
 	public Optional<Boolean> checkProtocol(TelemetryManager telemetryManager) {
-		// Retrieve the hostname
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
-
-		// Create and set the Ping result to null
-		boolean pingResult = false;
-
 		// Retrieve Ping configuration from the telemetry manager
 		final PingConfiguration pingConfiguration = (PingConfiguration) telemetryManager
 			.getHostConfiguration()
@@ -97,6 +91,12 @@ public class PingExtension implements IProtocolExtension {
 		if (pingConfiguration == null) {
 			return Optional.empty();
 		}
+
+		// Retrieve the hostname
+		final String hostname = pingConfiguration.getHostname();
+
+		// Create and set the Ping result to null
+		boolean pingResult = false;
 
 		log.info("Hostname {} - Performing {} protocol health check.", hostname, getIdentifier());
 		log.info("Hostname {} - Checking Ping protocol status. Sending a ping to '/'.", hostname);

--- a/metricshub-ping-extension/src/test/java/org/sentrysoftware/metricshub/extension/ping/PingExtensionTest.java
+++ b/metricshub-ping-extension/src/test/java/org/sentrysoftware/metricshub/extension/ping/PingExtensionTest.java
@@ -59,7 +59,7 @@ class PingExtensionTest {
 			Map.of(HOST.getKey(), Map.of(HOST_NAME, hostMonitor))
 		);
 
-		final PingConfiguration pingConfiguration = PingConfiguration.builder().build();
+		final PingConfiguration pingConfiguration = PingConfiguration.builder().hostname(HOST_NAME).build();
 
 		final Connector connector = Connector.builder().build();
 
@@ -119,6 +119,18 @@ class PingExtensionTest {
 				new IConfiguration() {
 					@Override
 					public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+					@Override
+					public String getHostname() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+
+					@Override
+					public void setHostname(String hostname) {
+						// TODO Auto-generated method stub
+
+					}
 				}
 			)
 		);

--- a/metricshub-ping-extension/src/test/java/org/sentrysoftware/metricshub/extension/ping/PingExtensionTest.java
+++ b/metricshub-ping-extension/src/test/java/org/sentrysoftware/metricshub/extension/ping/PingExtensionTest.java
@@ -122,15 +122,11 @@ class PingExtensionTest {
 
 					@Override
 					public String getHostname() {
-						// TODO Auto-generated method stub
 						return null;
 					}
 
 					@Override
-					public void setHostname(String hostname) {
-						// TODO Auto-generated method stub
-
-					}
+					public void setHostname(String hostname) {}
 				}
 			)
 		);

--- a/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfiguration.java
+++ b/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfiguration.java
@@ -67,6 +67,8 @@ public class SnmpConfiguration implements ISnmpConfiguration {
 	@JsonDeserialize(using = TimeDeserializer.class)
 	private final Long timeout = 120L;
 
+	private String hostname;
+
 	@Override
 	public String toString() {
 		return version.getDisplayName() + " (" + new String(community) + ")";

--- a/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpExtensionTest.java
+++ b/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpExtensionTest.java
@@ -71,6 +71,7 @@ class SnmpExtensionTest {
 			.builder()
 			.community("public".toCharArray())
 			.version(SnmpConfiguration.SnmpVersion.V1)
+			.hostname(HOST_NAME)
 			.port(161)
 			.timeout(120L)
 			.build();
@@ -512,6 +513,18 @@ class SnmpExtensionTest {
 				new IConfiguration() {
 					@Override
 					public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+					@Override
+					public String getHostname() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+
+					@Override
+					public void setHostname(String hostname) {
+						// TODO Auto-generated method stub
+
+					}
 				}
 			)
 		);

--- a/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpExtensionTest.java
+++ b/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpExtensionTest.java
@@ -516,15 +516,11 @@ class SnmpExtensionTest {
 
 					@Override
 					public String getHostname() {
-						// TODO Auto-generated method stub
 						return null;
 					}
 
 					@Override
-					public void setHostname(String hostname) {
-						// TODO Auto-generated method stub
-
-					}
+					public void setHostname(String hostname) {}
 				}
 			)
 		);

--- a/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Configuration.java
+++ b/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Configuration.java
@@ -74,6 +74,8 @@ public class SnmpV3Configuration implements ISnmpConfiguration {
 	private char[] password;
 	private int[] retryIntervals;
 
+	private String hostname;
+
 	@Override
 	public String toString() {
 		String description = "SNMP V3";

--- a/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ExtensionTest.java
+++ b/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ExtensionTest.java
@@ -520,15 +520,11 @@ class SnmpV3ExtensionTest {
 
 					@Override
 					public String getHostname() {
-						// TODO Auto-generated method stub
 						return null;
 					}
 
 					@Override
-					public void setHostname(String hostname) {
-						// TODO Auto-generated method stub
-
-					}
+					public void setHostname(String hostname) {}
 				}
 			)
 		);

--- a/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ExtensionTest.java
+++ b/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ExtensionTest.java
@@ -517,6 +517,18 @@ class SnmpV3ExtensionTest {
 				new IConfiguration() {
 					@Override
 					public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+					@Override
+					public String getHostname() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+
+					@Override
+					public void setHostname(String hostname) {
+						// TODO Auto-generated method stub
+
+					}
 				}
 			)
 		);

--- a/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfiguration.java
+++ b/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfiguration.java
@@ -64,6 +64,8 @@ public class WbemConfiguration implements IConfiguration {
 	char[] password;
 	String vCenter;
 
+	private String hostname;
+
 	@Override
 	public String toString() {
 		String description = protocol + "/" + port;

--- a/metricshub-wbem-extension/src/test/java/org/sentrysoftware/metricshub/extension/wbem/WbemExtensionTest.java
+++ b/metricshub-wbem-extension/src/test/java/org/sentrysoftware/metricshub/extension/wbem/WbemExtensionTest.java
@@ -160,15 +160,11 @@ class WbemExtensionTest {
 
 					@Override
 					public String getHostname() {
-						// TODO Auto-generated method stub
 						return null;
 					}
 
 					@Override
-					public void setHostname(String hostname) {
-						// TODO Auto-generated method stub
-
-					}
+					public void setHostname(String hostname) {}
 				}
 			)
 		);

--- a/metricshub-wbem-extension/src/test/java/org/sentrysoftware/metricshub/extension/wbem/WbemExtensionTest.java
+++ b/metricshub-wbem-extension/src/test/java/org/sentrysoftware/metricshub/extension/wbem/WbemExtensionTest.java
@@ -157,6 +157,18 @@ class WbemExtensionTest {
 				new IConfiguration() {
 					@Override
 					public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+					@Override
+					public String getHostname() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+
+					@Override
+					public void setHostname(String hostname) {
+						// TODO Auto-generated method stub
+
+					}
 				}
 			)
 		);

--- a/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/WmiTestConfiguration.java
+++ b/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/WmiTestConfiguration.java
@@ -13,6 +13,8 @@ public class WmiTestConfiguration implements IWinConfiguration {
 	private char[] password;
 	private String namespace;
 
+	private String hostname;
+
 	@Default
 	private Long timeout = 120L;
 

--- a/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
+++ b/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
@@ -54,6 +54,8 @@ public class WinRmConfiguration implements IWinConfiguration {
 
 	private String namespace;
 
+	private String hostname;
+
 	@Default
 	@JsonSetter(nulls = SKIP)
 	private Integer port = 5985;

--- a/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtensionTest.java
+++ b/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtensionTest.java
@@ -193,6 +193,18 @@ class WinRmExtensionTest {
 				new IConfiguration() {
 					@Override
 					public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+					@Override
+					public String getHostname() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+
+					@Override
+					public void setHostname(String hostname) {
+						// TODO Auto-generated method stub
+
+					}
 				}
 			)
 		);

--- a/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtensionTest.java
+++ b/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtensionTest.java
@@ -196,15 +196,11 @@ class WinRmExtensionTest {
 
 					@Override
 					public String getHostname() {
-						// TODO Auto-generated method stub
 						return null;
 					}
 
 					@Override
-					public void setHostname(String hostname) {
-						// TODO Auto-generated method stub
-
-					}
+					public void setHostname(String hostname) {}
 				}
 			)
 		);

--- a/metricshub-wmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/wmi/WmiConfiguration.java
+++ b/metricshub-wmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/wmi/WmiConfiguration.java
@@ -49,6 +49,8 @@ public class WmiConfiguration implements IWinConfiguration {
 	private char[] password;
 	private String namespace;
 
+	private String hostname;
+
 	@Default
 	@JsonSetter(nulls = SKIP)
 	@JsonDeserialize(using = TimeDeserializer.class)

--- a/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtensionTest.java
+++ b/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtensionTest.java
@@ -203,15 +203,11 @@ class WmiExtensionTest {
 
 					@Override
 					public String getHostname() {
-						// TODO Auto-generated method stub
 						return null;
 					}
 
 					@Override
-					public void setHostname(String hostname) {
-						// TODO Auto-generated method stub
-
-					}
+					public void setHostname(String hostname) {}
 				}
 			)
 		);

--- a/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtensionTest.java
+++ b/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtensionTest.java
@@ -200,6 +200,18 @@ class WmiExtensionTest {
 				new IConfiguration() {
 					@Override
 					public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+					@Override
+					public String getHostname() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+
+					@Override
+					public void setHostname(String hostname) {
+						// TODO Auto-generated method stub
+
+					}
 				}
 			)
 		);


### PR DESCRIPTION
* Added getHostname() and setHostname() methods on IConfiguration interface which consequently required adding it on some IConfiguration subclasses.
* Added hostname attribute on all the configurations.
* Refactored ConfigHelper to add the hostname on each configuration if it's null.
* Refactored MetricsHubCliService to add hostname on each configuration.
* Refactored Ping Extension to handle the new Hostname.
* Tested using both the configurations:
```yaml
  ping-custom-vmname:
    attributes:
      host.name: custom-ping-vmname
      host.type: windows
    protocols:
      ping:
        hostname: vmname
  ping-stock-vmname:
    attributes:
      host.name: vmname
      host.type: windows
    protocols:
      ping:
```
Both work fine!