### PR TITLE
Issue #218: Add a hostname to be used as a class member for windows

### DIFF
--- a/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/detection/WinCommandLineCriterionProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/detection/WinCommandLineCriterionProcessor.java
@@ -99,11 +99,14 @@ public class WinCommandLineCriterionProcessor {
 			);
 		}
 
+		// Retrieve the configuration from the telemetryManager
+		final IWinConfiguration winConfiguration = configurationRetriever.apply(telemetryManager);
+
 		try {
 			final OsCommandResult osCommandResult = winCommandService.runOsCommand(
 				commandLineCriterion.getCommandLine(),
-				telemetryManager.getHostname(),
-				configurationRetriever.apply(telemetryManager),
+				winConfiguration.getHostname(),
+				winConfiguration,
 				telemetryManager.getEmbeddedFiles(connectorId)
 			);
 

--- a/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/detection/WinIpmiCriterionProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/detection/WinIpmiCriterionProcessor.java
@@ -70,6 +70,6 @@ public class WinIpmiCriterionProcessor {
 			.namespace("root\\hardware")
 			.build();
 
-		return wmiDetectionService.performDetectionTest(telemetryManager.getHostname(), winConfiguration, ipmiWmiCriterion);
+		return wmiDetectionService.performDetectionTest(winConfiguration.getHostname(), winConfiguration, ipmiWmiCriterion);
 	}
 }

