### PR TITLE
Issue #352: Exclude non hardware items from power estimation

### DIFF
--- a/metricshub-hardware/src/it/resources/os/SuperConnectorOsIT/connectors/SuperConnectorOS/SuperConnectorOS.yaml
+++ b/metricshub-hardware/src/it/resources/os/SuperConnectorOsIT/connectors/SuperConnectorOS/SuperConnectorOS.yaml
@@ -26,6 +26,7 @@ connector:
       commandLine: echo Criteria testing
       expectedResult: Criteria
       errorMessage: Does not match the criteria
+    tags: [ hardware ]
 monitors:
   enclosure:
     discovery:

--- a/metricshub-hardware/src/it/resources/snmp/DellOpenManageIT/connectors/DellOpenManage/DellOpenManage.yaml
+++ b/metricshub-hardware/src/it/resources/snmp/DellOpenManageIT/connectors/DellOpenManage/DellOpenManage.yaml
@@ -23,6 +23,7 @@ connector:
     criteria:
     - type: snmpGetNext
       oid: 1.3.6.1.4.1.674.10892.1.300.10.1
+    tags: [ hardware ]
 monitors:
   enclosure:
     discovery:

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
@@ -21,6 +21,7 @@ package org.sentrysoftware.metricshub.hardware;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_CONNECTOR_ID;
 import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_ENERGY_CPU_METRIC;
 import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_ENERGY_DISK_CONTROLLER_METRIC;
 import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_ENERGY_FAN_METRIC;
@@ -42,6 +43,7 @@ import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_POWER_V
 import static org.sentrysoftware.metricshub.hardware.util.HwConstants.POWER_SOURCE_ID_ATTRIBUTE;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -50,6 +52,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sentrysoftware.metricshub.engine.common.helpers.KnownMonitorType;
+import org.sentrysoftware.metricshub.engine.connector.model.Connector;
+import org.sentrysoftware.metricshub.engine.connector.model.ConnectorStore;
+import org.sentrysoftware.metricshub.engine.connector.model.identity.ConnectorIdentity;
+import org.sentrysoftware.metricshub.engine.connector.model.identity.Detection;
 import org.sentrysoftware.metricshub.engine.delegate.IPostExecutionService;
 import org.sentrysoftware.metricshub.engine.strategy.utils.CollectHelper;
 import org.sentrysoftware.metricshub.engine.telemetry.MetricFactory;
@@ -111,6 +117,7 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 			.stream()
 			.filter(monitor -> !HwCollectHelper.isMissing(monitor))
 			.filter(monitor -> telemetryManager.isConnectorStatusOk(monitor))
+			.filter(monitor -> connectorHasHardwareTag(monitor, telemetryManager))
 			.forEach(monitor ->
 				PowerAndEnergyCollectHelper.collectPowerAndEnergy(
 					monitor,
@@ -146,6 +153,7 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 			.stream()
 			.filter(monitor -> !HwCollectHelper.isMissing(monitor))
 			.filter(monitor -> telemetryManager.isConnectorStatusOk(monitor))
+			.filter(monitor -> connectorHasHardwareTag(monitor, telemetryManager))
 			.forEach(monitor ->
 				PowerAndEnergyCollectHelper.collectPowerAndEnergy(
 					monitor,
@@ -339,12 +347,63 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 			}
 		}
 
-		PowerAndEnergyCollectHelper.collectPowerAndEnergy(
-			monitor,
-			HW_POWER_NETWORK_METRIC,
-			HW_ENERGY_NETWORK_METRIC,
-			telemetryManager,
-			new NetworkPowerAndEnergyEstimator(monitor, telemetryManager)
-		);
+		if (connectorHasHardwareTag(monitor, telemetryManager)) {
+			PowerAndEnergyCollectHelper.collectPowerAndEnergy(
+				monitor,
+				HW_POWER_NETWORK_METRIC,
+				HW_ENERGY_NETWORK_METRIC,
+				telemetryManager,
+				new NetworkPowerAndEnergyEstimator(monitor, telemetryManager)
+			);
+		}
+	}
+
+	/**
+	 * Checks if the connector associated with the provided monitor has a "hardware" tag.
+	 *
+	 * @param monitor the monitor containing the connector ID attribute
+	 * @param telemetryManager the telemetry manager containing the connector store
+	 * @return true if the connector has a "hardware" tag, false otherwise
+	 */
+	private boolean connectorHasHardwareTag(final Monitor monitor, final TelemetryManager telemetryManager) {
+		if (monitor == null) {
+			return false;
+		}
+		final ConnectorStore telemetryManagerConnectorStore = telemetryManager.getConnectorStore();
+		if (telemetryManagerConnectorStore == null) {
+			log.error("No connectorStore found. Stopping detection operation.");
+			return false;
+		}
+
+		final Map<String, Connector> connectorStore = telemetryManagerConnectorStore.getStore();
+
+		if (connectorStore == null) {
+			log.error("No connectorStore found. Stopping detection operation.");
+			return false;
+		}
+
+		final String connectorId = monitor.getAttribute(MONITOR_ATTRIBUTE_CONNECTOR_ID);
+
+		if (connectorId == null) {
+			return false;
+		}
+
+		log.warn("CONNECTOR_ID= #" + connectorId);
+
+		final Connector connector = connectorStore.get(connectorId);
+
+		if (connector == null) {
+			log.warn("CONNECTOR is NULL");
+
+			return false;
+		}
+
+		final ConnectorIdentity connectorIdentity = connector.getConnectorIdentity();
+		log.warn("CONNECTOR_IDEN= #" + connectorIdentity);
+		final Detection detection = (connectorIdentity != null) ? connectorIdentity.getDetection() : null;
+		log.warn("CONNECTOR_DET= #" + connectorIdentity);
+		final Set<String> connectorTags = (detection != null) ? detection.getTags() : null;
+		log.warn("CONNECTOR_tags #" + connectorTags.toString());
+		return connectorTags != null && connectorTags.stream().anyMatch(tag -> tag.equalsIgnoreCase("hardware"));
 	}
 }

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
@@ -372,17 +372,17 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 		final ConnectorStore telemetryManagerConnectorStore = telemetryManager.getConnectorStore();
 		if (telemetryManagerConnectorStore == null) {
 			log.error(
-				"Hardware Energy and Sustainability Module: Host {} has no connectorStore found.",
+				"Hardware Energy and Sustainability Module: Host {} connectorStore does not exist.",
 				telemetryManager.getHostname()
 			);
 			return false;
 		}
 
