### PR TITLE
Issue #385: Move Connectors Directory to Introduction

### DIFF
--- a/metricshub-doc/src/site/markdown/index.md
+++ b/metricshub-doc/src/site/markdown/index.md
@@ -21,7 +21,7 @@ Because it is recommended to use an OpenTelemetry Collector in production enviro
 
 ## Monitoring Coverage
 
-**MetricsHub Enterprise** provides out-of-the box support for hundreds of  [servers, storage systems, network devices, and databases]((https://metricshub.com/docs/latest/metricshub-connector-reference.html)) through its built-in library of connectors.
+**MetricsHub Enterprise** provides out-of-the box support for hundreds of  [servers, storage systems, network devices, and databases](metricshub-connectors-directory.md) through its built-in library of connectors.
 
 Fully customizable, **MetricsHub** can also be configured to **cover new use cases in no time**, such as the monitoring of systems or applications not covered out-of-the-box through protocols like `HTTP`, `IPMI`, `PING`, `SNMP`, `SSH`, `WBEM`, `WinRM` or `WMI`.
 

--- a/metricshub-doc/src/site/markdown/index.md
+++ b/metricshub-doc/src/site/markdown/index.md
@@ -21,7 +21,7 @@ Because it is recommended to use an OpenTelemetry Collector in production enviro
 
 ## Monitoring Coverage
 
-**MetricsHub Enterprise** provides out-of-the box support for hundreds of  [servers, storage systems, network devices, and databases](metricshub-connectors-directory.md) through its built-in library of connectors.
+**MetricsHub Enterprise** provides out-of-the box support for hundreds of  [servers, storage systems, network devices, and databases](metricshub-connectors-directory.html) through its built-in library of connectors.
 
 Fully customizable, **MetricsHub** can also be configured to **cover new use cases in no time**, such as the monitoring of systems or applications not covered out-of-the-box through protocols like `HTTP`, `IPMI`, `PING`, `SNMP`, `SSH`, `WBEM`, `WinRM` or `WMI`.
 

--- a/metricshub-doc/src/site/site.xml
+++ b/metricshub-doc/src/site/site.xml
@@ -80,6 +80,7 @@
 
 		<menu name="Introduction">
 			<item name="Overview" href="index.html" />
+			<item name="Connectors Directory" href="metricshub-connectors-directory.html" />
 		</menu>
 
 		<menu name="Install">
@@ -170,8 +171,5 @@
 			<item name="References" href="develop/references.html" />
 		</menu>
 
-		<menu name="Appendix">
-			<item name="Connectors Directory" href="metricshub-connectors-directory.html" />
-		</menu>
 	</body>
 </project>


### PR DESCRIPTION
* Updated site.xml to move the Connectors Directory item.
* Updated incorrect link in `index.md`.