### PR TITLE
Issue #321: Update MetricsHub configuration repository name on Windows

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/AgentConstants.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/AgentConstants.java
@@ -47,6 +47,10 @@ public class AgentConstants {
 	 */
 	public static final String PRODUCT_CODE = "metricshub";
 	/**
+	 * Product directory name in PascalCase
+	 */
+	public static final String PRODUCT_WIN_DIR_NAME = "MetricsHub";
+	/**
 	 * Configuration example filename
 	 */
 	public static final String CONFIG_EXAMPLE_FILENAME = PRODUCT_CODE + "-example.yaml";

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
@@ -26,7 +26,7 @@ import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.CONFIG_E
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.DEFAULT_CONFIG_FILENAME;
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.FILE_PATH_FORMAT;
 import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.LOG_DIRECTORY_NAME;
-import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.PRODUCT_CODE;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.PRODUCT_WIN_DIR_NAME;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -113,7 +113,7 @@ public class ConfigHelper {
 
 			// Make sure the LOCALAPPDATA path is valid
 			if (localAppDataPath != null && !localAppDataPath.isBlank()) {
-				return createDirectories(Paths.get(localAppDataPath, PRODUCT_CODE, "logs"));
+				return createDirectories(Paths.get(localAppDataPath, PRODUCT_WIN_DIR_NAME, "logs"));
 			}
 		}
 
@@ -227,7 +227,7 @@ public class ConfigHelper {
 			.stream()
 			.map(path ->
 				Paths.get(
-					createDirectories(Paths.get(path, PRODUCT_CODE, directory)).toAbsolutePath().toString(),
+					createDirectories(Paths.get(path, PRODUCT_WIN_DIR_NAME, directory)).toAbsolutePath().toString(),
 					configFilename
 				)
 			)

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/security/PasswordEncrypt.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/security/PasswordEncrypt.java
@@ -73,7 +73,7 @@ public class PasswordEncrypt {
 		return ConfigHelper
 			.getProgramDataPath()
 			.stream()
-			.map(path -> Paths.get(path, AgentConstants.PRODUCT_CODE, AgentConstants.SECURITY_DIRECTORY_NAME))
+			.map(path -> Paths.get(path, AgentConstants.PRODUCT_WIN_DIR_NAME, AgentConstants.SECURITY_DIRECTORY_NAME))
 			.findFirst()
 			.orElseGet(PasswordEncrypt::getSecurityFolderFromInstallDir);
 	}

--- a/metricshub-doc/src/site/markdown/quick-start-community-prometheus-windows.md
+++ b/metricshub-doc/src/site/markdown/quick-start-community-prometheus-windows.md
@@ -38,11 +38,11 @@ After completing this quick start, you will have:
 1. Before creating your configuration file (`metricshub.yaml`), ensure that the required directories exist. If they do not, open a Command Prompt and run the following commands to create them:
 
    ```shell
-   mkdir C:\ProgramData\metricshub
-   mkdir C:\ProgramData\metricshub\config
+   mkdir C:\ProgramData\MetricsHub
+   mkdir C:\ProgramData\MetricsHub\config
    ```
 
-2. Copy the configuration example `metricshub-example.yaml` available in `C:\Program Files\MetricsHub\config\`, paste it into `C:\ProgramData\metricshub\config\` and rename the file to `metricshub.yaml`.
+2. Copy the configuration example `metricshub-example.yaml` available in `C:\Program Files\MetricsHub\config\`, paste it into `C:\ProgramData\MetricsHub\config\` and rename the file to `metricshub.yaml`.
 
 ### Configure localhost monitoring
 
@@ -60,13 +60,13 @@ resources:
 ```
 
 
-Open the `C:\ProgramData\metricshub\config\metricshub.yaml` file and search for the above section to verify that the configuration is active. 
+Open the `C:\ProgramData\MetricsHub\config\metricshub.yaml` file and search for the above section to verify that the configuration is active. 
 
-If you wish to use a protocol other than `WMI` (such as `HTTP`, `PING`, `SNMP`, `SSH`, `IPMI`, `WBEM`, or `WinRM`), refer to the configuration examples provided in `C:\ProgramData\metricshub\config\metricshub.yaml`.
+If you wish to use a protocol other than `WMI` (such as `HTTP`, `PING`, `SNMP`, `SSH`, `IPMI`, `WBEM`, or `WinRM`), refer to the configuration examples provided in `C:\ProgramData\MetricsHub\config\metricshub.yaml`.
 
 ### Configure Prometheus to receive MetricsHub data
 
-In the same configuration file (`C:\ProgramData\metricshub\config\metricshub.yaml`), add the below configuration under the `otel` section to push metrics to Prometheus:
+In the same configuration file (`C:\ProgramData\MetricsHub\config\metricshub.yaml`), add the below configuration under the `otel` section to push metrics to Prometheus:
 
 ```yaml
 otel:
@@ -115,7 +115,7 @@ Several log files are created under `C:\Users\{Username}\AppData\Local\metricshu
 * a global `MetricsHub` log file
 * one log file per configured host. 
 
-You can configure the log level in the `C:\ProgramData\metricshub\config\metricshub.yaml` file by setting the `loggerLevel` parameter to:
+You can configure the log level in the `C:\ProgramData\MetricsHub\config\metricshub.yaml` file by setting the `loggerLevel` parameter to:
 
 * `info` for high level information
 * `warn` for logging warning messages that indicate potential issues which are not immediately critical


### PR DESCRIPTION
* Changed the MetricsHub's configuration & logging directory names to `MetricsHub` in PascalCase.
* Updated MetricsHub Documentation to replace `C:\ProgramData\metricshub` by `C:\ProgramData\MetricsHub`.
* Tested the changes.