### PR TITLE
Issue 393: Data export topic is misleading

### DIFF
--- a/metricshub-doc/src/site/markdown/configuration/send-telemetry.md
+++ b/metricshub-doc/src/site/markdown/configuration/send-telemetry.md
@@ -1,7 +1,7 @@
 keywords: prometheus, exporter
-description: How to configure MetricsHub to send data to an observability back-end.
+description: How to configure MetricsHub to send telemetry to an observability back-end.
 
-# Sending Data to Observability Platforms
+# Sending Telemetry to Observability Platforms
 
 <!-- MACRO{toc|fromDepth=1|toDepth=1|id=toc} -->
 
@@ -159,7 +159,7 @@ service:
     #   exporters: [logging] # List here the platform of your choice
 ```
 
-## Configure the OTLP Receiver (Community Edition)
+## Configure the OTLP Exporter (Community Edition)
 
 By default, the **MetricsHub Agent** pushes the collected metrics to the [`OTLP Receiver`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver) through gRPC on port **TCP/4317**. To push data to the OTLP receiver of your choice:
 

--- a/metricshub-doc/src/site/site.xml
+++ b/metricshub-doc/src/site/site.xml
@@ -98,7 +98,7 @@
 
 		<menu name="Configuration">
 			<item name="Monitoring Configuration" href="configuration/configure-monitoring.html" />
-			<item name="Data export" href="configuration/send-data.html" />
+			<item name="Sending Telemetry" href="configuration/send-telemetry.html" />
 			<item name="Password Encryption" href="security/passwords.html" />
 		</menu>
 


### PR DESCRIPTION
* Renamed the topic Sending Telemetry Data to Observability Platforms
* Renamed the send-data.md file to send-telemetry.md
* Updated site.xml
* Replaced "Configure the OTLP Receiver" with "Configure the OTLP Exporter"