--- a/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/detection/WinServiceCriterionProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/detection/WinServiceCriterionProcessor.java
@@ -59,11 +59,6 @@ public class WinServiceCriterionProcessor {
 	 * @return A {@link CriterionTestResult} representing the outcome of the criterion evaluation.
 	 */
 	public CriterionTestResult process(final ServiceCriterion serviceCriterion, final TelemetryManager telemetryManager) {
-		// Sanity checks
-		if (serviceCriterion == null) {
-			return CriterionTestResult.error(serviceCriterion, "Malformed Service criterion.");
-		}
-
 		// Find the configured protocol (WinRM or WMI)
 		final IWinConfiguration winConfiguration = configurationRetriever.apply(telemetryManager);
 
@@ -72,6 +67,11 @@ public class WinServiceCriterionProcessor {
 				serviceCriterion,
 				"Neither WMI nor WinRM credentials are configured for this host."
 			);
+		}
+
+		// Sanity checks
+		if (serviceCriterion == null) {
+			return CriterionTestResult.error(serviceCriterion, "Malformed Service criterion.");
 		}
 
 		// The host system must be Windows
@@ -90,7 +90,7 @@ public class WinServiceCriterionProcessor {
 			return CriterionTestResult.success(serviceCriterion, "Service name is not specified. Skipping this test.");
 		}
 
-		final String hostname = telemetryManager.getHostname();
+		final String hostname = winConfiguration.getHostname();
 
 		// Build a new WMI criterion to check the service existence
 		final WmiCriterion serviceWmiCriterion = WmiCriterion

--- a/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/detection/WmiCriterionProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/detection/WmiCriterionProcessor.java
@@ -109,18 +109,19 @@ public class WmiCriterionProcessor {
 	 * @return A {@link CriterionTestResult} representing the outcome of the criterion evaluation.
 	 */
 	public CriterionTestResult process(final WmiCriterion wmiCriterion, final TelemetryManager telemetryManager) {
-		// Sanity check
-		if (wmiCriterion == null) {
-			return CriterionTestResult.error(wmiCriterion, "Malformed criterion. Cannot perform detection.");
-		}
-
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
-
 		// Find the configured Windows protocol (WMI or WinRM)
 		final IWinConfiguration winConfiguration = configurationRetriever.apply(telemetryManager);
 
 		if (winConfiguration == null) {
 			return CriterionTestResult.error(wmiCriterion, "Neither WMI nor WinRM credentials are configured for this host.");
+		}
+
+		// Retrieve the hostname from the IWinConfiguration
+		final String hostname = winConfiguration.getHostname();
+
+		// Sanity check
+		if (wmiCriterion == null) {
+			return CriterionTestResult.error(wmiCriterion, "Malformed criterion. Cannot perform detection.");
 		}
 
 		// If namespace is specified as "Automatic"

--- a/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/source/WinCommandLineSourceProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/source/WinCommandLineSourceProcessor.java
@@ -68,7 +68,11 @@ public class WinCommandLineSourceProcessor {
 	 *         Returns an empty table if an error occurs or if the command line is invalid.
 	 */
 	public SourceTable process(final CommandLineSource commandLineSource, final TelemetryManager telemetryManager) {
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		// Retrieve the IWinConfiguration from the telemetryManager (WMI or WinRm)
+		final IWinConfiguration winConfiguration = configurationRetriever.apply(telemetryManager);
+
+		// Retrieve the hostname from the IWinConfiguration
+		final String hostname = winConfiguration.getHostname();
 
 		if (commandLineSource == null || commandLineSource.getCommandLine().isEmpty()) {
 			log.error("Hostname {} - Malformed OS command source.", hostname);
@@ -79,7 +83,7 @@ public class WinCommandLineSourceProcessor {
 			final OsCommandResult osCommandResult = winCommandService.runOsCommand(
 				commandLineSource.getCommandLine(),
 				hostname,
-				configurationRetriever.apply(telemetryManager),
+				winConfiguration,
 				telemetryManager.getEmbeddedFiles(connectorId)
 			);
 

--- a/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/source/WinIpmiSourceProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/source/WinIpmiSourceProcessor.java
@@ -67,15 +67,17 @@ public class WinIpmiSourceProcessor {
 		// Find the configured protocol (WinRM or WMI)
 		final IWinConfiguration winConfiguration = configurationRetriever.apply(telemetryManager);
 
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
-
 		if (winConfiguration == null) {
 			log.warn(
 				"Hostname {} - The Windows protocol credentials are not configured. Cannot process Windows IPMI source.",
-				hostname
+				telemetryManager.getHostname()
 			);
 			return SourceTable.empty();
 		}
+
+		// Retrieve the hostname from the IWinConfiguration.
+		final String hostname = winConfiguration.getHostname();
+
 		final String sourceKey = ipmiSource.getKey();
 		final String nameSpaceRootCimv2 = "root/cimv2";
 		final String nameSpaceRootHardware = "root/hardware";

--- a/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/source/WmiSourceProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/sentrysoftware/metricshub/extension/win/source/WmiSourceProcessor.java
@@ -67,22 +67,22 @@ public class WmiSourceProcessor {
 	 * @return A {@link SourceTable} containing the results of the executed query or an empty table in case of an error.
 	 */
 	public SourceTable process(final WmiSource wmiSource, final TelemetryManager telemetryManager) {
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
-
-		if (wmiSource == null) {
-			log.warn("Hostname {} - Malformed WMI source {}. Returning an empty table.", hostname, wmiSource);
-			return SourceTable.empty();
-		}
-
 		// Find the configured protocol (WinRM or WMI)
 		final IWinConfiguration winConfiguration = configurationRetriever.apply(telemetryManager);
 
 		if (winConfiguration == null) {
 			log.debug(
-				"Hostname {} - Neither WMI nor WinRM credentials are configured for this host. Returning an empty table for WMI source {}.",
-				hostname,
-				wmiSource.getKey()
+				"Hostname {} - Neither WMI nor WinRM credentials are configured for this host. Returning an empty table.",
+				telemetryManager.getHostname()
 			);
+			return SourceTable.empty();
+		}
+
+		// Retrieve the hostname from the IWinConfiguration
+		final String hostname = winConfiguration.getHostname();
+
+		if (wmiSource == null) {
+			log.warn("Hostname {} - Malformed WMI source {}. Returning an empty table.", hostname, wmiSource);
 			return SourceTable.empty();
 		}
 

--- a/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/detection/WinCommandLineCriterionProcessorTest.java
+++ b/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/detection/WinCommandLineCriterionProcessorTest.java
@@ -254,6 +254,7 @@ class WinCommandLineCriterionProcessorTest {
 
 		final WmiTestConfiguration wmiConfiguration = WmiTestConfiguration
 			.builder()
+			.hostname(HOST_NAME)
 			.username(USERNAME)
 			.password(PASSWORD)
 			.build();

--- a/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/detection/WinServiceCriterionProcessorTest.java
+++ b/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/detection/WinServiceCriterionProcessorTest.java
@@ -82,8 +82,26 @@ class WinServiceCriterionProcessorTest {
 	@Test
 	void testProcessServiceCheckServiceNull() {
 		final ServiceCriterion serviceCriterion = null;
+		final WmiTestConfiguration wmiConfiguration = WmiTestConfiguration.builder().hostname(HOST_NAME).build();
+		final TelemetryManager telemetryManager = TelemetryManager
+			.builder()
+			.hostConfiguration(
+				HostConfiguration
+					.builder()
+					.hostname(HOST_NAME)
+					.hostId(HOST_NAME)
+					.configurations(Map.of(WmiTestConfiguration.class, wmiConfiguration))
+					.build()
+			)
+			.build();
+
+		doReturn(wmiConfiguration).when(configurationRetrieverMock).apply(telemetryManager);
+
 		assertTrue(
-			winServiceCriterionProcessor.process(serviceCriterion, null).getMessage().contains("Malformed Service criterion.")
+			winServiceCriterionProcessor
+				.process(serviceCriterion, telemetryManager)
+				.getMessage()
+				.contains("Malformed Service criterion.")
 		);
 	}
 

--- a/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/detection/WmiCriterionProcessorTest.java
+++ b/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/detection/WmiCriterionProcessorTest.java
@@ -189,6 +189,7 @@ class WmiCriterionProcessorTest {
 			.builder()
 			.username(USERNAME)
 			.password(PASSWORD)
+			.hostname(HOST_NAME)
 			.timeout(15L)
 			.build();
 
@@ -203,6 +204,8 @@ class WmiCriterionProcessorTest {
 					.build()
 			)
 			.build();
+
+		doReturn(wmiConfiguration).when(configurationRetrieverMock).apply(telemetryManager);
 
 		final CriterionTestResult result = wmiCriterionProcessor.process(null, telemetryManager);
 		assertFalse(result.isSuccess());

--- a/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/source/WinCommandLineSourceProcessorTest.java
+++ b/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/source/WinCommandLineSourceProcessorTest.java
@@ -56,6 +56,7 @@ class WinCommandLineSourceProcessorTest {
 			.builder()
 			.username(HOST_NAME + "\\" + USERNAME)
 			.password(PASSWORD)
+			.hostname(HOST_NAME)
 			.build();
 		final TelemetryManager telemetryManager = TelemetryManager
 			.builder()
@@ -69,6 +70,8 @@ class WinCommandLineSourceProcessorTest {
 					.build()
 			)
 			.build();
+
+		doReturn(wmiConfiguration).when(configurationRetrieverMock).apply(telemetryManager);
 
 		// Command line null
 		assertEquals(SourceTable.empty(), winCommandLineSourceProcessor.process(null, telemetryManager));
@@ -109,6 +112,7 @@ class WinCommandLineSourceProcessorTest {
 			.builder()
 			.username(HOST_NAME + "\\" + USERNAME)
 			.password(PASSWORD)
+			.hostname(HOST_NAME)
 			.build();
 		final TelemetryManager telemetryManager = TelemetryManager
 			.builder()

--- a/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/source/WinIpmiSourceProcessorTest.java
+++ b/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/source/WinIpmiSourceProcessorTest.java
@@ -53,6 +53,7 @@ class WinIpmiSourceProcessorTest {
 			.builder()
 			.username(USERNAME)
 			.password(PASSWORD)
+			.hostname(HOST_NAME)
 			.timeout(120L)
 			.build();
 		final HostConfiguration hostConfiguration = HostConfiguration

--- a/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/source/WmiSourceProcessorTest.java
+++ b/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/source/WmiSourceProcessorTest.java
@@ -87,6 +87,7 @@ class WmiSourceProcessorTest {
 			.builder()
 			.username(HOST_NAME + "\\" + USERNAME)
 			.password(PASSWORD)
+			.hostname(HOST_NAME)
 			.build();
 		final TelemetryManager telemetryManager = TelemetryManager
 			.builder()
@@ -149,6 +150,7 @@ class WmiSourceProcessorTest {
 			.builder()
 			.username(HOST_NAME + "\\" + USERNAME)
 			.password(PASSWORD)
+			.hostname(HOST_NAME)
 			.build();
 		final TelemetryManager telemetryManager = TelemetryManager
 			.builder()

--- a/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtension.java
+++ b/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtension.java
@@ -132,8 +132,8 @@ public class WinRmExtension implements IProtocolExtension {
 		// Create and set the WinRM result to null
 		List<List<String>> winRmResult = null;
 
-		// Retrieve the hostname
-		final String hostname = telemetryManager.getHostname();
+		// Retrieve the hostname from the WinRm Configuration
+		final String hostname = winRmConfiguration.getHostname();
 
 		log.info("Hostname {} - Performing {} protocol health check.", hostname, getIdentifier());
 		log.info(

--- a/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtensionTest.java
+++ b/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtensionTest.java
@@ -106,6 +106,7 @@ class WinRmExtensionTest {
 			.builder()
 			.password(PASSWORD)
 			.username(USERNAME)
+			.hostname(HOST_NAME)
 			.namespace(NAMESPACE)
 			.port(443)
 			.protocol(TransportProtocols.HTTP)
@@ -236,6 +237,7 @@ class WinRmExtensionTest {
 			.builder()
 			.username(USERNAME)
 			.password(PASSWORD)
+			.hostname(HOST_NAME)
 			.namespace(NAMESPACE)
 			.port(443)
 			.timeout(15L)
@@ -340,6 +342,7 @@ class WinRmExtensionTest {
 			.builder()
 			.username(USERNAME)
 			.password(PASSWORD)
+			.hostname(HOST_NAME)
 			.timeout(15L)
 			.build();
 

--- a/metricshub-wmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtension.java
+++ b/metricshub-wmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtension.java
@@ -120,12 +120,6 @@ public class WmiExtension implements IProtocolExtension {
 
 	@Override
 	public Optional<Boolean> checkProtocol(TelemetryManager telemetryManager) {
-		// Create and set the WMI result to null
-		List<List<String>> wmiResult = null;
-
-		// Retrieve the hostname
-		final String hostname = telemetryManager.getHostname();
-
 		// Retrieve WMI Configuration from the telemetry manager host configuration
 		final WmiConfiguration wmiConfiguration = (WmiConfiguration) telemetryManager
 			.getHostConfiguration()
@@ -136,6 +130,12 @@ public class WmiExtension implements IProtocolExtension {
 		if (wmiConfiguration == null) {
 			return Optional.empty();
 		}
+
+		// Retrieve the hostname
+		final String hostname = wmiConfiguration.getHostname();
+
+		// Create and set the WMI result to null
+		List<List<String>> wmiResult = null;
 
 		log.info("Hostname {} - Performing {} protocol health check.", hostname, getIdentifier());
 		log.info(

--- a/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtensionTest.java
+++ b/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtensionTest.java
@@ -101,6 +101,7 @@ class WmiExtensionTest {
 			.builder()
 			.password("pass".toCharArray())
 			.username("user")
+			.hostname(HOST_NAME)
 			.timeout(120L)
 			.build();
 
@@ -243,6 +244,7 @@ class WmiExtensionTest {
 			.builder()
 			.username(USERNAME)
 			.password(PASSWORD)
+			.hostname(HOST_NAME)
 			.timeout(15L)
 			.build();
 
@@ -352,6 +354,7 @@ class WmiExtensionTest {
 	void testProcessSource() throws Exception {
 		final WmiConfiguration wmiConfiguration = WmiConfiguration
 			.builder()
+			.hostname(HOST_NAME)
 			.username(USERNAME)
 			.password(PASSWORD)
 			.timeout(15L)


### PR DESCRIPTION

* Refactored WMI-common, Wmi and WinRm Extensions to use the right hostname.
* Refactored unit tests to include a hostname in the configurations.
* Added mocks in some tests to make them run.
* Tested both extensions using the MetricsHub Agent.