### PR TITLE
Issue #318: Separate Maven Properties for Community and Enterprise

### DIFF
--- a/metricshub-doc/pom.xml
+++ b/metricshub-doc/pom.xml
@@ -14,6 +14,12 @@
 	<description>MetricsHub Documentation (site)</description>
 	<url>https://metricshub.com/docs/latest/</url>
 
+	<properties>
+		<communityVersion>${project.version}</communityVersion>
+		<enterpriseVersion>1.0.00</enterpriseVersion>
+		<otelVersion>0.102.0</otelVersion>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/metricshub-doc/src/site/markdown/develop/connector.md
+++ b/metricshub-doc/src/site/markdown/develop/connector.md
@@ -27,7 +27,7 @@ connector:
   platforms: # <string>
   reliesOn: # <string>
   version:  # <string>
-  projectVersion: # <string> | default: ${project.version}
+  projectVersion: # <string> | default: {esc.d}${project.version}
   information: # <string>
   detection: # <object>
 ```
@@ -98,7 +98,7 @@ connector:
   platforms: # <string>
   reliesOn: # <string>
   version:  # <string>
-  projectVersion: # <string> | default: ${project.version}
+  projectVersion: # <string> | default: {esc.d}${project.version}
   information: # <string>
 
   detection: # <object>

--- a/metricshub-doc/src/site/markdown/install.md
+++ b/metricshub-doc/src/site/markdown/install.md
@@ -11,15 +11,15 @@ You can install **MetricsHub** on the operating system of your choice as they ar
 
 ### Download
 
-Download the Linux package, `metricshub-linux-${project.version}.tar.gz`, from the [MetricsHub Release v${project.version}](https://github.com/sentrysoftware/metricshub/releases/tag/v${project.version}) page.
+Download the Linux package, `metricshub-linux-${communityVersion}.tar.gz`, from the [MetricsHub Release v${communityVersion}](https://github.com/sentrysoftware/metricshub/releases/tag/v${communityVersion}) page.
 
 ### Install
 
-Unzip and untar the content of `metricshub-linux-${project.version}.tar.gz` into a program directory, like `/opt`. There is no need to create a specific subdirectory for `metricshub` as the archive already contains a `metricshub` directory.
+Unzip and untar the content of `metricshub-linux-${communityVersion}.tar.gz` into a program directory, like `/opt`. There is no need to create a specific subdirectory for `metricshub` as the archive already contains a `metricshub` directory.
 
 ```shell-session
 / $ cd /opt
-/opt $ sudo tar xzf /tmp/metricshub-linux-${project.version}.tar.gz
+/opt $ sudo tar xzf /tmp/metricshub-linux-${communityVersion}.tar.gz
 ```
 
 ### Configure
@@ -154,11 +154,11 @@ If the **MetricsHub Service** was set up as a **Linux Service**, delete the file
 
 ### Download
 
-Download the Windows package, `metricshub-windows-${project.version}.zip`, from the [MetricsHub Release v${project.version}](https://github.com/sentrysoftware/metricshub/releases/tag/v${project.version}) page.
+Download the Windows package, `metricshub-windows-${communityVersion}.zip`, from the [MetricsHub Release v${communityVersion}](https://github.com/sentrysoftware/metricshub/releases/tag/v${communityVersion}) page.
 
 ### Install
 
-Unzip the content of `metricshub-windows-${project.version}.zip` into a program folder, like `C:\Program Files`. There is no need to create a specific subdirectory for `MetricsHub` as the zip archive already contains a `MetricsHub` directory.
+Unzip the content of `metricshub-windows-${communityVersion}.zip` into a program folder, like `C:\Program Files`. There is no need to create a specific subdirectory for `MetricsHub` as the zip archive already contains a `MetricsHub` directory.
 
 > Note: You will need administrative privileges to unzip into `C:\Program Files`.
 
@@ -248,15 +248,15 @@ If the **MetricsHub Service** was set up as a **Windows Service**, run the follo
 
 ### Download
 
-Download the Docker package, `metricshub-linux-${project.version}-docker.tar.gz`, from the [MetricsHub Release v${project.version}](https://github.com/sentrysoftware/metricshub/releases/tag/v${project.version}) page.
+Download the Docker package, `metricshub-linux-${communityVersion}-docker.tar.gz`, from the [MetricsHub Release v${communityVersion}](https://github.com/sentrysoftware/metricshub/releases/tag/v${communityVersion}) page.
 
 ### Install
 
-Unzip and untar the content of `metricshub-linux-${project.version}-docker.tar.gz` into a directory, like `/docker`.
+Unzip and untar the content of `metricshub-linux-${communityVersion}-docker.tar.gz` into a directory, like `/docker`.
 
 ```shell-session
 / $ cd /docker
