### PR TITLE
Issue #333: Fix Improper Default Right Line Interpretation

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/SourceProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/SourceProcessor.java
@@ -27,7 +27,6 @@ import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubCons
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -355,14 +354,12 @@ public class SourceProcessor implements ISourceProcessor {
 			hostname
 		);
 
-		String defaultRightLine = tableJoinSource.getDefaultRightLine();
-
 		final List<List<String>> executeTableJoin = clientsExecutor.executeTableJoin(
 			leftTable.getTable(),
 			rightTable.getTable(),
 			tableJoinSource.getLeftKeyColumn(),
 			tableJoinSource.getRightKeyColumn(),
-			defaultRightLine != null ? Arrays.asList(defaultRightLine.split(";")) : null,
+			SourceTable.lineToList(tableJoinSource.getDefaultRightLine(), SEMICOLON),
 			"wbem".equalsIgnoreCase(tableJoinSource.getKeyType()),
 			true
 		);

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/compute/ComputeProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/compute/ComputeProcessor.java
@@ -869,10 +869,18 @@ public class ComputeProcessor implements IComputeProcessor {
 			return;
 		}
 
-		try {
-			final List<String> jsonToCsvProperties = new ArrayList<>(
-				Arrays.asList(json2csv.getProperties().split(SEMICOLON))
+		final String properties = json2csv.getProperties();
+		if (properties == null) {
+			log.warn(
+				"Hostname {} - Compute Operation (Json2CSV) properties are null, the table remains unchanged.",
+				hostname
 			);
+			return;
+		}
+
+		try {
+			final List<String> jsonToCsvProperties = SourceTable.lineToList(properties, SEMICOLON);
+
 			final String json2csvResult = clientsExecutor.executeJson2Csv(
 				sourceTable.getRawData(),
 				json2csv.getEntryKey(),

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/compute/ComputeProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/compute/ComputeProcessor.java
@@ -865,14 +865,14 @@ public class ComputeProcessor implements IComputeProcessor {
 	@WithSpan("Compute Json2Csv Exec")
 	public void process(@SpanAttribute("compute.definition") final Json2Csv json2csv) {
 		if (json2csv == null) {
-			log.warn("Hostname {} - Compute Operation (Json2CSV) is null, the table remains unchanged.", hostname);
+			log.warn("Hostname {} - Json2CSV compute is null. As a result, the table remains unchanged.", hostname);
 			return;
 		}
 
 		final String properties = json2csv.getProperties();
 		if (properties == null) {
 			log.warn(
-				"Hostname {} - Compute Operation (Json2CSV) properties are null, the table remains unchanged.",
+				"Hostname {} - Json2CSV processor encountered null properties. As a result, the table remains unchanged.",
 				hostname
 			);
 			return;

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/source/SourceProcessorTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/source/SourceProcessorTest.java
@@ -412,7 +412,7 @@ class SourceProcessorTest {
 		expectedResult = SourceTable.builder().table(expectedJoin).build();
 		doReturn(expectedJoin)
 			.when(clientsExecutorMock)
-			.executeTableJoin(tabl1.getTable(), tabl2.getTable(), 1, 1, null, false, true);
+			.executeTableJoin(tabl1.getTable(), tabl2.getTable(), 1, 1, new ArrayList<>(), false, true);
 		tableJoinExample =
 			TableJoinSource
 				.builder()
@@ -439,12 +439,11 @@ class SourceProcessorTest {
 			)
 			.build();
 		mapSources.put(TAB3_REF, tabl3);
-		connectorNamespace = ConnectorNamespace.builder().sourceTables(mapSources).build();
 		expectedJoin = Arrays.asList(Arrays.asList(LOWERCASE_A, LOWERCASE_B, LOWERCASE_C));
 		expectedResult = SourceTable.builder().table(expectedJoin).build();
 		doReturn(expectedJoin)
 			.when(clientsExecutorMock)
-			.executeTableJoin(tabl1.getTable(), tabl3.getTable(), 1, 1, null, false, true);
+			.executeTableJoin(tabl1.getTable(), tabl3.getTable(), 1, 1, new ArrayList<>(), false, true);
 		tableJoinExample =
 			TableJoinSource
 				.builder()
@@ -469,7 +468,6 @@ class SourceProcessorTest {
 				)
 				.build();
 		mapSources.put(TAB3_REF, tabl3);
-		connectorNamespace = ConnectorNamespace.builder().sourceTables(mapSources).build();
 		tableJoinExample =
 			TableJoinSource
 				.builder()


### PR DESCRIPTION
* SourceTable.lineToList is called now to correctly convert `TableJoin.defaultRightLine` and `Json2Csv.properties` to list of strings.