### PR TITLE
Issue #366: Recognize '2c' as a valid SNMP version option

### DIFF
--- a/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfiguration.java
+++ b/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfiguration.java
@@ -108,7 +108,12 @@ public class SnmpConfiguration implements ISnmpConfiguration {
 				return V1;
 			}
 
-			if ("2".equals(lowerCaseVersion) || "v2".equals(lowerCaseVersion) || "v2c".equals(lowerCaseVersion)) {
+			if (
+				"2".equals(lowerCaseVersion) ||
+				"v2".equals(lowerCaseVersion) ||
+				"v2c".equals(lowerCaseVersion) ||
+				"2c".equals(lowerCaseVersion)
+			) {
 				return V2C;
 			}
 

--- a/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfigurationTest.java
+++ b/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfigurationTest.java
@@ -1,5 +1,6 @@
 package org.sentrysoftware.metricshub.extension.snmp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -98,5 +99,15 @@ class SnmpConfigurationTest {
 
 			assertThrows(InvalidConfigurationException.class, () -> snmpConfig.validateConfiguration(resourceKey));
 		}
+	}
+
+	@Test
+	void testSnmpVersionInterpretValueOf() {
+		assertEquals(SnmpVersion.V1, SnmpVersion.interpretValueOf("1"));
+		assertEquals(SnmpVersion.V1, SnmpVersion.interpretValueOf("v1"));
+		assertEquals(SnmpVersion.V2C, SnmpVersion.interpretValueOf("2"));
+		assertEquals(SnmpVersion.V2C, SnmpVersion.interpretValueOf("v2"));
+		assertEquals(SnmpVersion.V2C, SnmpVersion.interpretValueOf("v2c"));
+		assertEquals(SnmpVersion.V2C, SnmpVersion.interpretValueOf("2c"));
 	}
 }


### PR DESCRIPTION
* Updated SnmpConfiguration to accept '2c' as a valid SNMP version.