### PR TITLE
Issue #410: Shallow copy issue when managing multiple hosts in protocol configuration

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/ResourceConfig.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/config/ResourceConfig.java
@@ -110,7 +110,7 @@ public class ResourceConfig {
 
 	/**
 	 * Creates and returns a shallow copy of all the fields in this
-	 * ResourceConfig object except the attributes map which is deeply copied.
+	 * ResourceConfig object except the attributes and protocols maps which are deeply copied.
 	 *
 	 * @return A new ResourceConfig object with the same property values as this one.
 	 */
@@ -134,7 +134,10 @@ public class ResourceConfig {
 					)
 			)
 			.metrics(metrics)
-			.protocols(protocols)
+			// Deep copies the IConfigurations
+			.protocols(
+				protocols.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().copy()))
+			)
 			.variables(variables)
 			.connectors(connectors)
 			.connector(connector)

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/IConfiguration.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/configuration/IConfiguration.java
@@ -53,4 +53,13 @@ public interface IConfiguration {
 	 *         necessary criteria.
 	 */
 	void validateConfiguration(String resourceKey) throws InvalidConfigurationException;
+
+	/**
+	 * Creates and returns a deep copy of the current {@code IConfiguration} instance.
+	 * The returned instance will have the same attribute values as the original,
+	 * but modifications to either instance will not affect the other.
+	 *
+	 * @return a new {@code IConfiguration} instance that is a deep copy of the original.
+	 */
+	IConfiguration copy();
 }

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/configuration/OsCommandTestConfiguration.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/configuration/OsCommandTestConfiguration.java
@@ -75,4 +75,9 @@ public class OsCommandTestConfiguration implements IConfiguration {
 	public String toString() {
 		return "Local Commands";
 	}
+
+	@Override
+	public IConfiguration copy() {
+		return null;
+	}
 }

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/extension/TestConfiguration.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/extension/TestConfiguration.java
@@ -21,4 +21,9 @@ public class TestConfiguration implements IConfiguration {
 
 	@Override
 	public void setHostname(String hostname) {}
+
+	@Override
+	public IConfiguration copy() {
+		return null;
+	}
 }

--- a/metricshub-http-extension/pom.xml
+++ b/metricshub-http-extension/pom.xml
@@ -18,6 +18,7 @@
 		<dependency>
 			<groupId>org.sentrysoftware</groupId>
 			<artifactId>metricshub-engine</artifactId>
+			<version>0.9.07-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/metricshub-http-extension/pom.xml
+++ b/metricshub-http-extension/pom.xml
@@ -18,7 +18,6 @@
 		<dependency>
 			<groupId>org.sentrysoftware</groupId>
 			<artifactId>metricshub-engine</artifactId>
-			<version>0.9.07-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/metricshub-http-extension/src/main/java/org/sentrysoftware/metricshub/extension/http/HttpConfiguration.java
+++ b/metricshub-http-extension/src/main/java/org/sentrysoftware/metricshub/extension/http/HttpConfiguration.java
@@ -100,4 +100,16 @@ public class HttpConfiguration implements IConfiguration {
 				)
 		);
 	}
+
+	@Override
+	public IConfiguration copy() {
+		return HttpConfiguration
+			.builder()
+			.username(username)
+			.password(password)
+			.https(https)
+			.port(port)
+			.timeout(timeout)
+			.build();
+	}
 }

