### PR TITLE
Issue #355: Added support for `%{PASSWORD_JSON}` and `%{USERNAME_JSON}`

### DIFF
--- a/metricshub-http-extension/src/main/java/org/sentrysoftware/metricshub/extension/http/utils/HttpMacrosUpdater.java
+++ b/metricshub-http-extension/src/main/java/org/sentrysoftware/metricshub/extension/http/utils/HttpMacrosUpdater.java
@@ -43,6 +43,8 @@ public class HttpMacrosUpdater {
 	static final String PASSWORD_BASE64_MACRO = "%{PASSWORD_BASE64}";
 	static final String BASIC_AUTH_BASE64_MACRO = "%{BASIC_AUTH_BASE64}";
 	static final String SHA256_AUTH_MACRO = "%{SHA256_AUTH}";
+	static final String PASSWORD_JSON = "%{PASSWORD_JSON}";
+	static final String USERNAME_JSON = "%{USERNAME_JSON}";
 
 	/**
 	 * Replaces each known HTTP macro in the given text with the literal target sequences:<br>
@@ -76,6 +78,8 @@ public class HttpMacrosUpdater {
 			.replace(USERNAME_MACRO, username)
 			.replace(HOSTNAME_MACRO, hostname)
 			.replace(PASSWORD_MACRO, passwordAsString)
+			.replace(USERNAME_JSON, jsonValueEscape(username))
+			.replace(PASSWORD_JSON, jsonValueEscape(passwordAsString))
 			.replace("%{AUTHENTICATIONTOKEN}", authenticationToken);
 
 		// Encode the password into a base64 string
@@ -103,5 +107,22 @@ public class HttpMacrosUpdater {
 		}
 
 		return updatedContent;
+	}
+
+	/**
+	 * Escape special characters in a JSON string value (\ " \n \r \t).
+	 *
+	 * @param value The value to escape.
+	 * @return The escaped value
+	 */
+	static String jsonValueEscape(final String value) {
+		// Escape common characters
+		return value
+			// Escape characters (\ " \n \r \t)
+			.replace("\\", "\\\\")
+			.replace("\"", "\\\"")
+			.replace("\n", "\\n")
+			.replace("\r", "\\r")
+			.replace("\t", "\\t");
 	}
 }

--- a/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/utils/HttpMacrosUpdaterTest.java
+++ b/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/utils/HttpMacrosUpdaterTest.java
@@ -19,13 +19,17 @@ class HttpMacrosUpdaterTest {
 			%s
 			%s
 			%s
+			%s
+			%s
 			""",
 			HOSTNAME_MACRO,
 			PASSWORD_MACRO,
 			USERNAME_MACRO,
 			HttpMacrosUpdater.BASIC_AUTH_BASE64_MACRO,
 			HttpMacrosUpdater.SHA256_AUTH_MACRO,
-			HttpMacrosUpdater.PASSWORD_BASE64_MACRO
+			HttpMacrosUpdater.PASSWORD_BASE64_MACRO,
+			HttpMacrosUpdater.USERNAME_JSON,
+			HttpMacrosUpdater.PASSWORD_JSON
 		);
 
 		final String result = HttpMacrosUpdater.update(text, "user", "pwd".toCharArray(), "token", "hostname");
@@ -37,7 +41,18 @@ class HttpMacrosUpdaterTest {
 			dXNlcjpwd2Q=
 			3c469e9d6c5875d37a43f353d4f88e61fcf812c66eee3457465a40b0da4153e0
 			cHdk
+			user
+			pwd
 			""";
 		assertEquals(expected, result);
+	}
+
+	@Test
+	void testJsonValueEscape() {
+		assertEquals("test\\\"test", HttpMacrosUpdater.jsonValueEscape("test\"test"));
+		assertEquals("test\\ttest", HttpMacrosUpdater.jsonValueEscape("test\ttest"));
+		assertEquals("test\\ntest", HttpMacrosUpdater.jsonValueEscape("test\ntest"));
+		assertEquals("test\\rtest", HttpMacrosUpdater.jsonValueEscape("test\rtest"));
+		assertEquals("te\\\\st", HttpMacrosUpdater.jsonValueEscape("te\\st"));
 	}
 }


### PR DESCRIPTION
* Escaped chars (\ " \n \r \t) for `%{PASSWORD_JSON}` and `%{USERNAME_JSON}` values.