-		final Map<String, Connector> connectorStore = telemetryManagerConnectorStore.getStore();
+		final Map<String, Connector> store = telemetryManagerConnectorStore.getStore();
 
-		if (connectorStore == null) {
+		if (store == null) {
 			log.error(
-				"Hardware Energy and Sustainability Module: Host {} has no connectorStore found.",
+				"Hardware Energy and Sustainability Module: Host {} connectorStore store does not exist.",
 				telemetryManager.getHostname()
 			);
 			return false;
@@ -399,7 +399,7 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 			return false;
 		}
 
-		final Connector connector = connectorStore.get(connectorId);
+		final Connector connector = store.get(connectorId);
 
 		if (connector == null) {
 			log.error(

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
@@ -371,39 +371,48 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 		}
 		final ConnectorStore telemetryManagerConnectorStore = telemetryManager.getConnectorStore();
 		if (telemetryManagerConnectorStore == null) {
-			log.error("No connectorStore found. Stopping detection operation.");
+			log.error(
+				"Hardware Energy and Sustainability Module: Host {} has no connectorStore found.",
+				telemetryManager.getHostname()
+			);
 			return false;
 		}
 
 		final Map<String, Connector> connectorStore = telemetryManagerConnectorStore.getStore();
 
 		if (connectorStore == null) {
-			log.error("No connectorStore found. Stopping detection operation.");
+			log.error(
+				"Hardware Energy and Sustainability Module: Host {} has no connectorStore found.",
+				telemetryManager.getHostname()
+			);
 			return false;
 		}
 
 		final String connectorId = monitor.getAttribute(MONITOR_ATTRIBUTE_CONNECTOR_ID);
 
 		if (connectorId == null) {
+			log.error(
+				"Hardware Energy and Sustainability Module: Host {}. Monitor {} connector_id attribute does not exist.",
+				telemetryManager.getHostname(),
+				monitor.getId()
+			);
 			return false;
 		}
-
-		log.warn("CONNECTOR_ID= #" + connectorId);
 
 		final Connector connector = connectorStore.get(connectorId);
 
 		if (connector == null) {
-			log.warn("CONNECTOR is NULL");
-
+			log.error(
+				"Hardware Energy and Sustainability Module: Host {}. Monitor {} connector_id attribute does not correspond to any valid connector id.",
+				telemetryManager.getHostname(),
+				monitor.getId()
+			);
 			return false;
 		}
 
 		final ConnectorIdentity connectorIdentity = connector.getConnectorIdentity();
-		log.warn("CONNECTOR_IDEN= #" + connectorIdentity);
 		final Detection detection = (connectorIdentity != null) ? connectorIdentity.getDetection() : null;
-		log.warn("CONNECTOR_DET= #" + connectorIdentity);
 		final Set<String> connectorTags = (detection != null) ? detection.getTags() : null;
-		log.warn("CONNECTOR_tags #" + connectorTags.toString());
 		return connectorTags != null && connectorTags.stream().anyMatch(tag -> tag.equalsIgnoreCase("hardware"));
 	}
 }

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
@@ -372,7 +372,7 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 		final ConnectorStore telemetryManagerConnectorStore = telemetryManager.getConnectorStore();
 		if (telemetryManagerConnectorStore == null) {
 			log.error(
-				"Hardware Energy and Sustainability Module: Host {} connectorStore does not exist.",
+				"Hostname {} - ConnectorStore does not exist.",
 				telemetryManager.getHostname()
 			);
 			return false;
@@ -382,7 +382,7 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 
 		if (store == null) {
 			log.error(
-				"Hardware Energy and Sustainability Module: Host {} connectorStore store does not exist.",
+				"Hostname {} - ConnectorStore store does not exist.",
 				telemetryManager.getHostname()
 			);
 			return false;
@@ -392,7 +392,7 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 
 		if (connectorId == null) {
 			log.error(
-				"Hardware Energy and Sustainability Module: Host {}. Monitor {} connector_id attribute does not exist.",
+				"Hostname {} - Monitor {} connector_id attribute does not exist.",
 				telemetryManager.getHostname(),
 				monitor.getId()
 			);
@@ -403,7 +403,7 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 
 		if (connector == null) {
 			log.error(
-				"Hardware Energy and Sustainability Module: Host {}. Monitor {} connector_id attribute does not correspond to any valid connector id.",
+				"Hostname {} - Monitor {} connector_id attribute does not correspond to any valid connector id.",
 				telemetryManager.getHostname(),
 				monitor.getId()
 			);
@@ -411,8 +411,8 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 		}
 
 		final ConnectorIdentity connectorIdentity = connector.getConnectorIdentity();
-		final Detection detection = (connectorIdentity != null) ? connectorIdentity.getDetection() : null;
-		final Set<String> connectorTags = (detection != null) ? detection.getTags() : null;
+		final Detection detection = connectorIdentity != null ? connectorIdentity.getDetection() : null;
+		final Set<String> connectorTags = detection != null ? detection.getTags() : null;
 		return connectorTags != null && connectorTags.stream().anyMatch(tag -> tag.equalsIgnoreCase("hardware"));
 	}
 }

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
@@ -371,20 +371,14 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 		}
 		final ConnectorStore telemetryManagerConnectorStore = telemetryManager.getConnectorStore();
 		if (telemetryManagerConnectorStore == null) {
-			log.error(
-				"Hostname {} - ConnectorStore does not exist.",
-				telemetryManager.getHostname()
-			);
+			log.error("Hostname {} - ConnectorStore does not exist.", telemetryManager.getHostname());
 			return false;
 		}
 
 		final Map<String, Connector> store = telemetryManagerConnectorStore.getStore();
 
 		if (store == null) {
-			log.error(
-				"Hostname {} - ConnectorStore store does not exist.",
-				telemetryManager.getHostname()
-			);
+			log.error("Hostname {} - ConnectorStore store does not exist.", telemetryManager.getHostname());
 			return false;
 		}
 

