### PR TITLE
Issue #401: Report `hw.network.bandwidth.limit` in bytes/s

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/utils/MappingProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/utils/MappingProcessor.java
@@ -237,7 +237,7 @@ public class MappingProcessor {
 		} else if (isAwkScript(value)) {
 			result.put(key, executeAwkScript(value, key));
 		} else if (isMegaBit2Bit(value)) { // TODO Update this check when the connector references megaBit2byte function instead of megaBit2bit
-			result.put(key, megaBit2byte(value, key));
+			result.put(key, megaBit2Byte(value, key));
 		} else if (isPercentToRatioFunction(value)) {
 			result.put(key, percent2Ratio(value, key));
 		} else if (isMegaHertz2HertzFunction(value)) {
@@ -625,11 +625,11 @@ public class MappingProcessor {
 	/**
 	 * Converts megabit values to byte values.
 	 *
-	 * @param value		String representing a megaBit2byte function with a value in megabits.
-	 * @param key		The attribute key.
-	 * @return			String representing a double value in bytes.
+	 * @param value String representing a megaBit2byte function with a value in megabits.
+	 * @param key   The attribute key.
+	 * @return String representing a double value in bytes.
 	 */
-	private String megaBit2byte(final String value, final String key) {
+	private String megaBit2Byte(final String value, final String key) {
 		final List<String> functionArguments = FunctionArgumentsExtractor.extractArguments(value);
 
 		final Optional<Double> maybeDoubleValue = extractDoubleValue(functionArguments.get(0), key);

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/utils/MappingProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/utils/MappingProcessor.java
@@ -236,8 +236,8 @@ public class MappingProcessor {
 			result.put(key, extractColumnValue(value, key));
 		} else if (isAwkScript(value)) {
 			result.put(key, executeAwkScript(value, key));
-		} else if (isMegaBit2Bit(value)) {
-			result.put(key, megaBit2bit(value, key));
+		} else if (isMegaBit2Bit(value)) { // TODO Update this check when the connector references megaBit2byte function instead of megaBit2bit
+			result.put(key, megaBit2byte(value, key));
 		} else if (isPercentToRatioFunction(value)) {
 			result.put(key, percent2Ratio(value, key));
 		} else if (isMegaHertz2HertzFunction(value)) {
@@ -611,12 +611,30 @@ public class MappingProcessor {
 	 * @param key		The attribute key
 	 * @return			String representing a double value in bits
 	 */
-	private String megaBit2bit(String value, String key) {
+	String megaBit2bit(final String value, final String key) {
 		final List<String> functionArguments = FunctionArgumentsExtractor.extractArguments(value);
 
 		final Optional<Double> maybeDoubleValue = extractDoubleValue(functionArguments.get(0), key);
 		if (maybeDoubleValue.isPresent()) {
 			return multiplyValueByFactor(maybeDoubleValue.get(), MEGABIT_2_BIT_FACTOR);
+		}
+
+		return EMPTY;
+	}
+
+	/**
+	 * Converts megabit values to byte values.
+	 *
+	 * @param value		String representing a megaBit2byte function with a value in megabits.
+	 * @param key		The attribute key.
+	 * @return			String representing a double value in bytes.
+	 */
+	private String megaBit2byte(final String value, final String key) {
+		final List<String> functionArguments = FunctionArgumentsExtractor.extractArguments(value);
+
+		final Optional<Double> maybeDoubleValue = extractDoubleValue(functionArguments.get(0), key);
+		if (maybeDoubleValue.isPresent()) {
+			return multiplyValueByFactor(maybeDoubleValue.get(), MEGABIT_2_BIT_FACTOR / 8.0);
 		}
 
 		return EMPTY;

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/utils/MappingProcessorTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/utils/MappingProcessorTest.java
@@ -63,7 +63,7 @@ class MappingProcessorTest {
 			expected.put("testMebiByte2Byte", "1048576.0");
 			expected.put("testMegaHertz2Hertz", "1000000.0");
 			expected.put("testMilliVolt2Volt", "0.001");
-			expected.put("testMegaBit2Bit", "1000000.0");
+			expected.put("testMegaBit2Bit", "125000.0");
 			expected.put("testPercent2Ratio", "0.1");
 			expected.put("testValue", "10");
 			expected.put("testSourceReferenceKey", "vendor1");
@@ -101,7 +101,7 @@ class MappingProcessorTest {
 				"testMilliVolt2Volt",
 				"0.001",
 				"testMegaBit2Bit",
-				"1000000.0",
+				"125000.0",
 				"testPercent2Ratio",
 				"0.1",
 				"testValue",

--- a/metricshub-hardware/src/it/resources/os/SuperConnectorOsIT/expected/expected.json
+++ b/metricshub-hardware/src/it/resources/os/SuperConnectorOsIT/expected/expected.json
@@ -3273,7 +3273,7 @@
         "previousCollectTime" : null,
         "attributes" : { },
         "resetMetricTime" : false,
-        "value" : 1.0E9,
+        "value" : 1.25E8,
         "previousValue" : null,
         "type" : "NumberMetric",
         "updated" : true
@@ -3404,7 +3404,7 @@
         "previousCollectTime" : null,
         "attributes" : { },
         "resetMetricTime" : false,
-        "value" : 1.0E9,
+        "value" : 1.25E8,
         "previousValue" : null,
         "type" : "NumberMetric",
         "updated" : true
@@ -3548,7 +3548,7 @@
         "previousCollectTime" : null,
         "attributes" : { },
         "resetMetricTime" : false,
-        "value" : 1.0E9,
+        "value" : 1.25E8,
         "previousValue" : null,
         "type" : "NumberMetric",
         "updated" : true
@@ -3730,7 +3730,7 @@
         "previousCollectTime" : null,
         "attributes" : { },
         "resetMetricTime" : false,
-        "value" : 5.6E10,
+        "value" : 7.0E9,
         "previousValue" : null,
         "type" : "NumberMetric",
         "updated" : true

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/HardwareEnergyPostExecutionService.java
@@ -304,26 +304,26 @@ public class HardwareEnergyPostExecutionService implements IPostExecutionService
 
 		// If we don't have the linkSpeed, we can't compute the bandwidth Utilization
 		if (linkSpeed != null && linkSpeed != 0) {
-			final Double transmittedByteRate = HwCollectHelper.calculateMetricRate(
+			final Double transmittedByteRate = HwCollectHelper.calculateMetricRatePerSecond(
 				monitor,
 				"hw.network.io{direction=\"transmit\"}",
 				"__hw.network.io.rate{direction=\"transmit\"}",
 				hostname
 			);
 
-			final Double receivedByteRate = HwCollectHelper.calculateMetricRate(
+			final Double receivedByteRate = HwCollectHelper.calculateMetricRatePerSecond(
 				monitor,
 				"hw.network.io{direction=\"receive\"}",
 				"__hw.network.io.rate{direction=\"receive\"}",
 				hostname
 			);
 
-			// The bandwidths are 'byteRate * 8 / linkSpeed (in Bit/s)'
+			// The bandwidths are 'byteRate / linkSpeed (in Byte/s)'
 			final Double bandwidthUtilizationTransmitted = HwCollectHelper.isValidPositive(transmittedByteRate)
-				? (transmittedByteRate * 8) / linkSpeed
+				? transmittedByteRate / linkSpeed
 				: null;
 			final Double bandwidthUtilizationReceived = HwCollectHelper.isValidPositive(receivedByteRate)
-				? (receivedByteRate * 8) / linkSpeed
+				? receivedByteRate / linkSpeed
 				: null;
 
 			final MetricFactory metricFactory = new MetricFactory(hostname);

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/sustainability/NetworkPowerAndEnergyEstimator.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/sustainability/NetworkPowerAndEnergyEstimator.java
@@ -28,6 +28,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.strategy.utils.CollectHelper;
+import org.sentrysoftware.metricshub.engine.strategy.utils.MathOperationsHelper;
 import org.sentrysoftware.metricshub.engine.telemetry.Monitor;
 import org.sentrysoftware.metricshub.engine.telemetry.TelemetryManager;
 import org.sentrysoftware.metricshub.hardware.util.HwCollectHelper;
@@ -60,7 +61,12 @@ public class NetworkPowerAndEnergyEstimator extends HardwarePowerAndEnergyEstima
 			return 1.0;
 		}
 
-		final Double linkSpeed = CollectHelper.getNumberMetricValue(monitor, "hw.network.bandwidth.limit", false);
+		final Double linkSpeedMegaBit = MathOperationsHelper.divide(
+			"hw.network.bandwidth.limit",
+			CollectHelper.getNumberMetricValue(monitor, "hw.network.bandwidth.limit", false),
+			(1024 * 1024) / 8.0,
+			telemetryManager.getHostname()
+		);
 
 		final Double transmittedBandwidthUtilization = CollectHelper.getNumberMetricValue(
 			monitor,
@@ -74,8 +80,8 @@ public class NetworkPowerAndEnergyEstimator extends HardwarePowerAndEnergyEstima
 		 * Default: (0.5 + 0.5 * bandwidth Utilization) * 5
 		 */
 		if (HwCollectHelper.isValidRatio(transmittedBandwidthUtilization)) {
-			if (HwCollectHelper.isValidPositive(linkSpeed) && linkSpeed > 10) {
-				return (0.5 + 0.5 * transmittedBandwidthUtilization) * 5 * Math.log10(linkSpeed);
+			if (HwCollectHelper.isValidPositive(linkSpeedMegaBit) && linkSpeedMegaBit > 10) {
+				return (0.5 + 0.5 * transmittedBandwidthUtilization) * 5 * Math.log10(linkSpeedMegaBit);
 			} else {
 				return (0.5 + 0.5 * transmittedBandwidthUtilization) * 5;
 			}
@@ -86,9 +92,9 @@ public class NetworkPowerAndEnergyEstimator extends HardwarePowerAndEnergyEstima
 		 * Link Speed > 10: 0.75 * 5 * log10(linkSpeed)
 		 * Default: 2
 		 */
-		if (linkSpeed != null) {
-			if (linkSpeed > 10) {
-				return 0.75 * 5 * Math.log10(linkSpeed);
+		if (linkSpeedMegaBit != null) {
+			if (linkSpeedMegaBit > 10) {
+				return 0.75 * 5 * Math.log10(linkSpeedMegaBit);
 			} else {
 				return 2.0;
 			}

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/util/HwCollectHelper.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/util/HwCollectHelper.java
@@ -25,6 +25,7 @@ import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_VM_POWE
 import static org.sentrysoftware.metricshub.hardware.util.HwConstants.HW_VM_POWER_STATE_METRIC;
 import static org.sentrysoftware.metricshub.hardware.util.HwConstants.PRESENT_STATUS;
 
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -122,14 +123,14 @@ public class HwCollectHelper {
 	}
 
 	/**
-	 * Calculate a rate for the given metric between the current collect and the previous collect
+	 * Calculate a rate per second for the given metric between the current collect and the previous collect
 	 * @param monitor           The monitor from which to retrieve the metric value
 	 * @param counterMetricName The name of the counter metric we want to calculate the rate from
 	 * @param rateMetricName    The name of the rate metric we are caculating
 	 * @param hostname          The hostname
 	 * @return the calculated rate
 	 */
-	public static Double calculateMetricRate(
+	public static Double calculateMetricRatePerSecond(
 		final Monitor monitor,
 		final String counterMetricName,
 		final String rateMetricName,
@@ -140,7 +141,12 @@ public class HwCollectHelper {
 		final Double collectTime = CollectHelper.getNumberMetricCollectTime(monitor, counterMetricName, false);
 		final Double previousCollectTime = CollectHelper.getNumberMetricCollectTime(monitor, counterMetricName, true);
 
-		return MathOperationsHelper.rate(rateMetricName, value, previousValue, collectTime, previousCollectTime, hostname);
+		return Optional
+			.ofNullable(
+				MathOperationsHelper.rate(rateMetricName, value, previousValue, collectTime, previousCollectTime, hostname)
+			)
+			.map(rate -> rate * 1000.0) // Convert rate from per millisecond to per second
+			.orElse(null);
 	}
 
 	/**

--- a/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/sustainability/NetworkPowerAndEnergyEstimatorTest.java
+++ b/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/sustainability/NetworkPowerAndEnergyEstimatorTest.java
@@ -45,25 +45,25 @@ class NetworkPowerAndEnergyEstimatorTest {
 		monitor.addMetric(NETWORK_LINK_STATUS_METRIC, NumberMetric.builder().value(0.0).build());
 		assertEquals(10.0, networkPowerAndEnergyEstimator.estimatePower());
 
-		// linkStatus is up, bandwidthUtilization is null and linkSpeed = 100.0
+		// linkStatus is up, bandwidthUtilization is null and linkSpeed = 100.0 MegaBit
 		// estimated power consumption is 7.5
-		monitor.addMetric(NETWORK_LINK_SPEED_ATTRIBUTE, NumberMetric.builder().value(100.0).build());
+		monitor.addMetric(NETWORK_LINK_SPEED_ATTRIBUTE, NumberMetric.builder().value((100.0 / 8) * 1024 * 1024).build());
 		assertEquals(7.5, networkPowerAndEnergyEstimator.estimatePower());
 
-		// linkStatus is up, bandwidthUtilization is null and linkSpeed = 5.0
+		// linkStatus is up, bandwidthUtilization is null and linkSpeed = 5.0 MegaBit
 		// estimated power consumption is 2.0
-		monitor.addMetric(NETWORK_LINK_SPEED_ATTRIBUTE, NumberMetric.builder().value(5.0).build());
+		monitor.addMetric(NETWORK_LINK_SPEED_ATTRIBUTE, NumberMetric.builder().value((5.0 / 8) * 1024 * 1024).build());
 		assertEquals(2.0, networkPowerAndEnergyEstimator.estimatePower());
 
-		// linkStatus is up, bandwidthUtilization = 0.5, linkSpeed = 100.0
+		// linkStatus is up, bandwidthUtilization = 0.5, linkSpeed = 100.0 MegaBit
 		// estimated power consumption is 7.5
 		monitor.addMetric(NETWORK_TRANSMITTED_BANDWIDTH_UTILIZATION_METRIC, NumberMetric.builder().value(0.5).build());
-		monitor.addMetric(NETWORK_LINK_SPEED_ATTRIBUTE, NumberMetric.builder().value(100.0).build());
+		monitor.addMetric(NETWORK_LINK_SPEED_ATTRIBUTE, NumberMetric.builder().value((100.0 / 8) * 1024 * 1024).build());
 		assertEquals(7.5, networkPowerAndEnergyEstimator.estimatePower());
 
-		// linkStatus is up, bandwidthUtilization = 0.5, linkSpeed = 5.0
+		// linkStatus is up, bandwidthUtilization = 0.5, linkSpeed = 5.0 MegaBit
 		// estimated power consumption is 2.75
-		monitor.addMetric(NETWORK_LINK_SPEED_ATTRIBUTE, NumberMetric.builder().value(5.0).build());
+		monitor.addMetric(NETWORK_LINK_SPEED_ATTRIBUTE, NumberMetric.builder().value((5.0 / 8) * 1024 * 1024).build());
 		assertEquals(3.75, networkPowerAndEnergyEstimator.estimatePower());
 	}
 
@@ -71,7 +71,7 @@ class NetworkPowerAndEnergyEstimatorTest {
 	void testEstimateEnergy() {
 		Monitor monitor = Monitor
 			.builder()
-			.attributes(new HashMap<>(Map.of("name", "real_network_card", NETWORK_LINK_SPEED_ATTRIBUTE, "100.0")))
+			.attributes(new HashMap<>(Map.of("name", "real_network_card")))
 			.metrics(
 				new HashMap<>(
 					Map.of(

--- a/metricshub-oscommand-extension/src/it/resources/os/SuperConnectorOsIT/expected/expected.json
+++ b/metricshub-oscommand-extension/src/it/resources/os/SuperConnectorOsIT/expected/expected.json
@@ -2247,7 +2247,7 @@
         "previousCollectTime" : null,
         "attributes" : { },
         "resetMetricTime" : false,
-        "value" : 1.0E9,
+        "value" : 1.25E8,
         "previousValue" : null,
         "type" : "NumberMetric",
         "updated" : true
@@ -2351,7 +2351,7 @@
         "previousCollectTime" : null,
         "attributes" : { },
         "resetMetricTime" : false,
-        "value" : 1.0E9,
+        "value" : 1.25E8,
         "previousValue" : null,
         "type" : "NumberMetric",
         "updated" : true
@@ -2468,7 +2468,7 @@
         "previousCollectTime" : null,
         "attributes" : { },
         "resetMetricTime" : false,
-        "value" : 1.0E9,
+        "value" : 1.25E8,
         "previousValue" : null,
         "type" : "NumberMetric",
         "updated" : true
@@ -2623,7 +2623,7 @@
         "previousCollectTime" : null,
         "attributes" : { },
         "resetMetricTime" : false,
-        "value" : 5.6E10,
+        "value" : 7.0E9,
         "previousValue" : null,
         "type" : "NumberMetric",
         "updated" : true


### PR DESCRIPTION
- Implemented the `megaBit2Byte` conversion in the Mapping processor.
- Reported `hw.network.io{direction="transmit|receive"}` in bytes per second instead of bytes per millisecond.
- Corrected the computation of `hw.network.bandwidth.utilization` to ensure that both the dividend and divisor are in the same unit (bytes).
- Adjusted the power estimator for network devices because `hw.network.bandwidth.limit` is now measured in bytes.