### PR TITLE
Issue #304: Rename Appendix pages in the documentation

### DIFF
--- a/metricshub-doc/src/site/site.xml
+++ b/metricshub-doc/src/site/site.xml
@@ -156,8 +156,8 @@
 		</menu>
 
 		<menu name="Appendix">
-			<item name="Community Connectors Reference" href="metricshub-connector-reference.html" />
-			<item name="Community Connector Platforms" href="platform-requirements.html" />
+			<item name="Connectors Reference" href="metricshub-connector-reference.html" />
+			<item name="Connector Platforms" href="platform-requirements.html" />
 		</menu>
 
 		<menu ref="reports" />


### PR DESCRIPTION
* Renamed `Community Connectors Reference` to `Connectors Reference`.
* Renamed `Community Connector Platforms` to `Connector Platforms`.