--- a/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/HttpConfigurationTest.java
+++ b/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/HttpConfigurationTest.java
@@ -2,10 +2,12 @@ package org.sentrysoftware.metricshub.extension.http;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 
 /**
  * Test of {@link HttpConfiguration}
@@ -66,6 +68,11 @@ class HttpConfigurationTest {
 			.username("username")
 			.build();
 
-		assertEquals(httpConfiguration, httpConfiguration.copy());
+		final IConfiguration httpConfigurationCopy = httpConfiguration.copy();
+		// Verify that the copied configuration has the same values as the original configuration
+		assertEquals(httpConfiguration, httpConfigurationCopy);
+
+		// Ensure that the copied configuration is a distinct object
+		assert (httpConfiguration != httpConfigurationCopy);
 	}
 }

--- a/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/HttpConfigurationTest.java
+++ b/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/HttpConfigurationTest.java
@@ -54,4 +54,18 @@ class HttpConfigurationTest {
 			HttpConfiguration.builder().timeout(60L).port(1234).build().validateConfiguration(RESOURCE_KEY)
 		);
 	}
+
+	@Test
+	void testCopy() {
+		final HttpConfiguration httpConfiguration = HttpConfiguration
+			.builder()
+			.https(true)
+			.password("password".toCharArray())
+			.port(100)
+			.timeout(100L)
+			.username("username")
+			.build();
+
+		assertEquals(httpConfiguration, httpConfiguration.copy());
+	}
 }

--- a/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/HttpExtensionTest.java
+++ b/metricshub-http-extension/src/test/java/org/sentrysoftware/metricshub/extension/http/HttpExtensionTest.java
@@ -145,6 +145,11 @@ class HttpExtensionTest {
 
 					@Override
 					public void setHostname(String hostname) {}
+
+					@Override
+					public IConfiguration copy() {
+						return null;
+					}
 				}
 			)
 		);

--- a/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiConfiguration.java
+++ b/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiConfiguration.java
@@ -87,4 +87,16 @@ public class IpmiConfiguration implements IConfiguration {
 				)
 		);
 	}
+
+	@Override
+	public IConfiguration copy() {
+		return IpmiConfiguration
+			.builder()
+			.bmcKey(bmcKey)
+			.password(password)
+			.skipAuth(skipAuth)
+			.timeout(timeout)
+			.username(username)
+			.build();
+	}
 }

--- a/metricshub-ipmi-extension/src/test/java/org/sentrysoftware/IpmiConfigurationTest.java
+++ b/metricshub-ipmi-extension/src/test/java/org/sentrysoftware/IpmiConfigurationTest.java
@@ -61,4 +61,18 @@ class IpmiConfigurationTest {
 			assertThrows(InvalidConfigurationException.class, () -> ipmiConfig.validateConfiguration(resourceKey));
 		}
 	}
+
+	@Test
+	void testCopy() {
+		final IpmiConfiguration ipmiConfiguration = IpmiConfiguration
+			.builder()
+			.bmcKey(BMC_KEY)
+			.password(PASSWORD.toCharArray())
+			.skipAuth(false)
+			.timeout(100L)
+			.username(USERNAME)
+			.build();
+
+		assertEquals(ipmiConfiguration, ipmiConfiguration.copy());
+	}
 }

--- a/metricshub-ipmi-extension/src/test/java/org/sentrysoftware/IpmiConfigurationTest.java
+++ b/metricshub-ipmi-extension/src/test/java/org/sentrysoftware/IpmiConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 import org.sentrysoftware.metricshub.extension.ipmi.IpmiConfiguration;
 
 /**
@@ -73,6 +74,12 @@ class IpmiConfigurationTest {
 			.username(USERNAME)
 			.build();
 
-		assertEquals(ipmiConfiguration, ipmiConfiguration.copy());
+		final IConfiguration ipmiConfigurationCopy = ipmiConfiguration.copy();
+
+		// Verify that the copied configuration has the same values as the original configuration
+		assertEquals(ipmiConfiguration, ipmiConfigurationCopy);
+
+		// Ensure that the copied configuration is a distinct object
+		assert (ipmiConfiguration != ipmiConfigurationCopy);
 	}
 }

--- a/metricshub-ipmi-extension/src/test/java/org/sentrysoftware/IpmiExtensionTest.java
+++ b/metricshub-ipmi-extension/src/test/java/org/sentrysoftware/IpmiExtensionTest.java
@@ -143,6 +143,11 @@ class IpmiExtensionTest {
 
 					@Override
 					public void setHostname(String hostname) {}
+
+					@Override
+					public IConfiguration copy() {
+						return null;
+					}
 				}
 			)
 		);

--- a/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfiguration.java
+++ b/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfiguration.java
@@ -105,4 +105,15 @@ public class OsCommandConfiguration implements IConfiguration {
 	public String toString() {
 		return "Local Commands";
 	}
+
+	@Override
+	public IConfiguration copy() {
+		return OsCommandConfiguration
+			.builder()
+			.sudoCommand(sudoCommand)
+			.timeout(timeout)
+			.useSudo(useSudo)
+			.useSudoCommands(useSudoCommands)
+			.build();
+	}
 }

--- a/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfiguration.java
+++ b/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfiguration.java
@@ -113,7 +113,7 @@ public class OsCommandConfiguration implements IConfiguration {
 			.sudoCommand(sudoCommand)
 			.timeout(timeout)
 			.useSudo(useSudo)
-			.useSudoCommands(useSudoCommands)
+			.useSudoCommands(new HashSet<>(useSudoCommands))
 			.build();
 	}
 }

--- a/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/SshConfiguration.java
+++ b/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/SshConfiguration.java
@@ -127,4 +127,18 @@ public class SshConfiguration extends OsCommandConfiguration {
 		}
 		return desc;
 	}
+
+	public SshConfiguration copy() {
+		return SshConfiguration
+			.sshConfigurationBuilder()
+			.password(password)
+			.port(port)
+			.privateKey(privateKey)
+			.sudoCommand(sudoCommand)
+			.timeout(timeout)
+			.username(username)
+			.useSudo(useSudo)
+			.useSudoCommands(useSudoCommands)
+			.build();
+	}
 }

--- a/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/SshConfiguration.java
+++ b/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/SshConfiguration.java
@@ -24,6 +24,7 @@ package org.sentrysoftware.metricshub.extension.oscommand;
 import static com.fasterxml.jackson.annotation.Nulls.SKIP;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
+import java.util.HashSet;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Data;
@@ -128,6 +129,7 @@ public class SshConfiguration extends OsCommandConfiguration {
 		return desc;
 	}
 
+	@Override
 	public SshConfiguration copy() {
 		return SshConfiguration
 			.sshConfigurationBuilder()
@@ -138,7 +140,7 @@ public class SshConfiguration extends OsCommandConfiguration {
 			.timeout(timeout)
 			.username(username)
 			.useSudo(useSudo)
-			.useSudoCommands(useSudoCommands)
+			.useSudoCommands(new HashSet<>(useSudoCommands))
 			.build();
 	}
 }

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfigurationTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfigurationTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 
 /**
  * Test of {@link OsCommandConfiguration}
@@ -44,6 +45,13 @@ class OsCommandConfigurationTest {
 			.useSudoCommands(Set.of("sudo"))
 			.useSudo(true)
 			.build();
-		assertEquals(osCommandConfiguration, osCommandConfiguration.copy());
+
+		final IConfiguration osCommandConfigurationCopy = osCommandConfiguration.copy();
+
+		// Verify that the copied configuration has the same values as the original configuration
+		assertEquals(osCommandConfiguration, osCommandConfigurationCopy);
+
+		// Ensure that the copied configuration is a distinct object
+		assert (osCommandConfiguration != osCommandConfigurationCopy);
 	}
 }

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfigurationTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfigurationTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
-import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 
 /**
  * Test of {@link OsCommandConfiguration}
@@ -46,12 +45,13 @@ class OsCommandConfigurationTest {
 			.useSudo(true)
 			.build();
 
-		final IConfiguration osCommandConfigurationCopy = osCommandConfiguration.copy();
+		final OsCommandConfiguration osCommandConfigurationCopy = (OsCommandConfiguration) osCommandConfiguration.copy();
 
 		// Verify that the copied configuration has the same values as the original configuration
 		assertEquals(osCommandConfiguration, osCommandConfigurationCopy);
 
 		// Ensure that the copied configuration is a distinct object
 		assert (osCommandConfiguration != osCommandConfigurationCopy);
+		assert (osCommandConfiguration.getUseSudoCommands() != osCommandConfigurationCopy.getUseSudoCommands());
 	}
 }

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfigurationTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfigurationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 
@@ -32,5 +33,17 @@ class OsCommandConfigurationTest {
 
 		osConfiguration.setTimeout(-1L);
 		assertThrows(InvalidConfigurationException.class, () -> osConfiguration.validateConfiguration(resourceKey));
+	}
+
+	@Test
+	void testCopy() {
+		final OsCommandConfiguration osCommandConfiguration = OsCommandConfiguration
+			.builder()
+			.sudoCommand("sudoCommand")
+			.timeout(100L)
+			.useSudoCommands(Set.of("sudo"))
+			.useSudo(true)
+			.build();
+		assertEquals(osCommandConfiguration, osCommandConfiguration.copy());
 	}
 }

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtensionTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtensionTest.java
@@ -128,6 +128,11 @@ class OsCommandExtensionTest {
 
 					@Override
 					public void setHostname(String hostname) {}
+
+					@Override
+					public IConfiguration copy() {
+						return null;
+					}
 				}
 			)
 		);

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/SshConfigurationTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/SshConfigurationTest.java
@@ -83,4 +83,21 @@ class SshConfigurationTest {
 		sshConfiguration.setUsername(" ");
 		assertThrows(InvalidConfigurationException.class, () -> sshConfiguration.validateConfiguration(resourceKey));
 	}
+
+	@Test
+	void testCopy() {
+		final SshConfiguration sshConfiguration = SshConfiguration
+			.sshConfigurationBuilder()
+			.password(PASSWORD.toCharArray())
+			.port(100)
+			.privateKey("privateKey")
+			.sudoCommand(SSH_SUDO_COMMAND)
+			.timeout(SSH_CONFIGURATION_TIMEOUT)
+			.username(USERNAME)
+			.useSudo(false)
+			.useSudoCommands(Set.of("sudo"))
+			.build();
+
+		assertEquals(sshConfiguration, sshConfiguration.copy());
+	}
 }

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/SshConfigurationTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/SshConfigurationTest.java
@@ -98,6 +98,13 @@ class SshConfigurationTest {
 			.useSudoCommands(Set.of("sudo"))
 			.build();
 
-		assertEquals(sshConfiguration, sshConfiguration.copy());
+		final SshConfiguration sshConfigurationCopy = sshConfiguration.copy();
+
+		// Verify that the copied configuration has the same values as the original configuration
+		assertEquals(sshConfiguration, sshConfigurationCopy);
+
+		// Ensure that the copied configuration is a distinct object
+		assert (sshConfiguration != sshConfigurationCopy);
+		assert (sshConfiguration.getUseSudoCommands() != sshConfigurationCopy.getUseSudoCommands());
 	}
 }

--- a/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingConfiguration.java
+++ b/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingConfiguration.java
@@ -69,4 +69,9 @@ public class PingConfiguration implements IConfiguration {
 				)
 		);
 	}
+
+	@Override
+	public IConfiguration copy() {
+		return PingConfiguration.builder().timeout(timeout).build();
+	}
 }

--- a/metricshub-ping-extension/src/test/java/org/sentrysoftware/metricshub/extension/ping/PingConfigurationTest.java
+++ b/metricshub-ping-extension/src/test/java/org/sentrysoftware/metricshub/extension/ping/PingConfigurationTest.java
@@ -1,6 +1,7 @@
 package org.sentrysoftware.metricshub.extension.ping;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -24,5 +25,12 @@ class PingConfigurationTest {
 			() -> PingConfiguration.builder().timeout(null).build().validateConfiguration(RESOURCE_KEY)
 		);
 		assertDoesNotThrow(() -> PingConfiguration.builder().timeout(60L).build().validateConfiguration(RESOURCE_KEY));
+	}
+
+	@Test
+	void testCopy() {
+		final PingConfiguration pingConfiguration = PingConfiguration.builder().timeout(100L).build();
+
+		assertEquals(pingConfiguration, pingConfiguration.copy());
 	}
 }

--- a/metricshub-ping-extension/src/test/java/org/sentrysoftware/metricshub/extension/ping/PingConfigurationTest.java
+++ b/metricshub-ping-extension/src/test/java/org/sentrysoftware/metricshub/extension/ping/PingConfigurationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 
 /**
  * Test of {@link PingConfiguration}
@@ -31,6 +32,12 @@ class PingConfigurationTest {
 	void testCopy() {
 		final PingConfiguration pingConfiguration = PingConfiguration.builder().timeout(100L).build();
 
-		assertEquals(pingConfiguration, pingConfiguration.copy());
+		final IConfiguration pingConfigurationCopy = pingConfiguration.copy();
+
+		// Verify that the copied configuration has the same values as the original configuration
+		assertEquals(pingConfiguration, pingConfigurationCopy);
+
+		// Ensure that the copied configuration is a distinct object
+		assert (pingConfiguration != pingConfigurationCopy);
 	}
 }

--- a/metricshub-ping-extension/src/test/java/org/sentrysoftware/metricshub/extension/ping/PingExtensionTest.java
+++ b/metricshub-ping-extension/src/test/java/org/sentrysoftware/metricshub/extension/ping/PingExtensionTest.java
@@ -127,6 +127,11 @@ class PingExtensionTest {
 
 					@Override
 					public void setHostname(String hostname) {}
+
+					@Override
+					public IConfiguration copy() {
+						return null;
+					}
 				}
 			)
 		);

--- a/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfiguration.java
+++ b/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfiguration.java
@@ -34,6 +34,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 
 /**
@@ -168,5 +169,10 @@ public class SnmpConfiguration implements ISnmpConfiguration {
 	@Override
 	public int getIntVersion() {
 		return version.intVersion;
+	}
+
+	@Override
+	public IConfiguration copy() {
+		return SnmpConfiguration.builder().community(community).port(port).timeout(timeout).version(version).build();
 	}
 }

--- a/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfigurationTest.java
+++ b/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 import org.sentrysoftware.metricshub.extension.snmp.SnmpConfiguration.SnmpVersion;
 
 class SnmpConfigurationTest {
@@ -121,6 +122,12 @@ class SnmpConfigurationTest {
 			.version(SnmpVersion.V2C)
 			.build();
 
-		assertEquals(snmpConfiguration, snmpConfiguration.copy());
+		final IConfiguration snmpConfigurationCopy = snmpConfiguration.copy();
+
+		// Verify that the copied configuration has the same values as the original configuration
+		assertEquals(snmpConfiguration, snmpConfigurationCopy);
+
+		// Ensure that the copied configuration is a distinct object
+		assert (snmpConfiguration != snmpConfigurationCopy);
 	}
 }

--- a/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfigurationTest.java
+++ b/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfigurationTest.java
@@ -110,4 +110,17 @@ class SnmpConfigurationTest {
 		assertEquals(SnmpVersion.V2C, SnmpVersion.interpretValueOf("v2c"));
 		assertEquals(SnmpVersion.V2C, SnmpVersion.interpretValueOf("2c"));
 	}
+
+	@Test
+	void testCopy() {
+		final SnmpConfiguration snmpConfiguration = SnmpConfiguration
+			.builder()
+			.community("public".toCharArray())
+			.port(100)
+			.timeout(100L)
+			.version(SnmpVersion.V2C)
+			.build();
+
+		assertEquals(snmpConfiguration, snmpConfiguration.copy());
+	}
 }

--- a/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpExtensionTest.java
+++ b/metricshub-snmp-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmp/SnmpExtensionTest.java
@@ -521,6 +521,11 @@ class SnmpExtensionTest {
 
 					@Override
 					public void setHostname(String hostname) {}
+
+					@Override
+					public IConfiguration copy() {
+						return null;
+					}
 				}
 			)
 		);

--- a/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Configuration.java
+++ b/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Configuration.java
@@ -33,6 +33,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 import org.sentrysoftware.metricshub.extension.snmp.ISnmpConfiguration;
 
@@ -201,5 +202,21 @@ public class SnmpV3Configuration implements ISnmpConfiguration {
 	@Override
 	public int getIntVersion() {
 		return V3;
+	}
+
+	@Override
+	public IConfiguration copy() {
+		return SnmpV3Configuration
+			.builder()
+			.authType(authType)
+			.contextName(contextName)
+			.password(password)
+			.port(port)
+			.privacy(privacy)
+			.privacyPassword(privacyPassword)
+			.retryIntervals(retryIntervals)
+			.timeout(timeout)
+			.username(username)
+			.build();
 	}
 }

--- a/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ConfigurationTest.java
+++ b/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ConfigurationTest.java
@@ -146,4 +146,22 @@ class SnmpV3ConfigurationTest {
 	void testPrivacyInterpretValueOf_InvalidValue() {
 		assertThrows(IllegalArgumentException.class, () -> Privacy.interpretValueOf("INVALID_PRIVACY"));
 	}
+
+	@Test
+	void testCopy() {
+		final SnmpV3Configuration snmpV3Configuration = SnmpV3Configuration
+			.builder()
+			.authType(AuthType.MD5)
+			.contextName("context")
+			.password("password".toCharArray())
+			.port(100)
+			.privacy(Privacy.AES)
+			.privacyPassword("privacyPassword".toCharArray())
+			.retryIntervals(new int[] { 10, 10 })
+			.timeout(100L)
+			.username("username")
+			.build();
+
+		assertEquals(snmpV3Configuration, snmpV3Configuration.copy());
+	}
 }

--- a/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ConfigurationTest.java
+++ b/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 import org.sentrysoftware.metricshub.extension.snmpv3.SnmpV3Configuration.AuthType;
 import org.sentrysoftware.metricshub.extension.snmpv3.SnmpV3Configuration.Privacy;
 
@@ -162,6 +163,12 @@ class SnmpV3ConfigurationTest {
 			.username("username")
 			.build();
 
-		assertEquals(snmpV3Configuration, snmpV3Configuration.copy());
+		final IConfiguration snmpV3ConfigurationCopy = snmpV3Configuration.copy();
+
+		// Verify that the copied configuration has the same values as the original configuration
+		assertEquals(snmpV3Configuration, snmpV3ConfigurationCopy);
+
+		// Ensure that the copied configuration is a distinct object
+		assert (snmpV3Configuration != snmpV3ConfigurationCopy);
 	}
 }

--- a/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ExtensionTest.java
+++ b/metricshub-snmpv3-extension/src/test/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3ExtensionTest.java
@@ -525,6 +525,11 @@ class SnmpV3ExtensionTest {
 
 					@Override
 					public void setHostname(String hostname) {}
+
+					@Override
+					public IConfiguration copy() {
+						return null;
+					}
 				}
 			)
 		);

--- a/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfiguration.java
+++ b/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfiguration.java
@@ -133,4 +133,18 @@ public class WbemConfiguration implements IConfiguration {
 				)
 		);
 	}
+
+	@Override
+	public IConfiguration copy() {
+		return WbemConfiguration
+			.builder()
+			.namespace(namespace)
+			.password(password)
+			.port(port)
+			.protocol(protocol)
+			.timeout(timeout)
+			.username(username)
+			.vCenter(vCenter)
+			.build();
+	}
 }

--- a/metricshub-wbem-extension/src/test/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfigurationTest.java
+++ b/metricshub-wbem-extension/src/test/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfigurationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.TransportProtocols;
 
 /**
  * Test of {@link WbemConfiguration}
@@ -78,5 +79,21 @@ class WbemConfigurationTest {
 				.build()
 				.validateConfiguration(resourceKey)
 		);
+	}
+
+	@Test
+	void testCopy() {
+		final WbemConfiguration wbemConfiguration = WbemConfiguration
+			.builder()
+			.namespace(WBEM_NAMESPACE)
+			.password(PASSWORD.toCharArray())
+			.port(100)
+			.protocol(TransportProtocols.HTTPS)
+			.timeout(100L)
+			.username(USERNAME)
+			.vCenter(WBEM_VCENTER)
+			.build();
+
+		assertEquals(wbemConfiguration, wbemConfiguration.copy());
 	}
 }

--- a/metricshub-wbem-extension/src/test/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfigurationTest.java
+++ b/metricshub-wbem-extension/src/test/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfigurationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 import org.sentrysoftware.metricshub.engine.configuration.TransportProtocols;
 
 /**
@@ -94,6 +95,12 @@ class WbemConfigurationTest {
 			.vCenter(WBEM_VCENTER)
 			.build();
 
-		assertEquals(wbemConfiguration, wbemConfiguration.copy());
+		final IConfiguration wbemConfigurationCopy = wbemConfiguration.copy();
+
+		// Verify that the copied configuration has the same values as the original configuration
+		assertEquals(wbemConfiguration, wbemConfigurationCopy);
+
+		// Ensure that the copied configuration is a distinct object
+		assert (wbemConfiguration != wbemConfigurationCopy);
 	}
 }

--- a/metricshub-wbem-extension/src/test/java/org/sentrysoftware/metricshub/extension/wbem/WbemExtensionTest.java
+++ b/metricshub-wbem-extension/src/test/java/org/sentrysoftware/metricshub/extension/wbem/WbemExtensionTest.java
@@ -165,6 +165,11 @@ class WbemExtensionTest {
 
 					@Override
 					public void setHostname(String hostname) {}
+
+					@Override
+					public IConfiguration copy() {
+						return null;
+					}
 				}
 			)
 		);

--- a/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/WmiTestConfiguration.java
+++ b/metricshub-win-extension-common/src/test/java/org/sentrysoftware/metricshub/extension/win/WmiTestConfiguration.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Data;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 
 @Data
 @Builder
@@ -20,4 +21,9 @@ public class WmiTestConfiguration implements IWinConfiguration {
 
 	@Override
 	public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {}
+
+	@Override
+	public IConfiguration copy() {
+		return null;
+	}
 }

--- a/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
+++ b/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
@@ -33,6 +33,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 import org.sentrysoftware.metricshub.engine.configuration.TransportProtocols;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 import org.sentrysoftware.metricshub.extension.win.IWinConfiguration;
@@ -119,5 +120,19 @@ public class WinRmConfiguration implements IWinConfiguration {
 			desc = desc + " as " + username;
 		}
 		return desc;
+	}
+
+	@Override
+	public IConfiguration copy() {
+		return WinRmConfiguration
+			.builder()
+			.authentications(authentications)
+			.namespace(namespace)
+			.password(password)
+			.port(port)
+			.protocol(protocol)
+			.timeout(timeout)
+			.username(username)
+			.build();
 	}
 }

--- a/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
+++ b/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
@@ -25,6 +25,7 @@ import static com.fasterxml.jackson.annotation.Nulls.SKIP;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -126,7 +127,7 @@ public class WinRmConfiguration implements IWinConfiguration {
 	public IConfiguration copy() {
 		return WinRmConfiguration
 			.builder()
-			.authentications(authentications)
+			.authentications(new ArrayList<>(authentications))
 			.namespace(namespace)
 			.password(password)
 			.port(port)

--- a/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfigurationTest.java
+++ b/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfigurationTest.java
@@ -4,8 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.TransportProtocols;
+import org.sentrysoftware.winrm.service.client.auth.AuthenticationEnum;
 
 class WinRmConfigurationTest {
 
@@ -47,5 +50,21 @@ class WinRmConfigurationTest {
 				.build()
 				.toString()
 		);
+	}
+
+	@Test
+	void testCopy() {
+		final WinRmConfiguration winRmConfiguration = WinRmConfiguration
+			.builder()
+			.authentications(List.of(AuthenticationEnum.KERBEROS))
+			.namespace("namespace")
+			.password("password".toCharArray())
+			.port(100)
+			.protocol(TransportProtocols.HTTPS)
+			.timeout(100L)
+			.username("username")
+			.build();
+
+		assertEquals(winRmConfiguration, winRmConfiguration.copy());
 	}
 }

--- a/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfigurationTest.java
+++ b/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfigurationTest.java
@@ -65,6 +65,13 @@ class WinRmConfigurationTest {
 			.username("username")
 			.build();
 
-		assertEquals(winRmConfiguration, winRmConfiguration.copy());
+		final WinRmConfiguration winRmConfigurationCopy = (WinRmConfiguration) winRmConfiguration.copy();
+
+		// Verify that the copied configuration has the same values as the original configuration
+		assertEquals(winRmConfiguration, winRmConfigurationCopy);
+
+		// Ensure that the copied configuration is a distinct object
+		assert (winRmConfiguration != winRmConfigurationCopy);
+		assert (winRmConfiguration.getAuthentications() != winRmConfigurationCopy.getAuthentications());
 	}
 }

--- a/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtensionTest.java
+++ b/metricshub-winrm-extension/src/test/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtensionTest.java
@@ -201,6 +201,11 @@ class WinRmExtensionTest {
 
 					@Override
 					public void setHostname(String hostname) {}
+
+					@Override
+					public IConfiguration copy() {
+						return null;
+					}
 				}
 			)
 		);

--- a/metricshub-wmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/wmi/WmiConfiguration.java
+++ b/metricshub-wmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/wmi/WmiConfiguration.java
@@ -32,6 +32,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 import org.sentrysoftware.metricshub.extension.win.IWinConfiguration;
 
@@ -79,5 +80,16 @@ public class WmiConfiguration implements IWinConfiguration {
 					timeout
 				)
 		);
+	}
+
+	@Override
+	public IConfiguration copy() {
+		return WmiConfiguration
+			.builder()
+			.namespace(namespace)
+			.password(password)
+			.timeout(timeout)
+			.username(username)
+			.build();
 	}
 }

--- a/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiConfigurationTest.java
+++ b/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiConfigurationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 
 class WmiConfigurationTest {
 
@@ -56,6 +57,13 @@ class WmiConfigurationTest {
 			.timeout(100L)
 			.username("username")
 			.build();
-		assertEquals(wmiConfiguration, wmiConfiguration.copy());
+
+		final IConfiguration wmiConfigurationCopy = wmiConfiguration.copy();
+
+		// Verify that the copied configuration has the same values as the original configuration
+		assertEquals(wmiConfiguration, wmiConfigurationCopy);
+
+		// Ensure that the copied configuration is a distinct object
+		assert (wmiConfiguration != wmiConfigurationCopy);
 	}
 }

--- a/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiConfigurationTest.java
+++ b/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiConfigurationTest.java
@@ -46,4 +46,16 @@ class WmiConfigurationTest {
 				.toString()
 		);
 	}
+
+	@Test
+	void testCopy() {
+		final WmiConfiguration wmiConfiguration = WmiConfiguration
+			.builder()
+			.namespace("namespace")
+			.password("password".toCharArray())
+			.timeout(100L)
+			.username("username")
+			.build();
+		assertEquals(wmiConfiguration, wmiConfiguration.copy());
+	}
 }

--- a/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtensionTest.java
+++ b/metricshub-wmi-extension/src/test/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtensionTest.java
@@ -208,6 +208,11 @@ class WmiExtensionTest {
 
 					@Override
 					public void setHostname(String hostname) {}
+
+					@Override
+					public IConfiguration copy() {
+						return null;
+					}
 				}
 			)
 		);


### PR DESCRIPTION

* Added `copy()` method to IConfiguration interface.
* Implemented `copy()` on all the IConfiguration implementations.
* Fixed shallow copy bug on ResourceConfig by deep copying protocols.
* Created unit tests on all IConfiguration impementations.
* Tested on the metricshub agent.

# Before
<img width="1299" alt="Before fixing" src="https://github.com/user-attachments/assets/01fd766e-b306-47e2-891b-5f0fd3da6f72">

# After
<img width="851" alt="After Fixing" src="https://github.com/user-attachments/assets/33952ee0-af3c-4394-90d6-9fa3757ca809">