--- a/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionServiceTest.java
+++ b/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionServiceTest.java
@@ -1,71 +1,21 @@
 package org.sentrysoftware.metricshub.hardware;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_CONNECTOR_ID;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.CPU_POWER_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.DISK_CONTROLLER_ENERGY_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.DISK_CONTROLLER_POWER_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.FAN_ENERGY_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.FAN_POWER_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.FAN_SPEED_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.HOST_1;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.HW_CONNECTOR;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.HW_CPU_POWER;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.HW_HOST_AMBIENT_TEMPERATURE;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.HW_HOST_AVERAGE_CPU_TEMPERATURE;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.HW_MEMORY_POWER;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.HW_PHYSICAL_DISK_POWER;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.LOCALHOST;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.MEMORY_ENERGY_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.MEMORY_POWER_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.NETWORK_ENERGY_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.NETWORK_LINK_SPEED_ATTRIBUTE;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.NETWORK_LINK_STATUS_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.NETWORK_POWER_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.NETWORK_TRANSMITTED_BANDWIDTH_UTILIZATION_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.ON;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.PHYSICAL_DISK_ENERGY_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.PHYSICAL_DISK_POWER_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.ROBOTICS_ENERGY_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.ROBOTICS_MOVE_COUNT_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.ROBOTICS_POWER_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.TAPE_DRIVE_ENERGY_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.TAPE_DRIVE_MOUNT_COUNT_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.TAPE_DRIVE_POWER_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.TAPE_DRIVE_UNMOUNT_COUNT_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.TEMPERATURE_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.VM_1_ONLINE;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.VM_OFFLINE_2;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.VM_ONLINE_3;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.VM_ONLINE_BAD_POWER_SHARE_5;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.VM_ONLINE_NO_POWER_SHARE_4;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_CPU_SPEED_LIMIT_LIMIT_TYPE_MAX;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_ENERGY_CPU_METRIC;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_ENERGY_VM_METRIC;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_HOST_CPU_THERMAL_DISSIPATION_RATE;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_HOST_ESTIMATED_ENERGY;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_HOST_ESTIMATED_POWER;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_POWER_CPU_METRIC;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_POWER_VM_METRIC;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_VM_POWER_SHARE_METRIC;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_VM_POWER_STATE_METRIC;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.POWER_SOURCE_ID_ATTRIBUTE;
-import static org.sentrysoftware.metricshub.hardware.util.HwConstants.PRESENT_STATUS;
+import static org.sentrysoftware.metricshub.hardware.common.Constants.*;
+import static org.sentrysoftware.metricshub.hardware.util.HwConstants.*;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.helpers.KnownMonitorType;
 import org.sentrysoftware.metricshub.engine.configuration.HostConfiguration;
+import org.sentrysoftware.metricshub.engine.connector.model.ConnectorStore;
 import org.sentrysoftware.metricshub.engine.strategy.utils.CollectHelper;
