### PR TITLE
Issue #238: Hardware Enrichment - Adjust Hardware Thresholds - Skeleton setup

### DIFF
--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/MetricNormalizationService.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/MetricNormalizationService.java
@@ -31,6 +31,12 @@ import org.sentrysoftware.metricshub.engine.delegate.IPostExecutionService;
 import org.sentrysoftware.metricshub.engine.telemetry.Monitor;
 import org.sentrysoftware.metricshub.engine.telemetry.TelemetryManager;
 
+/**
+ * Service class for normalizing hardware monitor metrics.
+ * This service retrieves all monitors from the {@link TelemetryManager}, filters the hardware monitors,
+ * and normalizes their metrics based on their type.
+ * Implements the {@link IPostExecutionService} interface to define the post-execution metric normalization logic.
+ */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -47,12 +53,25 @@ public class MetricNormalizationService implements IPostExecutionService {
 		KnownMonitorType.HOST.name()
 	);
 
+	/**
+	 * Checks if the given monitor is a hardware monitor.
+	 * This method determines if a given monitor is a hardware monitor by
+	 * checking if its type is not included in the {@code EXCLUDED_MONITOR_TYPES} set.
+	 * @param monitor the monitor to check
+	 * @return {@code true} if the monitor is a hardware monitor, {@code false} otherwise
+	 */
 	private boolean isHardwareMonitor(final Monitor monitor) {
 		return !EXCLUDED_MONITOR_TYPES.contains(monitor.getType());
 	}
 
