### PR TITLE
Issue #380: Implement StateSet metrics compression

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/AgentConfig.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/AgentConfig.java
@@ -128,6 +128,10 @@ public class AgentConfig {
 	@JsonSetter(nulls = SKIP)
 	private Map<String, ResourceGroupConfig> resourceGroups = new HashMap<>();
 
+	@Default
+	@JsonSetter(nulls = SKIP)
+	private String stateSetCompression = StateSetMetricCompression.SUPPRESS_ZEROS;
+
 	/**
 	 * Build a new empty instance
 	 *

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/ResourceConfig.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/ResourceConfig.java
@@ -105,6 +105,8 @@ public class ResourceConfig {
 	@JsonIgnore
 	private Connector connector;
 
+	private String stateSetCompression;
+
 	/**
 	 * Creates and returns a shallow copy of all the fields in this
 	 * ResourceConfig object except the attributes map which is deeply copied.
@@ -135,6 +137,7 @@ public class ResourceConfig {
 			.variables(variables)
 			.connectors(connectors)
 			.connector(connector)
+			.stateSetCompression(stateSetCompression)
 			.build();
 	}
 }

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/ResourceGroupConfig.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/ResourceGroupConfig.java
@@ -74,4 +74,6 @@ public class ResourceGroupConfig {
 	@Default
 	@JsonSetter(nulls = SKIP)
 	private Map<String, ResourceConfig> resources = new HashMap<>();
+
+	private String stateSetCompression;
 }

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/StateSetMetricCompression.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/StateSetMetricCompression.java
@@ -1,0 +1,43 @@
+package org.sentrysoftware.metricshub.agent.config;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * StateSetMetricCompression represents the possible compression methods for the state set metrics.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class StateSetMetricCompression {
+
+	/**
+	 * Compression mechanism that records the zero value only on the initial state change,
+	 * retaining only the non-zero metric value thereafter.
+	 */
+	public static final String SUPPRESS_ZEROS = "suppressZeros";
+
+	/**
+	 * No compression, all zero and non-zero values are recorded.
+	 */
+	public static final String NONE = "none";
+}

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
@@ -520,6 +520,11 @@ public class ConfigHelper {
 			resourceConfig.setJobTimeout(agentConfig.getJobTimeout());
 		}
 
+		// Set the state set compression
+		if (resourceConfig.getStateSetCompression() == null) {
+			resourceConfig.setStateSetCompression(agentConfig.getStateSetCompression());
+		}
+
 		// Set agent attributes in the agent configuration attributes map
 		final Map<String, String> attributes = new HashMap<>();
 		mergeAttributes(agentConfig.getAttributes(), attributes);
@@ -598,6 +603,11 @@ public class ConfigHelper {
 			resourceConfig.setJobTimeout(resourceGroupConfig.getJobTimeout());
 		}
 
+		// Set the state set compression
+		if (resourceConfig.getStateSetCompression() == null) {
+			resourceConfig.setStateSetCompression(resourceGroupConfig.getStateSetCompression());
+		}
+
 		// Set agent attributes in the resource group attributes map
 		final Map<String, String> attributes = new HashMap<>();
 		mergeAttributes(resourceGroupConfig.getAttributes(), attributes);