-import org.sentrysoftware.metricshub.engine.telemetry.ConnectorNamespace;
-import org.sentrysoftware.metricshub.engine.telemetry.HostProperties;
-import org.sentrysoftware.metricshub.engine.telemetry.MetricFactory;
-import org.sentrysoftware.metricshub.engine.telemetry.Monitor;
-import org.sentrysoftware.metricshub.engine.telemetry.TelemetryManager;
+import org.sentrysoftware.metricshub.engine.telemetry.*;
 import org.sentrysoftware.metricshub.engine.telemetry.metric.NumberMetric;
 import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
 
@@ -73,6 +23,7 @@ class HardwareEnergyPostExecutionServiceTest {
 
 	private static final Long STRATEGY_TIME = 1696597422644L;
 	private static final Long NEXT_STRATEGY_TIME = STRATEGY_TIME + 2 * 60 * 1000;
+	private static final String TEST_CONNECTOR = "TestConnector";
 
 	private HardwareEnergyPostExecutionService hardwareEnergyPostExecutionService;
 
@@ -90,18 +41,22 @@ class HardwareEnergyPostExecutionServiceTest {
 
 	@BeforeEach
 	void init() {
+		final Path yamlTestPath = Paths.get("src", "test", "resources", "strategy", "collect");
+
+		final ConnectorStore connectorStore = new ConnectorStore(yamlTestPath);
 		telemetryManager =
 			TelemetryManager
 				.builder()
 				.hostConfiguration(HostConfiguration.builder().hostname(LOCALHOST).build())
 				.strategyTime(STRATEGY_TIME)
+				.connectorStore(connectorStore)
 				.build();
 
 		// Set the status ok in the host properties
 		final ConnectorNamespace connectorNamespace = ConnectorNamespace.builder().isStatusOk(true).build();
 		final HostProperties hostProperties = HostProperties
 			.builder()
-			.connectorNamespaces(new HashMap<>(Map.of(HW_CONNECTOR, connectorNamespace)))
+			.connectorNamespaces(new HashMap<>(Map.of("TestConnector", connectorNamespace)))
 			.build();
 		telemetryManager.setHostProperties(hostProperties);
 	}
@@ -113,7 +68,7 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.type(FAN)
 			.metrics(new HashMap<>(Map.of(FAN_SPEED_METRIC, NumberMetric.builder().value(0.7).build())))
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		// Set the previously created fan monitor in telemetryManager
@@ -147,7 +102,7 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.type(FAN)
 			.metrics(new HashMap<>(Map.of(FAN_SPEED_METRIC, NumberMetric.builder().value(0.7).build())))
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, TEST_CONNECTOR)))
 			.build();
 
 		// Set Fan monitor as missing
@@ -182,7 +137,7 @@ class HardwareEnergyPostExecutionServiceTest {
 		final Monitor roboticsMonitor = Monitor
 			.builder()
 			.type(ROBOTICS)
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.metrics(new HashMap<>(Map.of(ROBOTICS_MOVE_COUNT_METRIC, NumberMetric.builder().value(0.7).build())))
 			.build();
 
@@ -226,7 +181,7 @@ class HardwareEnergyPostExecutionServiceTest {
 					)
 				)
 			)
