### PR TITLE
Issue 394: Removed reference to Hardware Sentry Agent

### DIFF
--- a/metricshub-doc/src/site/markdown/troubleshooting/status.md
+++ b/metricshub-doc/src/site/markdown/troubleshooting/status.md
@@ -81,7 +81,7 @@ otelcol_process_runtime_total_sys_memory_bytes{service_instance_id="xxxxxxxxx-xx
 ...
 ```
 
-The above processor time utilization and memory consumption metrics pertain to the `otelcol-contrib` process only, and do not represent the activity of the internal **Hardware Sentry Agent**.
+The above processor time utilization and memory consumption metrics pertain to the `otelcol-contrib` process only, and do not represent the activity of the internal **MetricsHub Agent**.
 
 You can choose to integrate these internal metrics in the pipeline of the *OpenTelemetry Collector* to push them to the platform of your choice. To do so, [edit the otel/otel-config.yaml configuration file](../configuration/configure-otel.md) to add `prometheus/internal` in the list of receivers:
 


### PR DESCRIPTION
* Replaced Hardware Sentry Agent with MetricsHub Agent