+	/**
+	 * Normalizes hardware monitors metrics.
+	 * Retrieves all monitors from the {@code telemetryManager}, filters for hardware monitors,
+	 * and normalizes the metrics of each monitor based on its type.
+	 */
 	@Override
 	public void run() {
+		// Retrieve hardware monitors from the TelemetryManager
 		final List<Monitor> hardwareMonitors = telemetryManager
 			.getMonitors()
 			.values()
@@ -61,6 +80,7 @@ public class MetricNormalizationService implements IPostExecutionService {
 			.filter(this::isHardwareMonitor)
 			.toList();
 
+		// For each hardware monitor type, call the corresponding metric normalization class
 		hardwareMonitors.forEach(monitor -> {
 			switch (monitor.getType()) {
 				case "cpu":

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/MetricNormalizationService.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/MetricNormalizationService.java
@@ -1,0 +1,97 @@
+package org.sentrysoftware.metricshub.hardware;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+import java.util.List;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.sentrysoftware.metricshub.engine.common.helpers.KnownMonitorType;
+import org.sentrysoftware.metricshub.engine.delegate.IPostExecutionService;
+import org.sentrysoftware.metricshub.engine.telemetry.Monitor;
+import org.sentrysoftware.metricshub.engine.telemetry.TelemetryManager;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MetricNormalizationService implements IPostExecutionService {
+
+	private TelemetryManager telemetryManager;
+
+	/**
+	 * The connector and hosts are generic kinds, so they are excluded from the physical types
+	 */
+	private static final Set<String> EXCLUDED_MONITOR_TYPES = Set.of(
+		KnownMonitorType.CONNECTOR.name(),
+		KnownMonitorType.HOST.name()
+	);
+
+	private boolean isHardwareMonitor(final Monitor monitor) {
+		return !EXCLUDED_MONITOR_TYPES.contains(monitor.getType());
+	}
+
+	@Override
+	public void run() {
+		final List<Monitor> hardwareMonitors = telemetryManager
+			.getMonitors()
+			.values()
+			.stream()
+			.flatMap(monitors -> monitors.values().stream())
+			.filter(this::isHardwareMonitor)
+			.toList();
+
+		hardwareMonitors.forEach(monitor -> {
+			switch (monitor.getType()) {
+				case "cpu":
+				//TODO
+				case "fan":
+				//TODO
+				case "gpu":
+				//TODO
+				case "logical_disk":
+				//TODO
+				case "lun":
+				//TODO
+				case "memory":
+				//TODO
+				case "network":
+				//TODO
+				case "other_device":
+				//TODO
+				case "physical_disk":
+				//TODO
+				case "robotics":
+				//TODO
+				case "tape_drive":
+				//TODO
+				case "temperature":
+				//TODO
+				case "voltage":
+				//TODO
+				default:
+				//TODO other hardware monitor types
+			}
+		});
+	}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/strategy/HardwareStrategy.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/strategy/HardwareStrategy.java
@@ -64,6 +64,7 @@ public class HardwareStrategy implements IStrategy {
 	public void run() {
 		if (hasHardwareMonitors(telemetryManager)) {
 			new HardwareEnergyPostExecutionService(telemetryManager).run();
+			// Call the service responsible for the monitor metrics normalization
 			new MetricNormalizationService(telemetryManager).run();
 		}
 	}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/strategy/HardwareStrategy.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/strategy/HardwareStrategy.java
@@ -31,6 +31,7 @@ import org.sentrysoftware.metricshub.engine.common.helpers.KnownMonitorType;
 import org.sentrysoftware.metricshub.engine.strategy.IStrategy;
 import org.sentrysoftware.metricshub.engine.telemetry.TelemetryManager;
 import org.sentrysoftware.metricshub.hardware.HardwareEnergyPostExecutionService;
+import org.sentrysoftware.metricshub.hardware.MetricNormalizationService;
 
 @RequiredArgsConstructor
 @Data
@@ -63,6 +64,7 @@ public class HardwareStrategy implements IStrategy {
 	public void run() {
 		if (hasHardwareMonitors(telemetryManager)) {
 			new HardwareEnergyPostExecutionService(telemetryManager).run();
+			new MetricNormalizationService(telemetryManager).run();
 		}
 	}
 

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/AbstractMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/AbstractMetricNormalizer.java
@@ -24,6 +24,11 @@ import java.util.Map;
 import org.sentrysoftware.metricshub.engine.telemetry.MetricFactory;
 import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
 
+/**
+ * An abstract class that provides methods for normalizing metrics in a monitoring system.
+ * This class contains utility methods to check the availability of the monitor metrics and to adjust their values
+ * based on specified conditions.
+ */
 public abstract class AbstractMetricNormalizer {
 
 	/**
@@ -36,6 +41,7 @@ public abstract class AbstractMetricNormalizer {
 	 *         {@code false} otherwise
 	 */
 	private boolean containsAllEntries(Map<String, String> firstMap, Map<String, String> secondMap) {
+		// Checks if the second map entries are all contained within the first map
 		return secondMap
 			.entrySet()
 			.stream()
@@ -59,15 +65,35 @@ public abstract class AbstractMetricNormalizer {
 		final String prefix,
 		final Map<String, String> attributes
 	) {
+		// Extract the metric name prefix
 		final String metricNamePrefix = MetricFactory.extractName(metricName);
+
 		if (!prefix.equals(metricNamePrefix)) {
 			return false;
 		}
+
+		// Extract the metric attributes
 		final Map<String, String> metricAttributes = MetricFactory.extractAttributesFromMetricName(metricName);
+
+		// Check all the attributes are available in the extracted metric attributes
 		return containsAllEntries(metricAttributes, attributes);
 	}
 
+	/**
+	 * Adjusts the corresponding monitor's metric as follows:
+	 * If the hw.MONITOR_TYPE.METRIC{limit_type="low.critical"} metric is not available while the  hw.MONITOR_TYPE.METRIC{limit_type="low.degraded"}
+	 * metric is, set hw.MONITOR_TYPE.METRIC{limit_type="low.critical"} to hw.MONITOR_TYPE.METRIC{limit_type="low.degraded"} * 0.9.
+	 * We need to manage the following use case as well:
+	 * If the hw.MONITOR_TYPE.METRIC{limit_type="low.critical"} metric is not available while the hw.MONITOR_TYPE.METRIC{limit_type="low.degraded",
+	 * unknown_attr="value"} metric is, set hw.MONITOR_TYPE.METRIC{limit_type="low.critical", unknown_attr="value"} to
+	 * hw.MONITOR_TYPE.METRIC{limit_type="low.degraded", unknown_attr="value"} * 0.9.
+	 * @param metric A given monitor's Number metric
+	 */
 	public abstract void normalize(AbstractMetric metric);
 
+	/**
+	 * Adjusts the metric hw.errors.limit.
+	 * @param metric A given monitor's Number metric
+	 */
 	public abstract void normalizeErrorsLimitMetric(AbstractMetric metric);
 }

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/AbstractMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/AbstractMetricNormalizer.java
@@ -1,0 +1,73 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+import java.util.Map;
+import org.sentrysoftware.metricshub.engine.telemetry.MetricFactory;
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public abstract class AbstractMetricNormalizer {
+
+	/**
+	 * Checks if all entries of the second map are contained in the first map.
+	 * This method iterates through all entries of the second map and checks if each entry is present
+	 * in the first map with the same key and value.
+	 * @param firstMap the map to be checked for containing all entries of the second map
+	 * @param secondMap the map whose entries are to be checked against the first map
+	 * @return {@code true} if all entries of the second map are contained in the first map,
+	 *         {@code false} otherwise
+	 */
+	private boolean containsAllEntries(Map<String, String> firstMap, Map<String, String> secondMap) {
+		return secondMap
+			.entrySet()
+			.stream()
+			.allMatch(entry -> firstMap.containsKey(entry.getKey()) && firstMap.get(entry.getKey()).equals(entry.getValue()));
+	}
+
+	/**
+	 * Checks if a metric with the specified name and attributes is available.
+	 * This method first extracts the metric name prefix and compares it with the provided prefix.
+	 * If they do not match, the metric is considered unavailable. It then extracts the attributes
+	 * from the metric name and checks if all the specified attributes are present in the extracted
+	 * attributes.
+	 * @param metricName the name of the metric to check
+	 * @param prefix the prefix to compare against the extracted metric name prefix
+	 * @param attributes the attributes to verify against the extracted attributes from the metric name
+	 * @return {@code true} if the metric name has the specified prefix and contains all the specified attributes,
+	 *         {@code false} otherwise
+	 */
+	protected boolean isMetricAvailable(
+		final String metricName,
+		final String prefix,
+		final Map<String, String> attributes
+	) {
+		final String metricNamePrefix = MetricFactory.extractName(metricName);
+		if (!prefix.equals(metricNamePrefix)) {
+			return false;
+		}
+		final Map<String, String> metricAttributes = MetricFactory.extractAttributesFromMetricName(metricName);
+		return containsAllEntries(metricAttributes, attributes);
+	}
+
+	public abstract void normalize(AbstractMetric metric);
+
+	public abstract void normalizeErrorsLimitMetric(AbstractMetric metric);
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/CpuMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/CpuMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class CpuMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/FanMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/FanMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class FanMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/GpuMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/GpuMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class GpuMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/LogicalDiskMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/LogicalDiskMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class LogicalDiskMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/LunMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/LunMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class LunMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/MemoryMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/MemoryMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class MemoryMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/NetworkMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/NetworkMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class NetworkMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/OtherDeviceMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/OtherDeviceMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class OtherDeviceMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/PhysicalDiskMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/PhysicalDiskMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class PhysicalDiskMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/RoboticsMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/RoboticsMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class RoboticsMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/TapeDriveMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/TapeDriveMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class TapeDriveMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/TemperatureMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/TemperatureMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class TemperatureMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/VoltageMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/VoltageMetricNormalizer.java
@@ -1,0 +1,33 @@
+package org.sentrysoftware.metricshub.hardware.threshold;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Hardware Energy and Sustainability Module
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.sentrysoftware.metricshub.engine.telemetry.metric.AbstractMetric;
+
+public class VoltageMetricNormalizer extends AbstractMetricNormalizer {
+
+	@Override
+	public void normalize(AbstractMetric metric) {}
+
+	@Override
+	public void normalizeErrorsLimitMetric(AbstractMetric metric) {}
+}


### PR DESCRIPTION
* Create the metrics normalization service
* Add the normalization classes for each hardware monitor type
* Call the created normalization service in HardwareStrategy