-			.attributes(new HashMap<>(Map.of("name", "lto123", MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of("name", "lto123", MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		// Set the previously created tape drive monitor in telemetryManager
@@ -258,7 +213,7 @@ class HardwareEnergyPostExecutionServiceTest {
 		// Create a disk controller monitor
 		final Monitor diskControllerMonitor = Monitor
 			.builder()
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.type(DISK_CONTROLLER)
 			.build();
 
@@ -292,7 +247,7 @@ class HardwareEnergyPostExecutionServiceTest {
 		final Monitor memoryMonitor = Monitor
 			.builder()
 			.type(MEMORY)
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		// Set the previously created monitor in telemetryManager
@@ -325,7 +280,7 @@ class HardwareEnergyPostExecutionServiceTest {
 		final Monitor physicalDiskMonitor = Monitor
 			.builder()
 			.type(PHYSICAL_DISK)
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		// Set the previously created physical disk monitor in telemetryManager
@@ -366,7 +321,7 @@ class HardwareEnergyPostExecutionServiceTest {
 						NETWORK_LINK_SPEED_ATTRIBUTE,
 						"100.0",
 						MONITOR_ATTRIBUTE_CONNECTOR_ID,
-						HW_CONNECTOR
+						"TestConnector"
 					)
 				)
 			)
@@ -440,7 +395,7 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.id(KnownMonitorType.HOST.getKey())
 			.type(KnownMonitorType.HOST.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 		host.setAsEndpoint();
 
@@ -458,14 +413,14 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.id(KnownMonitorType.ENCLOSURE.getKey())
 			.type(KnownMonitorType.ENCLOSURE.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		final Monitor cpu = Monitor
 			.builder()
 			.id("cpu1")
 			.type(KnownMonitorType.CPU.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 		metricFactory.collectNumberMetric(cpu, HW_CPU_POWER, 60.0, telemetryManager.getStrategyTime());
 		metricFactory.collectNumberMetric(
@@ -479,7 +434,7 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.id("memory1")
 			.type(KnownMonitorType.MEMORY.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 		metricFactory.collectNumberMetric(
 			memory,
@@ -494,7 +449,7 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.id("disk_nvm_1")
 			.type(KnownMonitorType.PHYSICAL_DISK.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		metricFactory.collectNumberMetric(disk, HW_PHYSICAL_DISK_POWER, 6.0, telemetryManager.getStrategyTime());
@@ -503,14 +458,14 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.id("disk_noPower")
 			.type(KnownMonitorType.PHYSICAL_DISK.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		final Monitor missingDisk = Monitor
 			.builder()
 			.id("disk_nvm_2")
 			.type(KnownMonitorType.PHYSICAL_DISK.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		// Add the previously created monitors to telemetry manager
@@ -558,7 +513,7 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.id(KnownMonitorType.HOST.getKey())
 			.type(KnownMonitorType.HOST.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 		host.setAsEndpoint();
 
@@ -576,14 +531,14 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.id(KnownMonitorType.ENCLOSURE.getKey())
 			.type(KnownMonitorType.ENCLOSURE.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		final Monitor cpu = Monitor
 			.builder()
 			.id("cpu1")
 			.type(KnownMonitorType.CPU.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 		metricFactory.collectNumberMetric(cpu, HW_CPU_POWER, 60.0, telemetryManager.getStrategyTime());
 
@@ -591,7 +546,7 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.id("memory1")
 			.type(KnownMonitorType.MEMORY.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		metricFactory.collectNumberMetric(memory, HW_MEMORY_POWER, 4.0, telemetryManager.getStrategyTime());
@@ -600,7 +555,7 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.id("disk_nvm_1")
 			.type(KnownMonitorType.PHYSICAL_DISK.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		metricFactory.collectNumberMetric(disk, HW_PHYSICAL_DISK_POWER, 6.0, telemetryManager.getStrategyTime());
@@ -609,14 +564,14 @@ class HardwareEnergyPostExecutionServiceTest {
 			.builder()
 			.id("disk_noPower")
 			.type(KnownMonitorType.PHYSICAL_DISK.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		final Monitor missingDisk = Monitor
 			.builder()
 			.id("disk_nvm_2")
 			.type(KnownMonitorType.PHYSICAL_DISK.getKey())
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.build();
 
 		// Add the previously created monitors to telemetry manager
@@ -643,7 +598,7 @@ class HardwareEnergyPostExecutionServiceTest {
 		return Monitor
 			.builder()
 			.id(id)
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "TestConnector")))
 			.type(monitorType)
 			.build();
 	}
@@ -930,5 +885,32 @@ class HardwareEnergyPostExecutionServiceTest {
 		// Check the collected CPU power and energy metrics
 		assertEquals(19.0, cpuMonitor.getMetric(HW_POWER_CPU_METRIC, NumberMetric.class).getValue());
 		assertEquals(2280.0, cpuMonitor.getMetric(HW_ENERGY_CPU_METRIC, NumberMetric.class).getValue());
+	}
+
+	@Test
+	void testRunWithNonHardwareConnector() {
+		final Path yamlTestPath = Paths.get("src", "test", "resources", "Linux");
+
+		final ConnectorStore connectorStore = new ConnectorStore(yamlTestPath);
+		telemetryManager.setConnectorStore(connectorStore);
+
+		// Create a physical disk monitor
+		final Monitor physicalDiskMonitor = Monitor
+			.builder()
+			.type(PHYSICAL_DISK)
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, "Linux")))
+			.build();
+
+		// Set the previously created physical disk monitor in telemetryManager
+		final Map<String, Monitor> physicalDiskMonitors = new HashMap<>(Map.of("monitor5", physicalDiskMonitor));
+		telemetryManager.setMonitors(new HashMap<>(Map.of(PHYSICAL_DISK, physicalDiskMonitors)));
+
+		// Call run method in HardwareEnergyPostExecutionService
+		hardwareEnergyPostExecutionService = new HardwareEnergyPostExecutionService(telemetryManager);
+		hardwareEnergyPostExecutionService.run();
+
+		// Check the computed and collected power metric
+		final NumberMetric power = physicalDiskMonitor.getMetric(PHYSICAL_DISK_POWER_METRIC, NumberMetric.class);
+		assertNull(power);
 	}
 }

--- a/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionServiceTest.java
+++ b/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionServiceTest.java
@@ -42,7 +42,6 @@ class HardwareEnergyPostExecutionServiceTest {
 	@BeforeEach
 	void init() {
 		final Path yamlTestPath = Paths.get("src", "test", "resources", "strategy", "collect");
-
 		final ConnectorStore connectorStore = new ConnectorStore(yamlTestPath);
 		telemetryManager =
 			TelemetryManager

--- a/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/strategy/HardwareStrategyTest.java
+++ b/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/strategy/HardwareStrategyTest.java
@@ -8,15 +8,17 @@ import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubCons
 import static org.sentrysoftware.metricshub.hardware.common.Constants.FAN_ENERGY_METRIC;
 import static org.sentrysoftware.metricshub.hardware.common.Constants.FAN_POWER_METRIC;
 import static org.sentrysoftware.metricshub.hardware.common.Constants.FAN_SPEED_METRIC;
-import static org.sentrysoftware.metricshub.hardware.common.Constants.HW_CONNECTOR;
 import static org.sentrysoftware.metricshub.hardware.common.Constants.LOCALHOST;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.helpers.KnownMonitorType;
 import org.sentrysoftware.metricshub.engine.configuration.HostConfiguration;
+import org.sentrysoftware.metricshub.engine.connector.model.ConnectorStore;
 import org.sentrysoftware.metricshub.engine.strategy.IStrategy;
 import org.sentrysoftware.metricshub.engine.telemetry.ConnectorNamespace;
 import org.sentrysoftware.metricshub.engine.telemetry.HostProperties;
@@ -32,19 +34,28 @@ class HardwareStrategyTest {
 	private static final String FAN = KnownMonitorType.FAN.getKey();
 	private static final String HOST = KnownMonitorType.HOST.getKey();
 	private static final String CONNECTOR = KnownMonitorType.CONNECTOR.getKey();
+	private static final String TEST_CONNECTOR = "TestConnector";
 
 	private TelemetryManager telemetryManager;
 
 	@BeforeEach
 	void init() {
+		final Path yamlTestPath = Paths.get("src", "test", "resources", "strategy", "collect");
+
+		final ConnectorStore connectorStore = new ConnectorStore(yamlTestPath);
 		telemetryManager =
-			TelemetryManager.builder().hostConfiguration(HostConfiguration.builder().hostname(LOCALHOST).build()).build();
+			TelemetryManager
+				.builder()
+				.hostConfiguration(HostConfiguration.builder().hostname(LOCALHOST).build())
+				.strategyTime(STRATEGY_TIME)
+				.connectorStore(connectorStore)
+				.build();
 
 		// Set the status ok in the host properties
 		final ConnectorNamespace connectorNamespace = ConnectorNamespace.builder().isStatusOk(true).build();
 		final HostProperties hostProperties = HostProperties
 			.builder()
-			.connectorNamespaces(new HashMap<>(Map.of(HW_CONNECTOR, connectorNamespace)))
+			.connectorNamespaces(new HashMap<>(Map.of(TEST_CONNECTOR, connectorNamespace)))
 			.build();
 		telemetryManager.setHostProperties(hostProperties);
 	}
@@ -56,7 +67,7 @@ class HardwareStrategyTest {
 			.builder()
 			.type(FAN)
 			.metrics(new HashMap<>(Map.of(FAN_SPEED_METRIC, NumberMetric.builder().value(0.7).build())))
-			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, HW_CONNECTOR)))
+			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_CONNECTOR_ID, TEST_CONNECTOR)))
 			.build();
 
 		// Set the previously created fan monitor in telemetryManager

--- a/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/strategy/HardwareStrategyTest.java
+++ b/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/strategy/HardwareStrategyTest.java
@@ -41,7 +41,6 @@ class HardwareStrategyTest {
 	@BeforeEach
 	void init() {
 		final Path yamlTestPath = Paths.get("src", "test", "resources", "strategy", "collect");
-
 		final ConnectorStore connectorStore = new ConnectorStore(yamlTestPath);
 		telemetryManager =
 			TelemetryManager

--- a/metricshub-hardware/src/test/resources/Linux/Linux.yaml
+++ b/metricshub-hardware/src/test/resources/Linux/Linux.yaml
@@ -1,0 +1,255 @@
+extends:
+- ../System/System
+metrics:
+  system.service.status:
+    description: Service Status
+    type:
+      stateSet:
+        - running
+        - dead
+        - exited
+connector:
+  displayName: LinuxOS
+  platform: Any platform with LinuxOS
+  reliesOn: Linux OsCommands
+  information: Gives OS specific information and metrics
+  detection:
+    connectionTypes:
+    - remote
+    - local
+    appliesTo:
+    - linux
+    criteria:
+    - type: commandLine
+      commandLine: /usr/bin/uname -o || /bin/uname -o
+      expectedResult: GNU/Linux
+      errorMessage: Not a valid Linux host.
+    tags: [ system ]
+monitors:
+  cpu:
+    simple:
+      type: multiInstance
+      sources:
+        cpuInfo:
+          # cpuId;user;nice;system;idle;iowait
+          type: commandLine
+          commandLine: cat /proc/stat
+          computes:
+          - type: awk
+            script: |
+              /cpu[0-9]/ {
+                sub("cpu","");
+                print $1 ";" $2 / 100 ";" $3 / 100 ";" $4 / 100 ";" $5 / 100 ";" $6 / 100
+              }
+      mapping:
+        source: ${source::cpuInfo}
+        attributes:
+          id: $1
+          name: ${awk::sprintf("%s %s", "cpu", $1)}
+          system.cpu.logical_number: $1
+        metrics:
+          system.cpu.utilization{system.cpu.state="user"}: rate($2)
+          system.cpu.utilization{system.cpu.state="nice"}: rate($3)
+          system.cpu.utilization{system.cpu.state="system"}: rate($4)
+          system.cpu.utilization{system.cpu.state="idle"}: rate($5)
+          system.cpu.utilization{system.cpu.state="io_wait"}: rate($6)
+          system.cpu.time{system.cpu.state="user"}: $2
+          system.cpu.time{system.cpu.state="nice"}: $3
+          system.cpu.time{system.cpu.state="system"}: $4
+          system.cpu.time{system.cpu.state="idle"}: $5
+          system.cpu.time{system.cpu.state="io_wait"}: $6
+  process:
+    simple:
+      sources:
+        procrb:
+          type: commandLine  
+          commandLine: (cat /proc/stat)
+          computes:
+          - type: awk
+            script: |
+             /procs_/ {s = s ";" $2}
+             END {print s}
+      mapping:
+        source: ${source::procrb}
+        attributes:
+          id: $1
+          name: $2
+        metrics:
+          system.cpu.process{system.cpu.process="running"}: $2
+          system.cpu.process{system.cpu.process="blocked"}: $3           
+  memory:
+    simple:
+      sources:
+        memorySys:
+          # memSystem
+          type: commandLine  
+          commandLine: /usr/bin/lsmem -b || /usr/bin/free -b
+          computes:
+          - type: awk
+            script: |
+              /^Mem:/ { print $2 }
+              /^Total online memory:/ { print $4 }
+        memoryInfo:
+          # memTotal;memFree;memUsed;memBuffers;memCached;memFreeUtilization;memUsedUtilization;memBuffersUtilization;memCachedUtilization
+          type: commandLine
+          commandLine: cat /proc/meminfo
+          computes:
+          - type: awk
+            script: ${file::memory.awk}
+          - type: prepend
+            column: 1
+            value: ;
+          - type: append
+            column: 1
+            value: ${source::memorySys}
+      mapping:
+        source: ${source::memoryInfo}
+        attributes:
+          id: memory_usage
+        metrics:
+          system.memory.limit: $1
+          system.memory.usage{system.memory.state="free"}: $3
+          system.memory.usage{system.memory.state="used"}: $4
+          system.memory.usage{system.memory.state="buffers"}: $5
+          system.memory.usage{system.memory.state="cached"}: $6
+          system.memory.utilization{system.memory.state="free"}: $7
+          system.memory.utilization{system.memory.state="used"}: $8
+          system.memory.utilization{system.memory.state="buffers"}: $9
+          system.memory.utilization{system.memory.state="cached"}: $10    
+  network:
+    simple:
+      sources:
+        networkInformation:
+          # Interface;MTU;State;RX_bytes;RX_packets;RX_errors;RX_dropped;RX_missed;RX_mcast;TX_bytes;TX_packets;TX_errors;TX_dropped;TX_carrier;TX_collsns";
+          type: commandLine
+          commandLine: /usr/sbin/ip -s link
+          computes:
+          - type: awk
+            script: ${file::network.awk}
+      mapping:
+        source: ${source::networkInformation}
+        attributes:
+          id: $1
+        metrics:
+          system.network.dropped{network.io.direction="transmit"}: $13
+          system.network.dropped{network.io.direction="receive"}: $7
+          system.network.packets{network.io.direction="transmit"}: $11
+          system.network.packets{network.io.direction="receive"}: $5
+          system.network.errors{network.io.direction="transmit"}: $12
+          system.network.errors{network.io.direction="receive"}: $6
+          system.network.io{network.io.direction="transmit"}: $10
+          system.network.io{network.io.direction="receive"}: $4
+  physical_disk:
+    simple:
+      type: multiInstance
+      sources:
+        physicalDiskInformation:
+          # id;reads;readsMerged;readTime;writes;writesMerged;writeTime;ioTime
+          type: commandLine
+          commandLine: cat /proc/diskstats
+          selectColumns: 3,4,5,7,8,9,11,13
+          computes:
+          - type: divide
+            column: 2
+            value: 1000
+          - type: divide
+            column: 5
+            value: 1000
+          - type: divide
+            column: 8
+            value: 1000
+      mapping:
+        source: ${source::physicalDiskInformation}
+        attributes:
+          id: $1
+          system.disk.device: $1
+        metrics:
+          system.disk.operations{direction:read}: $2
+          system.disk.merged{direction:read}: $3
+          system.disk.operation_time{direction:read}: $4
+          system.disk.operations{direction:write}: $5
+          system.disk.merged{direction:write}: $6
+          system.disk.operation_time{direction:write}: $7
+          system.disk.io_time: $8
+  service:
+    simple:
+      type: multiInstance
+      sources:
+        serviceInfo:
+          # serviceName;load;active;sub;description
+          type: commandLine
+          commandLine: /usr/bin/systemctl list-units --type=service --all | sed 's/^[^a-zA-Z0-9]*//'
+          computes:
+          - type: awk
+            script: |
+              /\.service/ {
+                sub("\.service", "");
+                printf($1 ";" $2 ";" $3 ";" $4 ";")
+                for (i=5; i<=NF; i++) {
+                  printf("%s ", $i)
+                }
+                printf("\n")
+              }
+          - type: translate
+            column: 2
+            translationTable: ${translation::serviceLoadedTranslationTable}
+          - type: translate
+            column: 3
+            translationTable: ${translation::serviceActiveTranslationTable}
+      mapping:
+        source: ${source::serviceInfo}
+        attributes:
+          id: $1
+          description: $5
+        metrics:
+          system.service.status{state="loaded"}: $2
+          system.service.status{state="active"}: $3
+          system.service.status: $4
+  file_system:
+    simple:
+      type: multiInstance
+      sources:
+        fileSystemInfo:
+          # filesystem;mountpoint;type;used;available
+          type: commandLine
+          commandLine: /usr/bin/df -B1 --output=source,target,fstype,used,avail,size
+          computes:
+          - type: awk
+            script: NR > 1 {print $1 "(" $2 ")" ";" $2 ";" $3 ";" $4 ";" $5 ";" $4 / $6 ";" $5 / $6}
+      mapping:
+        source: ${source::fileSystemInfo}
+        attributes:
+          id: $1
+          system.filesystem.device: $1
+          system.filesystem.mountpoint: $2
+          system.filesystem.type: $3
+        metrics:
+          system.filesystem.usage{system.filesystem.state=used}: $4
+          system.filesystem.usage{system.filesystem.state=free}: $5
+          system.filesystem.utilization{system.filesystem.state=used}: $6
+          system.filesystem.utilization{system.filesystem.state=free}: $7
+  system:
+    simple:
+      sources:
+        # Distribution;Version;Kernel
+        osInformation:
+          type: commandLine
+          commandLine: |
+            . /etc/os-release
+            echo "$NAME;$VERSION;`uname -r`;`cut -d. -f1 /proc/uptime`"
+      mapping:
+        source: ${source::osInformation}
+        attributes:
+          id: $3
+          name: $1
+          version: $2
+          os_version: $3
+        metrics:
+          system.uptime: $4
+translations:
+  serviceLoadedTranslationTable:
+    not-found: "0"
+    loaded: "1"
+  serviceActiveTranslationTable:
+    inactive: "0"
+    active: "1"

--- a/metricshub-hardware/src/test/resources/Linux/memory.awk
+++ b/metricshub-hardware/src/test/resources/Linux/memory.awk
@@ -1,0 +1,24 @@
+/MemTotal/ {
+    memTotal = $2 * 1024
+}
+
+/MemFree/ {
+    memFree = $2 * 1024
+    memFreeUtilization = memFree / memTotal
+}
+
+/Buffers/ {
+    memBuffers = $2 * 1024
+    memBuffersUtilization = memBuffers / memTotal
+}
+
+/^Cached/ {
+    memCached = $2 * 1024
+    memCachedUtilization = memCached / memTotal
+    memUsed = memTotal - memCached - memFree
+    memUsedUtilization = memUsed / memTotal
+}
+
+END {
+    printf("%s;%s;%s;%s;%s;%s;%s;%s;%s\n", memTotal, memFree, memUsed, memBuffers, memCached, memFreeUtilization, memUsedUtilization, memBuffersUtilization, memCachedUtilization)
+}

--- a/metricshub-hardware/src/test/resources/Linux/network.awk
+++ b/metricshub-hardware/src/test/resources/Linux/network.awk
@@ -1,0 +1,45 @@
+BEGIN {
+	OFS = ";"
+}
+
+/mtu/ {
+	mtu = $5
+}
+
+/state/ {
+	state = $9
+}
+
+/RX:/ {
+	getline
+	rx_bytes = $1
+	rx_packets = $2
+	rx_errors = $3
+	rx_dropped = $4
+	rx_missed = $5
+	rx_mcast = $6
+}
+
+/TX:/ {
+	getline
+	tx_bytes = $1
+	tx_packets = $2
+	tx_errors = $3
+	tx_dropped = $4
+	tx_carrier = $5
+	tx_collsns = $6
+}
+
+/^[0-9]+:/ {
+	if (NR > 1) {
+		print iface, mtu, state, rx_bytes, rx_packets, rx_errors, rx_dropped, rx_missed, rx_mcast, tx_bytes, tx_packets, tx_errors, tx_dropped, tx_carrier, tx_collsns
+	}
+	split($2, a, ":")
+	iface = a[1]
+	mtu = state = rx_bytes = rx_packets = rx_errors = rx_dropped = rx_missed = rx_mcast = tx_bytes = tx_packets = tx_errors = tx_dropped = tx_carrier = tx_collsns = ""
+}
+
+END {
+	print iface, mtu, state, rx_bytes, rx_packets, rx_errors, rx_dropped, rx_missed, rx_mcast, tx_bytes, tx_packets, tx_errors, tx_dropped, tx_carrier, tx_collsns
+}
+

--- a/metricshub-hardware/src/test/resources/strategy/collect/TestConnector.yaml
+++ b/metricshub-hardware/src/test/resources/strategy/collect/TestConnector.yaml
@@ -14,6 +14,7 @@ connector:
     criteria:
       - type: snmpGetNext
         oid: 1.3.6.1.4.1.795.10.1.1.3.1.1
+    tags: [ hardware ]
 monitors:
   enclosure:
     discovery:


### PR DESCRIPTION
Exclude non hardware monitors from power estimation

    * Add connectorHasHardwareTag to compute power only for hardware monitors
    * Update unit tests