@@ -670,6 +680,11 @@ public class ConfigHelper {
 		// Set the job timeout value
 		if (resourceGroupConfig.getJobTimeout() == null) {
 			resourceGroupConfig.setJobTimeout(agentConfig.getJobTimeout());
+		}
+
+		// Set the state set compression
+		if (resourceGroupConfig.getStateSetCompression() == null) {
+			resourceGroupConfig.setStateSetCompression(agentConfig.getStateSetCompression());
 		}
 
 		// Set agent attributes in the resource group attributes map

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/AbstractNotCompressedStateMetricObserver.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/AbstractNotCompressedStateMetricObserver.java
@@ -1,0 +1,62 @@
+package org.sentrysoftware.metricshub.agent.service.signal;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
+
+/**
+ * Abstract class for observing state set metrics without applying any compression.
+ * Extends {@link AbstractStateMetricObserver}.
+ */
+public abstract class AbstractNotCompressedStateMetricObserver extends AbstractStateMetricObserver {
+
+	/**
+	 * Constructs a new {@code AbstractNotCompressedStateSetMetricObserver} with the specified parameters.
+	 *
+	 * @param meter       The OpenTelemetry meter to use for creating the metric.
+	 * @param attributes  The attributes to associate with the metric.
+	 * @param metricName  The name of the metric.
+	 * @param unit        The unit of the metric.
+	 * @param description The description of the metric.
+	 * @param state       The state used to observe the metric. E.g. "ok".
+	 * @param metric      The StateSetMetric to observe.
+	 */
+	protected AbstractNotCompressedStateMetricObserver(
+		final Meter meter,
+		final Attributes attributes,
+		final String metricName,
+		final String unit,
+		final String description,
+		final String state,
+		final StateSetMetric metric
+	) {
+		super(meter, attributes, metricName, unit, description, state, metric);
+	}
+
+	@Override
+	protected void recordMetricValue(final ObservableDoubleMeasurement recorder, final String value) {
+		recorder.record(value.equalsIgnoreCase(state) ? 1 : 0, attributes);
+	}
+}

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/AbstractStateMetricObserver.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/AbstractStateMetricObserver.java
@@ -38,6 +38,17 @@ import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
 @ToString(callSuper = true)
 public abstract class AbstractStateMetricObserver extends AbstractMetricObserver {
 
+	/**
+	 * Constructs a new {@code AbstractStateMetricObserver} with the specified parameters.
+	 *
+	 * @param meter       The OpenTelemetry meter to use for creating the metric.
+	 * @param attributes  The attributes to associate with the metric.
+	 * @param metricName  The name of the metric.
+	 * @param unit        The unit of the metric.
+	 * @param description The description of the metric.
+	 * @param state       The state used to observe the metric. E.g. "ok"
+	 * @param metric      The StateSetMetric to observe.
+	 */
 	protected AbstractStateMetricObserver(
 		final Meter meter,
 		final Attributes attributes,
@@ -56,20 +67,28 @@ public abstract class AbstractStateMetricObserver extends AbstractMetricObserver
 	protected StateSetMetric metric;
 
 	/**
-	 * Observe the given state metric value
+	 * Observe the given state metric value.
 	 *
 	 * @param recorder An interface for observing measurements with double values.
 	 */
 	protected void observeStateMetric(final ObservableDoubleMeasurement recorder) {
-		getMetricValue().ifPresent(value -> recorder.record(value.equalsIgnoreCase(state) ? 1 : 0, attributes));
+		getMetricValue().ifPresent(value -> recordMetricValue(recorder, value));
 	}
+
+	/**
+	 * Record the metric value using the given recorder.
+	 *
+	 * @param recorder The recorder to record the metric value.
+	 * @param value    The value as String to be recorded as a double value.
+	 */
+	protected abstract void recordMetricValue(ObservableDoubleMeasurement recorder, String value);
 
 	/**
 	 * Get the metric value
 	 *
 	 * @return Optional of a {@link String} value
 	 */
-	public Optional<String> getMetricValue() {
+	protected Optional<String> getMetricValue() {
 		if (metric != null && metric.isUpdated()) {
 			return Optional.ofNullable(metric.getValue());
 		}

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/AbstractSuppressZerosStateMetricObserver.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/AbstractSuppressZerosStateMetricObserver.java
@@ -1,0 +1,69 @@
+package org.sentrysoftware.metricshub.agent.service.signal;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
+
+/**
+ * Abstract class for observing state set metrics by applying a suppression of zero values.
+ * Extends {@link AbstractStateMetricObserver}.
+ */
+public abstract class AbstractSuppressZerosStateMetricObserver extends AbstractStateMetricObserver {
+
+	/**
+	 * Constructs a new {@code AbstractSuppressZerosStateMetricObserver} with the specified parameters.
+	 *
+	 * @param meter       The OpenTelemetry meter to use for creating the metric.
+	 * @param attributes  The attributes to associate with the metric.
+	 * @param metricName  The name of the metric.
+	 * @param unit        The unit of the metric.
+	 * @param description The description of the metric.
+	 * @param state       The state used to observe the metric. E.g. "ok".
+	 * @param metric      The StateSetMetric to observe.
+	 */
+	protected AbstractSuppressZerosStateMetricObserver(
+		final Meter meter,
+		final Attributes attributes,
+		final String metricName,
+		final String unit,
+		final String description,
+		final String state,
+		final StateSetMetric metric
+	) {
+		super(meter, attributes, metricName, unit, description, state, metric);
+	}
+
+	@Override
+	protected void recordMetricValue(final ObservableDoubleMeasurement recorder, final String value) {
+		if (value.equalsIgnoreCase(state)) {
+			recorder.record(1, attributes);
+		} else {
+			final String previousValue = metric.getPreviousValue();
+			if (previousValue != null && !previousValue.equalsIgnoreCase(value) && previousValue.equalsIgnoreCase(state)) {
+				recorder.record(0, attributes);
+			}
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/CounterStateMetricObserver.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/CounterStateMetricObserver.java
@@ -30,7 +30,7 @@ import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
  * Observer for a counter state metric, extending {@link AbstractStateMetricObserver}.
  * This observer initializes the metric and provides a callback for observing state changes.
  */
-public class CounterStateMetricObserver extends AbstractStateMetricObserver {
+public class CounterStateMetricObserver extends AbstractNotCompressedStateMetricObserver {
 
 	/**
 	 * Constructs a {@code CounterStateMetricObserver} with the specified parameters.

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/CounterSuppressZerosStateMetricObserver.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/CounterSuppressZerosStateMetricObserver.java
@@ -24,32 +24,27 @@ package org.sentrysoftware.metricshub.agent.service.signal;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
 import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
 
 /**
- * A metric observer for gauge state metrics.
+ * Observer for a counter state metric with suppression of zero values, extending {@link AbstractSuppressZerosStateMetricObserver}.
+ * This observer initializes the metric and provides a callback for observing state changes.
  */
-@Data
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
-public class GaugeStateMetricObserver extends AbstractNotCompressedStateMetricObserver {
+public class CounterSuppressZerosStateMetricObserver extends AbstractSuppressZerosStateMetricObserver {
 
 	/**
-	 * Constructs a new {@code GaugeStateMetricObserver} with the specified parameters.
+	 * Constructs a {@code CounterSuppressZerosStateMetricObserver} with the specified parameters.
 	 *
-	 * @param meter       the meter to which the metric belongs
-	 * @param attributes  the attributes associated with the metric
-	 * @param metricName  the name of the metric
-	 * @param unit        the unit of the metric
-	 * @param description the description of the metric
-	 * @param state       the state of the metric
-	 * @param metric      the gauge state metric to observe
+	 * @param meter       The OpenTelemetry meter to use for creating the metric.
+	 * @param attributes  The attributes to associate with the metric.
+	 * @param metricName  The name of the metric.
+	 * @param unit        The unit of the metric.
+	 * @param description The description of the metric.
+	 * @param state       The state used to observe the metric. E.g. "ok".
+	 * @param metric      The StateSetMetric to observe.
 	 */
 	@Builder(setterPrefix = "with")
-	public GaugeStateMetricObserver(
+	public CounterSuppressZerosStateMetricObserver(
 		final Meter meter,
 		final Attributes attributes,
 		final String metricName,
@@ -63,6 +58,6 @@ public class GaugeStateMetricObserver extends AbstractNotCompressedStateMetricOb
 
 	@Override
 	public void init() {
-		newDoubleGaugeBuilder().buildWithCallback(super::observeStateMetric);
+		newDoubleCounterBuilder().buildWithCallback(super::observeStateMetric);
 	}
 }

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/GaugeSuppressZerosStateMetricObserver.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/GaugeSuppressZerosStateMetricObserver.java
@@ -30,26 +30,27 @@ import lombok.ToString;
 import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
 
 /**
- * A metric observer for gauge state metrics.
+ * A metric observer for gauge state metrics with suppression of zero values.
+ * Extends {@link AbstractSuppressZerosStateMetricObserver}.
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class GaugeStateMetricObserver extends AbstractNotCompressedStateMetricObserver {
+public class GaugeSuppressZerosStateMetricObserver extends AbstractSuppressZerosStateMetricObserver {
 
 	/**
-	 * Constructs a new {@code GaugeStateMetricObserver} with the specified parameters.
+	 * Constructs a new {@code GaugeSuppressZerosStateMetricObserver} with the specified parameters.
 	 *
-	 * @param meter       the meter to which the metric belongs
-	 * @param attributes  the attributes associated with the metric
-	 * @param metricName  the name of the metric
-	 * @param unit        the unit of the metric
-	 * @param description the description of the metric
-	 * @param state       the state of the metric
-	 * @param metric      the gauge state metric to observe
+	 * @param meter       The OpenTelemetry meter to use for creating the metric.
+	 * @param attributes  The attributes to associate with the metric.
+	 * @param metricName  The name of the metric.
+	 * @param unit        The unit of the metric.
+	 * @param description The description of the metric.
+	 * @param state       The state used to observe the metric. E.g. "ok".
+	 * @param metric      The StateSetMetric to observe.
 	 */
 	@Builder(setterPrefix = "with")
-	public GaugeStateMetricObserver(
+	public GaugeSuppressZerosStateMetricObserver(
 		final Meter meter,
 		final Attributes attributes,
 		final String metricName,

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/UpDownCounterStateMetricObserver.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/UpDownCounterStateMetricObserver.java
@@ -30,7 +30,7 @@ import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
  * Observer for UpDownCounter state metrics.
  * Extends {@link AbstractStateMetricObserver}.
  */
-public class UpDownCounterStateMetricObserver extends AbstractStateMetricObserver {
+public class UpDownCounterStateMetricObserver extends AbstractNotCompressedStateMetricObserver {
 
 	/**
 	 * Constructs a new {@code UpDownCounterStateMetricObserver} with the specified parameters.

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/UpDownCounterSuppressZerosStateMetricObserver.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/signal/UpDownCounterSuppressZerosStateMetricObserver.java
@@ -24,32 +24,27 @@ package org.sentrysoftware.metricshub.agent.service.signal;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
 import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
 
 /**
- * A metric observer for gauge state metrics.
+ * Observer for UpDownCounter state metrics with suppression of zero values.
+ * Extends {@link AbstractSuppressZerosStateMetricObserver}.
  */
-@Data
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
-public class GaugeStateMetricObserver extends AbstractNotCompressedStateMetricObserver {
+public class UpDownCounterSuppressZerosStateMetricObserver extends AbstractSuppressZerosStateMetricObserver {
 
 	/**
-	 * Constructs a new {@code GaugeStateMetricObserver} with the specified parameters.
+	 * Constructs a new {@code UpDownCounterSuppressZerosStateMetricObserver} with the specified parameters.
 	 *
-	 * @param meter       the meter to which the metric belongs
-	 * @param attributes  the attributes associated with the metric
-	 * @param metricName  the name of the metric
-	 * @param unit        the unit of the metric
-	 * @param description the description of the metric
-	 * @param state       the state of the metric
-	 * @param metric      the gauge state metric to observe
+	 * @param meter       The OpenTelemetry meter to use for creating the metric.
+	 * @param attributes  The attributes to associate with the metric.
+	 * @param metricName  The name of the metric.
+	 * @param unit        The unit of the metric.
+	 * @param description The description of the metric.
+	 * @param state       The state used to observe the metric. E.g. "ok".
+	 * @param metric      The StateSetMetric to observe.
 	 */
 	@Builder(setterPrefix = "with")
-	public GaugeStateMetricObserver(
+	public UpDownCounterSuppressZerosStateMetricObserver(
 		final Meter meter,
 		final Attributes attributes,
 		final String metricName,
@@ -63,6 +58,6 @@ public class GaugeStateMetricObserver extends AbstractNotCompressedStateMetricOb
 
 	@Override
 	public void init() {
-		newDoubleGaugeBuilder().buildWithCallback(super::observeStateMetric);
+		newDoubleUpDownCounterBuilder().buildWithCallback(super::observeStateMetric);
 	}
 }

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/task/MonitoringTask.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/task/MonitoringTask.java
@@ -326,6 +326,7 @@ public class MonitoringTask implements Runnable {
 					.withMonitorId(monitor.getId())
 					.withResourceGroupKey(monitoringTaskInfo.getResourceGroupKey())
 					.withResourceKey(monitoringTaskInfo.getResourceKey())
+					.withStateSetCompression(monitoringTaskInfo.getResourceConfig().getStateSetCompression())
 					.build()
 			);
 

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/signal/CounterSuppressZerosStateMetricObserverTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/signal/CounterSuppressZerosStateMetricObserverTest.java
@@ -1,0 +1,209 @@
+package org.sentrysoftware.metricshub.agent.service.signal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.ATTRIBUTES;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.COMPANY_ATTRIBUTE_VALUE;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.HW_METRIC;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_DESCRIPTION;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_INSTRUMENTATION_SCOPE;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_STATE_DEGRADED;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_STATE_FAILED;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_STATE_OK;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_UNIT;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.OTEL_COMPANY_ATTRIBUTE_KEY;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
+
+class CounterSuppressZerosStateMetricObserverTest {
+
+	@Test
+	void testInitStateMatches() {
+		final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+		final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+		CounterSuppressZerosStateMetricObserver
+			.builder()
+			.withAttributes(ATTRIBUTES)
+			.withMetricName(HW_METRIC)
+			.withDescription(METRIC_DESCRIPTION)
+			.withUnit(METRIC_UNIT)
+			.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+			.withMetric(StateSetMetric.builder().collectTime(System.currentTimeMillis()).value(METRIC_STATE_OK).build())
+			.withState(METRIC_STATE_OK)
+			.build()
+			.init();
+
+		final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+		assertFalse(metrics.isEmpty());
+
+		final List<MetricData> metricList = metrics
+			.stream()
+			.filter(metricData -> HW_METRIC.equals(metricData.getName()))
+			.toList();
+
+		assertEquals(1, metricList.size());
+		final MetricData hwMetricData = metricList.get(0);
+
+		assertNotNull(hwMetricData);
+
+		assertEquals(METRIC_DESCRIPTION, hwMetricData.getDescription());
+		assertEquals(METRIC_UNIT, hwMetricData.getUnit());
+
+		final SumData<DoublePointData> doubleData = hwMetricData.getDoubleSumData();
+		final DoublePointData dataPoint = doubleData.getPoints().stream().findAny().orElse(null);
+		assertNotNull(dataPoint);
+		assertEquals(1, dataPoint.getValue());
+
+		final Attributes collectedAttributes = dataPoint.getAttributes();
+
+		assertEquals(COMPANY_ATTRIBUTE_VALUE, collectedAttributes.get(OTEL_COMPANY_ATTRIBUTE_KEY));
+	}
+
+	@Test
+	void testInitStateDoesntMatchMetricRecorded() {
+		final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+		final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+		final StateSetMetric stateSetMetric = StateSetMetric
+			.builder()
+			.collectTime(System.currentTimeMillis())
+			.value(METRIC_STATE_OK)
+			.build();
+		// The previous state was degraded, indicating the metric has transitioned from degraded to ok
+		stateSetMetric.setPreviousValue(METRIC_STATE_DEGRADED);
+
+		CounterSuppressZerosStateMetricObserver
+			.builder()
+			.withAttributes(ATTRIBUTES)
+			.withMetricName(HW_METRIC)
+			.withDescription(METRIC_DESCRIPTION)
+			.withUnit(METRIC_UNIT)
+			.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+			.withMetric(stateSetMetric)
+			.withState(METRIC_STATE_DEGRADED)
+			.build()
+			.init();
+
+		final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+		assertFalse(metrics.isEmpty());
+
+		final List<MetricData> metricList = metrics
+			.stream()
+			.filter(metricData -> HW_METRIC.equals(metricData.getName()))
+			.toList();
+
+		assertEquals(1, metricList.size());
+		final MetricData hwMetricData = metricList.get(0);
+
+		assertEquals(METRIC_DESCRIPTION, hwMetricData.getDescription());
+		assertEquals(METRIC_UNIT, hwMetricData.getUnit());
+
+		assertNotNull(hwMetricData);
+
+		final SumData<DoublePointData> doubleData = hwMetricData.getDoubleSumData();
+		final DoublePointData dataPoint = doubleData.getPoints().stream().findAny().orElse(null);
+		assertNotNull(dataPoint);
+		assertEquals(0, dataPoint.getValue());
+
+		final Attributes collectedAttributes = dataPoint.getAttributes();
+
+		assertEquals(COMPANY_ATTRIBUTE_VALUE, collectedAttributes.get(OTEL_COMPANY_ATTRIBUTE_KEY));
+	}
+
+	@Test
+	void testInitStateDoesntMatchMetricNotRecorded() {
+		{
+			final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+			final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+			final StateSetMetric stateSetMetric = StateSetMetric
+				.builder()
+				.collectTime(System.currentTimeMillis())
+				.value(METRIC_STATE_OK)
+				.build();
+
+			CounterSuppressZerosStateMetricObserver
+				.builder()
+				.withAttributes(ATTRIBUTES)
+				.withMetricName(HW_METRIC)
+				.withDescription(METRIC_DESCRIPTION)
+				.withUnit(METRIC_UNIT)
+				.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+				.withMetric(stateSetMetric)
+				.withState(METRIC_STATE_DEGRADED)
+				.build()
+				.init();
+
+			final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+			assertTrue(metrics.isEmpty());
+		}
+		{
+			final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+			final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+			final StateSetMetric stateSetMetric = StateSetMetric
+				.builder()
+				.collectTime(System.currentTimeMillis())
+				.value(METRIC_STATE_OK)
+				.build();
+			// The previous state was failed, indicating that the metric's state has transitioned from failed to ok (not from degraded to ok)
+			stateSetMetric.setPreviousValue(METRIC_STATE_FAILED);
+
+			CounterSuppressZerosStateMetricObserver
+				.builder()
+				.withAttributes(ATTRIBUTES)
+				.withMetricName(HW_METRIC)
+				.withDescription(METRIC_DESCRIPTION)
+				.withUnit(METRIC_UNIT)
+				.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+				.withMetric(stateSetMetric)
+				.withState(METRIC_STATE_DEGRADED)
+				.build()
+				.init();
+
+			final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+			assertTrue(metrics.isEmpty());
+		}
+	}
+
+	@Test
+	void testInitStateDoesntMatchUnchangedStateMetricNotRecorded() {
+		final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+		final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+		final StateSetMetric stateSetMetric = StateSetMetric
+			.builder()
+			.collectTime(System.currentTimeMillis())
+			.value(METRIC_STATE_OK)
+			.build();
+		// The previous state was ok, indicating that the metric's state has remained unchanged
+		stateSetMetric.setPreviousValue(METRIC_STATE_OK);
+
+		CounterSuppressZerosStateMetricObserver
+			.builder()
+			.withAttributes(ATTRIBUTES)
+			.withMetricName(HW_METRIC)
+			.withDescription(METRIC_DESCRIPTION)
+			.withUnit(METRIC_UNIT)
+			.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+			.withMetric(stateSetMetric)
+			.withState(METRIC_STATE_DEGRADED)
+			.build()
+			.init();
+
+		final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+		assertTrue(metrics.isEmpty());
+	}
+}

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/signal/GaugeSuppressZerosStateMetricObserverTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/signal/GaugeSuppressZerosStateMetricObserverTest.java
@@ -1,0 +1,209 @@
+package org.sentrysoftware.metricshub.agent.service.signal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.ATTRIBUTES;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.COMPANY_ATTRIBUTE_VALUE;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.HW_METRIC;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_DESCRIPTION;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_INSTRUMENTATION_SCOPE;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_STATE_DEGRADED;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_STATE_FAILED;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_STATE_OK;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_UNIT;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.OTEL_COMPANY_ATTRIBUTE_KEY;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.GaugeData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
+
+class GaugeSuppressZerosStateMetricObserverTest {
+
+	@Test
+	void testInitStateMatches() {
+		final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+		final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+		GaugeSuppressZerosStateMetricObserver
+			.builder()
+			.withAttributes(ATTRIBUTES)
+			.withMetricName(HW_METRIC)
+			.withDescription(METRIC_DESCRIPTION)
+			.withUnit(METRIC_UNIT)
+			.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+			.withMetric(StateSetMetric.builder().collectTime(System.currentTimeMillis()).value(METRIC_STATE_OK).build())
+			.withState(METRIC_STATE_OK)
+			.build()
+			.init();
+
+		final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+		assertFalse(metrics.isEmpty());
+
+		final List<MetricData> metricList = metrics
+			.stream()
+			.filter(metricData -> HW_METRIC.equals(metricData.getName()))
+			.toList();
+
+		assertEquals(1, metricList.size());
+		final MetricData hwMetricData = metricList.get(0);
+
+		assertNotNull(hwMetricData);
+
+		assertEquals(METRIC_DESCRIPTION, hwMetricData.getDescription());
+		assertEquals(METRIC_UNIT, hwMetricData.getUnit());
+
+		final GaugeData<DoublePointData> doubleData = hwMetricData.getDoubleGaugeData();
+		final DoublePointData dataPoint = doubleData.getPoints().stream().findAny().orElse(null);
+		assertNotNull(dataPoint);
+		assertEquals(1, dataPoint.getValue());
+
+		final Attributes collectedAttributes = dataPoint.getAttributes();
+
+		assertEquals(COMPANY_ATTRIBUTE_VALUE, collectedAttributes.get(OTEL_COMPANY_ATTRIBUTE_KEY));
+	}
+
+	@Test
+	void testInitStateDoesntMatchMetricRecorded() {
+		final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+		final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+		final StateSetMetric stateSetMetric = StateSetMetric
+			.builder()
+			.collectTime(System.currentTimeMillis())
+			.value(METRIC_STATE_OK)
+			.build();
+		// The previous state was degraded, indicating the metric has transitioned from degraded to ok
+		stateSetMetric.setPreviousValue(METRIC_STATE_DEGRADED);
+
+		GaugeSuppressZerosStateMetricObserver
+			.builder()
+			.withAttributes(ATTRIBUTES)
+			.withMetricName(HW_METRIC)
+			.withDescription(METRIC_DESCRIPTION)
+			.withUnit(METRIC_UNIT)
+			.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+			.withMetric(stateSetMetric)
+			.withState(METRIC_STATE_DEGRADED)
+			.build()
+			.init();
+
+		final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+		assertFalse(metrics.isEmpty());
+
+		final List<MetricData> metricList = metrics
+			.stream()
+			.filter(metricData -> HW_METRIC.equals(metricData.getName()))
+			.toList();
+
+		assertEquals(1, metricList.size());
+		final MetricData hwMetricData = metricList.get(0);
+
+		assertEquals(METRIC_DESCRIPTION, hwMetricData.getDescription());
+		assertEquals(METRIC_UNIT, hwMetricData.getUnit());
+
+		assertNotNull(hwMetricData);
+
+		final GaugeData<DoublePointData> doubleData = hwMetricData.getDoubleGaugeData();
+		final DoublePointData dataPoint = doubleData.getPoints().stream().findAny().orElse(null);
+		assertNotNull(dataPoint);
+		assertEquals(0, dataPoint.getValue());
+
+		final Attributes collectedAttributes = dataPoint.getAttributes();
+
+		assertEquals(COMPANY_ATTRIBUTE_VALUE, collectedAttributes.get(OTEL_COMPANY_ATTRIBUTE_KEY));
+	}
+
+	@Test
+	void testInitStateDoesntMatchMetricNotRecorded() {
+		{
+			final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+			final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+			final StateSetMetric stateSetMetric = StateSetMetric
+				.builder()
+				.collectTime(System.currentTimeMillis())
+				.value(METRIC_STATE_OK)
+				.build();
+
+			GaugeSuppressZerosStateMetricObserver
+				.builder()
+				.withAttributes(ATTRIBUTES)
+				.withMetricName(HW_METRIC)
+				.withDescription(METRIC_DESCRIPTION)
+				.withUnit(METRIC_UNIT)
+				.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+				.withMetric(stateSetMetric)
+				.withState(METRIC_STATE_DEGRADED)
+				.build()
+				.init();
+
+			final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+			assertTrue(metrics.isEmpty());
+		}
+		{
+			final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+			final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+			final StateSetMetric stateSetMetric = StateSetMetric
+				.builder()
+				.collectTime(System.currentTimeMillis())
+				.value(METRIC_STATE_OK)
+				.build();
+			// The previous state was failed, indicating that the metric's state has transitioned from failed to ok (not from degraded to ok)
+			stateSetMetric.setPreviousValue(METRIC_STATE_FAILED);
+
+			GaugeSuppressZerosStateMetricObserver
+				.builder()
+				.withAttributes(ATTRIBUTES)
+				.withMetricName(HW_METRIC)
+				.withDescription(METRIC_DESCRIPTION)
+				.withUnit(METRIC_UNIT)
+				.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+				.withMetric(stateSetMetric)
+				.withState(METRIC_STATE_DEGRADED)
+				.build()
+				.init();
+
+			final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+			assertTrue(metrics.isEmpty());
+		}
+	}
+
+	@Test
+	void testInitStateDoesntMatchUnchangedStateMetricNotRecorded() {
+		final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+		final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+		final StateSetMetric stateSetMetric = StateSetMetric
+			.builder()
+			.collectTime(System.currentTimeMillis())
+			.value(METRIC_STATE_OK)
+			.build();
+		// The previous state was ok, indicating that the metric's state has remained unchanged
+		stateSetMetric.setPreviousValue(METRIC_STATE_OK);
+
+		GaugeSuppressZerosStateMetricObserver
+			.builder()
+			.withAttributes(ATTRIBUTES)
+			.withMetricName(HW_METRIC)
+			.withDescription(METRIC_DESCRIPTION)
+			.withUnit(METRIC_UNIT)
+			.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+			.withMetric(stateSetMetric)
+			.withState(METRIC_STATE_DEGRADED)
+			.build()
+			.init();
+
+		final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+		assertTrue(metrics.isEmpty());
+	}
+}

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/signal/UpDownCounterSuppressZerosStateMetricObserverTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/signal/UpDownCounterSuppressZerosStateMetricObserverTest.java
@@ -1,0 +1,209 @@
+package org.sentrysoftware.metricshub.agent.service.signal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.ATTRIBUTES;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.COMPANY_ATTRIBUTE_VALUE;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.HW_METRIC;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_DESCRIPTION;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_INSTRUMENTATION_SCOPE;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_STATE_DEGRADED;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_STATE_FAILED;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_STATE_OK;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.METRIC_UNIT;
+import static org.sentrysoftware.metricshub.agent.helper.TestConstants.OTEL_COMPANY_ATTRIBUTE_KEY;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sentrysoftware.metricshub.engine.telemetry.metric.StateSetMetric;
+
+class UpDownCounterSuppressZerosStateMetricObserverTest {
+
+	@Test
+	void testInitStateMatches() {
+		final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+		final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+		UpDownCounterSuppressZerosStateMetricObserver
+			.builder()
+			.withAttributes(ATTRIBUTES)
+			.withMetricName(HW_METRIC)
+			.withDescription(METRIC_DESCRIPTION)
+			.withUnit(METRIC_UNIT)
+			.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+			.withMetric(StateSetMetric.builder().collectTime(System.currentTimeMillis()).value(METRIC_STATE_OK).build())
+			.withState(METRIC_STATE_OK)
+			.build()
+			.init();
+
+		final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+		assertFalse(metrics.isEmpty());
+
+		final List<MetricData> metricList = metrics
+			.stream()
+			.filter(metricData -> HW_METRIC.equals(metricData.getName()))
+			.toList();
+
+		assertEquals(1, metricList.size());
+		final MetricData hwMetricData = metricList.get(0);
+
+		assertNotNull(hwMetricData);
+
+		assertEquals(METRIC_DESCRIPTION, hwMetricData.getDescription());
+		assertEquals(METRIC_UNIT, hwMetricData.getUnit());
+
+		final SumData<DoublePointData> doubleData = hwMetricData.getDoubleSumData();
+		final DoublePointData dataPoint = doubleData.getPoints().stream().findAny().orElse(null);
+		assertNotNull(dataPoint);
+		assertEquals(1, dataPoint.getValue());
+
+		final Attributes collectedAttributes = dataPoint.getAttributes();
+
+		assertEquals(COMPANY_ATTRIBUTE_VALUE, collectedAttributes.get(OTEL_COMPANY_ATTRIBUTE_KEY));
+	}
+
+	@Test
+	void testInitStateDoesntMatchMetricRecorded() {
+		final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+		final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+		final StateSetMetric stateSetMetric = StateSetMetric
+			.builder()
+			.collectTime(System.currentTimeMillis())
+			.value(METRIC_STATE_OK)
+			.build();
+		// The previous state was degraded, indicating the metric has transitioned from degraded to ok
+		stateSetMetric.setPreviousValue(METRIC_STATE_DEGRADED);
+
+		UpDownCounterSuppressZerosStateMetricObserver
+			.builder()
+			.withAttributes(ATTRIBUTES)
+			.withMetricName(HW_METRIC)
+			.withDescription(METRIC_DESCRIPTION)
+			.withUnit(METRIC_UNIT)
+			.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+			.withMetric(stateSetMetric)
+			.withState(METRIC_STATE_DEGRADED)
+			.build()
+			.init();
+
+		final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+		assertFalse(metrics.isEmpty());
+
+		final List<MetricData> metricList = metrics
+			.stream()
+			.filter(metricData -> HW_METRIC.equals(metricData.getName()))
+			.toList();
+
+		assertEquals(1, metricList.size());
+		final MetricData hwMetricData = metricList.get(0);
+
+		assertEquals(METRIC_DESCRIPTION, hwMetricData.getDescription());
+		assertEquals(METRIC_UNIT, hwMetricData.getUnit());
+
+		assertNotNull(hwMetricData);
+
+		final SumData<DoublePointData> doubleData = hwMetricData.getDoubleSumData();
+		final DoublePointData dataPoint = doubleData.getPoints().stream().findAny().orElse(null);
+		assertNotNull(dataPoint);
+		assertEquals(0, dataPoint.getValue());
+
+		final Attributes collectedAttributes = dataPoint.getAttributes();
+
+		assertEquals(COMPANY_ATTRIBUTE_VALUE, collectedAttributes.get(OTEL_COMPANY_ATTRIBUTE_KEY));
+	}
+
+	@Test
+	void testInitStateDoesntMatchMetricNotRecorded() {
+		{
+			final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+			final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+			final StateSetMetric stateSetMetric = StateSetMetric
+				.builder()
+				.collectTime(System.currentTimeMillis())
+				.value(METRIC_STATE_OK)
+				.build();
+
+			UpDownCounterSuppressZerosStateMetricObserver
+				.builder()
+				.withAttributes(ATTRIBUTES)
+				.withMetricName(HW_METRIC)
+				.withDescription(METRIC_DESCRIPTION)
+				.withUnit(METRIC_UNIT)
+				.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+				.withMetric(stateSetMetric)
+				.withState(METRIC_STATE_DEGRADED)
+				.build()
+				.init();
+
+			final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+			assertTrue(metrics.isEmpty());
+		}
+		{
+			final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+			final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+			final StateSetMetric stateSetMetric = StateSetMetric
+				.builder()
+				.collectTime(System.currentTimeMillis())
+				.value(METRIC_STATE_OK)
+				.build();
+			// The previous state was failed, indicating that the metric's state has transitioned from failed to ok (not from degraded to ok)
+			stateSetMetric.setPreviousValue(METRIC_STATE_FAILED);
+
+			UpDownCounterSuppressZerosStateMetricObserver
+				.builder()
+				.withAttributes(ATTRIBUTES)
+				.withMetricName(HW_METRIC)
+				.withDescription(METRIC_DESCRIPTION)
+				.withUnit(METRIC_UNIT)
+				.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+				.withMetric(stateSetMetric)
+				.withState(METRIC_STATE_DEGRADED)
+				.build()
+				.init();
+
+			final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+			assertTrue(metrics.isEmpty());
+		}
+	}
+
+	@Test
+	void testInitStateDoesntMatchUnchangedStateMetricNotRecorded() {
+		final InMemoryMetricReader inMemoryReader = InMemoryMetricReader.create();
+		final SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(inMemoryReader).build();
+
+		final StateSetMetric stateSetMetric = StateSetMetric
+			.builder()
+			.collectTime(System.currentTimeMillis())
+			.value(METRIC_STATE_OK)
+			.build();
+		// The previous state was ok, indicating that the metric's state has remained unchanged
+		stateSetMetric.setPreviousValue(METRIC_STATE_OK);
+
+		UpDownCounterSuppressZerosStateMetricObserver
+			.builder()
+			.withAttributes(ATTRIBUTES)
+			.withMetricName(HW_METRIC)
+			.withDescription(METRIC_DESCRIPTION)
+			.withUnit(METRIC_UNIT)
+			.withMeter(sdkMeterProvider.get(METRIC_INSTRUMENTATION_SCOPE))
+			.withMetric(stateSetMetric)
+			.withState(METRIC_STATE_DEGRADED)
+			.build()
+			.init();
+
+		final Collection<MetricData> metrics = inMemoryReader.collectAllMetrics();
+		assertTrue(metrics.isEmpty());
+	}
+}


### PR DESCRIPTION
* Developed new classes to handle `suppressZeros` compression for StateSet metrics.
* Initialized the `suppressZeros` compression observers.
* Updated the configuration model to enable user configuration for compression.
* Added a new section to the documentation (Monitoring Configuration).