### PR TITLE
Issue #272: Replace all telemetryManager.getHostConfiguration().getHostname() occurrences 

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/client/ClientsExecutor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/client/ClientsExecutor.java
@@ -154,7 +154,7 @@ public class ClientsExecutor {
 			)
 		);
 
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		final Callable<String> jflatToCSV = () -> {
 			try {

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractAllAtOnceStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractAllAtOnceStrategy.java
@@ -388,7 +388,7 @@ public abstract class AbstractAllAtOnceStrategy extends AbstractStrategy {
 	 */
 	public void run() {
 		// Get the host name from telemetry manager
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		// Get the endpoint host monitor
 		final Monitor endpointHost = telemetryManager.getEndpointHostMonitor();

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java
@@ -518,7 +518,7 @@ public class CollectStrategy extends AbstractStrategy {
 	@Override
 	public void run() {
 		// Get the host name from telemetry manager
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		//Retrieve connector Monitor instances from TelemetryManager
 		final Map<String, Monitor> connectorMonitors = telemetryManager

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionProcessor.java
@@ -112,7 +112,7 @@ public class CriterionProcessor {
 		if (deviceTypeCriterion == null) {
 			log.error(
 				"Hostname {} - Malformed DeviceType criterion {}. Cannot process DeviceType criterion detection.",
-				telemetryManager.getHostConfiguration().getHostname(),
+				telemetryManager.getHostname(),
 				deviceTypeCriterion
 			);
 			return CriterionTestResult.empty();
@@ -198,7 +198,7 @@ public class CriterionProcessor {
 			.message(
 				String.format(
 					"Hostname %s - Failed to perform IPMI detection. %s is an unsupported OS for IPMI.",
-					telemetryManager.getHostConfiguration().getHostname(),
+					telemetryManager.getHostname(),
 					hostType.name()
 				)
 			)
@@ -225,7 +225,7 @@ public class CriterionProcessor {
 	 */
 	@WithSpan("Criterion Process Exec")
 	public CriterionTestResult process(@SpanAttribute("criterion.definition") ProcessCriterion processCriterion) {
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		if (processCriterion == null) {
 			log.error(

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/SourceProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/SourceProcessor.java
@@ -77,7 +77,7 @@ public class SourceProcessor implements ISourceProcessor {
 	@WithSpan("Source Copy Exec")
 	@Override
 	public SourceTable process(@SpanAttribute("source.definition") final CopySource copySource) {
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		if (copySource == null) {
 			log.error(
@@ -170,7 +170,7 @@ public class SourceProcessor implements ISourceProcessor {
 	@WithSpan("Source IPMI Exec")
 	@Override
 	public SourceTable process(@SpanAttribute("source.definition") final IpmiSource ipmiSource) {
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		if (ipmiSource == null) {
 			log.error("Hostname {} - IPMI Source cannot be null, the IPMI operation will return an empty result.", hostname);
@@ -218,7 +218,7 @@ public class SourceProcessor implements ISourceProcessor {
 	@WithSpan("Source Static Exec")
 	@Override
 	public SourceTable process(@SpanAttribute("source.definition") final StaticSource staticSource) {
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		if (staticSource == null) {
 			log.error(
@@ -277,7 +277,7 @@ public class SourceProcessor implements ISourceProcessor {
 	@WithSpan("Source TableJoin Exec")
 	@Override
 	public SourceTable process(@SpanAttribute("source.definition") final TableJoinSource tableJoinSource) {
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		if (tableJoinSource == null) {
 			log.error(
@@ -407,7 +407,7 @@ public class SourceProcessor implements ISourceProcessor {
 	@WithSpan("Source TableUnion Exec")
 	@Override
 	public SourceTable process(@SpanAttribute("source.definition") final TableUnionSource tableUnionSource) {
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		if (tableUnionSource == null) {
 			log.warn(

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/SourceUpdaterProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/SourceUpdaterProcessor.java
@@ -201,7 +201,7 @@ public class SourceUpdaterProcessor implements ISourceProcessor {
 			telemetryManager
 		);
 
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 		if (maybeSourceTable.isEmpty()) {
 			log.error(
 				"Hostname {} - Could not extract the foreign source table identified by {} and defined in original source {} to set the {} field.",
@@ -403,7 +403,7 @@ public class SourceUpdaterProcessor implements ISourceProcessor {
 			.get(sourceRefKey);
 
 		// Hostname used for the debug messages
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		if (sourceTable == null) {
 			log.error(
@@ -484,7 +484,7 @@ public class SourceUpdaterProcessor implements ISourceProcessor {
 			connectorId,
 			telemetryManager
 		);
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 		if (maybeSourceTable.isEmpty()) {
 			log.error(
 				"Hostname {} - The SourceTable referenced in the ExecuteForEachEntryOf field cannot be found : {}.",

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/utils/ForceSerializationHelper.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/utils/ForceSerializationHelper.java
@@ -70,7 +70,7 @@ public class ForceSerializationHelper {
 		@NonNull final T defaultValue
 	) {
 		final ReentrantLock forceSerializationLock = getForceSerializationLock(telemetryManager, connectorId);
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		final boolean isLockAcquired;
 		try {

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionProcessorTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionProcessorTest.java
@@ -377,7 +377,7 @@ class CriterionProcessorTest {
 		final ProcessCriterion processCriterion = new ProcessCriterion();
 		processCriterion.setCommandLine(PROCESS_CRITERION_COMMAND_LINE);
 
-		doReturn(HostConfiguration.builder().hostname(HOST_ID).build()).when(telemetryManagerMock).getHostConfiguration();
+		doReturn(HOST_ID).when(telemetryManagerMock).getHostname();
 		doReturn(HostProperties.builder().isLocalhost(true).build()).when(telemetryManagerMock).getHostProperties();
 
 		final IProtocolExtension protocolExtensionMock = spy(IProtocolExtension.class);
@@ -444,14 +444,6 @@ class CriterionProcessorTest {
 	void testProcessProcessProcessNull() {
 		final ProcessCriterion processCriterion = null;
 
-		final TelemetryManager telemetryManager = TelemetryManager
-			.builder()
-			.hostConfiguration(
-				HostConfiguration.builder().hostname(LOCALHOST).hostId(LOCALHOST).hostType(DeviceKind.LINUX).build()
-			)
-			.build();
-		doReturn(telemetryManager.getHostConfiguration()).when(telemetryManagerMock).getHostConfiguration();
-
 		assertEquals(CriterionTestResult.empty(), criterionProcessor.process(processCriterion));
 	}
 
@@ -459,14 +451,6 @@ class CriterionProcessorTest {
 	void testProcessProcessCommandLineEmpty() {
 		final ProcessCriterion processCriterion = new ProcessCriterion();
 		processCriterion.setCommandLine("");
-
-		final TelemetryManager telemetryManager = TelemetryManager
-			.builder()
-			.hostConfiguration(
-				HostConfiguration.builder().hostname(LOCALHOST).hostId(LOCALHOST).hostType(DeviceKind.LINUX).build()
-			)
-			.build();
-		doReturn(telemetryManager.getHostConfiguration()).when(telemetryManagerMock).getHostConfiguration();
 
 		final CriterionTestResult criterionTestResult = criterionProcessor.process(processCriterion);
 
@@ -487,7 +471,6 @@ class CriterionProcessorTest {
 				HostConfiguration.builder().hostname(LOCALHOST).hostId(LOCALHOST).hostType(DeviceKind.LINUX).build()
 			)
 			.build();
-		doReturn(telemetryManager.getHostConfiguration()).when(telemetryManagerMock).getHostConfiguration();
 		doReturn(telemetryManager.getHostProperties()).when(telemetryManagerMock).getHostProperties();
 
 		final CriterionTestResult criterionTestResult = criterionProcessor.process(processCriterion);
@@ -510,7 +493,6 @@ class CriterionProcessorTest {
 			)
 			.hostProperties(HostProperties.builder().isLocalhost(true).build())
 			.build();
-		doReturn(telemetryManager.getHostConfiguration()).when(telemetryManagerMock).getHostConfiguration();
 		doReturn(telemetryManager.getHostProperties()).when(telemetryManagerMock).getHostProperties();
 
 		try (final MockedStatic<LocalOsHandler> mockedLocalOSHandler = mockStatic(LocalOsHandler.class)) {
@@ -537,7 +519,7 @@ class CriterionProcessorTest {
 			)
 			.hostProperties(HostProperties.builder().isLocalhost(true).build())
 			.build();
-		doReturn(telemetryManager.getHostConfiguration()).when(telemetryManagerMock).getHostConfiguration();
+		doReturn(telemetryManager.getHostname()).when(telemetryManagerMock).getHostname();
 		doReturn(telemetryManager.getHostProperties()).when(telemetryManagerMock).getHostProperties();
 
 		try (
@@ -572,7 +554,7 @@ class CriterionProcessorTest {
 			)
 			.hostProperties(HostProperties.builder().isLocalhost(true).build())
 			.build();
-		doReturn(telemetryManager.getHostConfiguration()).when(telemetryManagerMock).getHostConfiguration();
+		doReturn(telemetryManager.getHostname()).when(telemetryManagerMock).getHostname();
 		doReturn(telemetryManager.getHostProperties()).when(telemetryManagerMock).getHostProperties();
 
 		try (
@@ -607,7 +589,7 @@ class CriterionProcessorTest {
 			)
 			.hostProperties(HostProperties.builder().isLocalhost(true).build())
 			.build();
-		doReturn(telemetryManager.getHostConfiguration()).when(telemetryManagerMock).getHostConfiguration();
+		doReturn(telemetryManager.getHostname()).when(telemetryManagerMock).getHostname();
 		doReturn(telemetryManager.getHostProperties()).when(telemetryManagerMock).getHostProperties();
 
 		try (final MockedStatic<LocalOsHandler> mockedLocalOSHandler = mockStatic(LocalOsHandler.class)) {

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/util/HwCollectHelper.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/util/HwCollectHelper.java
@@ -76,7 +76,7 @@ public class HwCollectHelper {
 		final String energyMetricName,
 		final Long collectTime
 	) {
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		final Double collectTimePrevious = CollectHelper.getNumberMetricCollectTime(monitor, powerMetricName, true);
 

--- a/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/CommandLineSourceProcessor.java
+++ b/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/CommandLineSourceProcessor.java
@@ -55,7 +55,7 @@ public class CommandLineSourceProcessor {
 		String connectorId,
 		TelemetryManager telemetryManager
 	) {
-		final String hostname = telemetryManager.getHostConfiguration().getHostname();
+		final String hostname = telemetryManager.getHostname();
 
 		if (
 			commandLineSource == null ||


### PR DESCRIPTION
- Update ClientsExecutor, AbstractAllAtOnceStrategy, CollectStrategy, CriterionProcessor, SourceProcessor, SourceUpdaterProcessor, ForceSerializationHelper, HwCollectHelper, CommandLineSourceProcessor and CriterionProcessorTest