### PR TITLE
Issue #350: Use MetricsHub Connector Maven Plugin `1.5.00`

### DIFF
--- a/metricshub-doc/pom.xml
+++ b/metricshub-doc/pom.xml
@@ -112,7 +112,7 @@
 			<plugin>
 				<groupId>org.sentrysoftware.maven</groupId>
 				<artifactId>metricshub-connector-maven-plugin</artifactId>
-				<version>1.0.03</version>
+				<version>1.0.05</version>
 				<configuration>
 					<sourceDirectory>${project.basedir}/../metricshub-agent/target/connectors</sourceDirectory>
 				</configuration>

--- a/metricshub-doc/src/site/resources/css/site.css
+++ b/metricshub-doc/src/site/resources/css/site.css
@@ -115,3 +115,9 @@ body.metricshub.dark code[class*=language-js] .token.punctuation {
 	background: var(--banner-bgcolor);
 	color: var(--banner-fgcolor);
 }
+
+.metricshub .metricshub-tag a {
+	color: white;
+	text-decoration: none;
+	font-size: small;
+}

--- a/metricshub-doc/src/site/site.xml
+++ b/metricshub-doc/src/site/site.xml
@@ -171,11 +171,7 @@
 		</menu>
 
 		<menu name="Appendix">
-			<item name="Connectors Directory" href="metricshub-connector-reference.html" />
-			<item name="Connector Platforms" href="platform-requirements.html" />
+			<item name="Connectors Directory" href="metricshub-connectors-directory.html" />
 		</menu>
-
-		<menu ref="reports" />
-
 	</body>
 </project>


### PR DESCRIPTION
* Upgraded MetricsHub Connector Maven Plugin to `1.5.00`.