-/docker $ sudo tar xzf /tmp/metricshub-linux-${project.version}-docker.tar.gz
+/docker $ sudo tar xzf /tmp/metricshub-linux-${communityVersion}-docker.tar.gz
 ```
 
 ### Configure

--- a/metricshub-doc/src/site/markdown/quick-start-community-prometheus-linux.md
+++ b/metricshub-doc/src/site/markdown/quick-start-community-prometheus-linux.md
@@ -15,16 +15,16 @@ After completing this quick start, you will have:
 
 ## Step 1: Install MetricsHub
 
-1. Download the latest package `metricshub-linux-${project.version}.tar.gz` using `wget` and save it under `/tmp`:
+1. Download the latest package `metricshub-linux-${communityVersion}.tar.gz` using `wget` and save it under `/tmp`:
    
    ```shell
-   sudo wget -O /tmp/metricshub-linux-${project.version}.tar.gz https://github.com/sentrysoftware/metricshub/releases/download/v${project.version}/metricshub-linux-${project.version}.tar.gz
+   sudo wget -O /tmp/metricshub-linux-${communityVersion}.tar.gz https://github.com/sentrysoftware/metricshub/releases/download/v${communityVersion}/metricshub-linux-${communityVersion}.tar.gz
    ```
 
-2. Run the below command to unzip `/tmp/metricshub-linux-${project.version}.tar.gz` under `/opt`:
+2. Run the below command to unzip `/tmp/metricshub-linux-${communityVersion}.tar.gz` under `/opt`:
 
    ```shell
-   sudo tar -xzvf /tmp/metricshub-linux-${project.version}.tar.gz -C /opt/
+   sudo tar -xzvf /tmp/metricshub-linux-${communityVersion}.tar.gz -C /opt/
    ```
 
 There is no need to create a specific subdirectory for `metricshub` as the archive already contains a `metricshub` directory.

--- a/metricshub-doc/src/site/markdown/quick-start-community-prometheus-windows.md
+++ b/metricshub-doc/src/site/markdown/quick-start-community-prometheus-windows.md
@@ -15,7 +15,7 @@ After completing this quick start, you will have:
 
 ## Step 1: Install MetricsHub
 
-1. Download the latest package, `metricshub-windows-${project.version}.zip`, from the [MetricsHub Releases](https://github.com/sentrysoftware/metricshub/releases/) page
+1. Download the latest package, `metricshub-windows-${communityVersion}.zip`, from the [MetricsHub Releases](https://github.com/sentrysoftware/metricshub/releases/) page
 
 2. Right-click on the archive, select **Extract All...**, enter `C:\Program Files\`, and click **Extract**. This will place the `MetricsHub` directory in `C:\Program Files\`.
 


### PR DESCRIPTION
* Updated the `pom.xml` file to include the new maven properties.
* Used `${communityVersion}` where the Community version is needed.
* Used `${enterpriseVersion}` where the Enterprise version is needed.
* Used `${otelVersion}` where the OpenTelemetry version is needed.