### PR TITLE
Issue #374: Add the possibility to add default connector variables 

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConfigHelper.java
@@ -828,19 +828,16 @@ public class ConfigHelper {
 			// Retrieve connectors variables map from the resource configuration
 			final Map<String, ConnectorVariables> connectorVariablesMap = resourceConfig.getVariables();
 
-			// If connectors variables exist then merge the existing connector store with a new one containing custom connectors
-			if (connectorVariablesMap != null && !connectorVariablesMap.isEmpty()) {
-				// Call ConnectorTemplateLibraryParser and parse the custom connectors
-				final ConnectorTemplateLibraryParser connectorTemplateLibraryParser = new ConnectorTemplateLibraryParser();
+			// Call ConnectorTemplateLibraryParser and parse the custom connectors
+			final ConnectorTemplateLibraryParser connectorTemplateLibraryParser = new ConnectorTemplateLibraryParser();
 
-				final Map<String, Connector> customConnectors = connectorTemplateLibraryParser.parse(
-					ConfigHelper.getSubDirectory("connectors", false),
-					connectorVariablesMap
-				);
+			final Map<String, Connector> customConnectors = connectorTemplateLibraryParser.parse(
+				ConfigHelper.getSubDirectory("connectors", false),
+				connectorVariablesMap
+			);
 
-				// Overwrite resourceConnectorStore
-				updateConnectorStore(resourceConnectorStore, customConnectors);
-			}
+			// Overwrite resourceConnectorStore
+			updateConnectorStore(resourceConnectorStore, customConnectors);
 
 			resourceGroupTelemetryManagers.putIfAbsent(
 				resourceKey,

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConnectorTemplateLibraryParser.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/helper/ConnectorTemplateLibraryParser.java
@@ -98,13 +98,14 @@ public class ConnectorTemplateLibraryParser {
 			);
 
 			// Retrieve the default connector variables that have been specified in this connector.
-			Map<String, ConnectorDefaultVariable> connectorDefaultVariables = getConnectorVariables(connectorNode);
+			final Map<String, ConnectorDefaultVariable> connectorDefaultVariables = getConnectorVariables(connectorNode);
 
 			// User didn't configure variables for this connector, and no connector default variables are configured
 			if (connectorUserVariables.getVariableValues().isEmpty() && connectorDefaultVariables.isEmpty()) {
 				return FileVisitResult.CONTINUE;
 			}
 
+			// For each configured default connector variable, if the user didn't specify a value to that variable, user default value.
 			for (final Entry<String, ConnectorDefaultVariable> entry : connectorDefaultVariables.entrySet()) {
 				connectorUserVariables.getVariableValues().putIfAbsent(entry.getKey(), entry.getValue().getDefaultValue());
 			}

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/helper/ConnectorTemplateLibraryParserTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/helper/ConnectorTemplateLibraryParserTest.java
@@ -1,14 +1,20 @@
 package org.sentrysoftware.metricshub.agent.helper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.sentrysoftware.metricshub.engine.connector.model.identity.ConnectionType.LOCAL;
+import static org.sentrysoftware.metricshub.engine.connector.model.identity.ConnectionType.REMOTE;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.configuration.ConnectorVariables;
 import org.sentrysoftware.metricshub.engine.connector.model.Connector;
+import org.sentrysoftware.metricshub.engine.connector.model.identity.Detection;
+import org.sentrysoftware.metricshub.engine.connector.model.identity.criterion.SnmpGetNextCriterion;
 
 class ConnectorTemplateLibraryParserTest {
 
@@ -21,17 +27,34 @@ class ConnectorTemplateLibraryParserTest {
 
 		// Call ConnectorTemplateLibraryParser to parse the custom connectors files using the connectorVariables map and the connector id
 		final ConnectorTemplateLibraryParser connectorTemplateLibraryParser = new ConnectorTemplateLibraryParser();
-		final ConnectorVariables connectorVariables = new ConnectorVariables(Map.of("snmp-get-next", "snmpGetNext"));
+
+		final ConnectorVariables connectorVariables = new ConnectorVariables(new HashMap<>());
+		connectorVariables.addVariableValue("snmp-get-next", "snmpGetNext");
+		connectorVariables.addVariableValue("local-variable", "local");
+		final Map<String, ConnectorVariables> connectorVariablesMap = new HashMap<>();
+		connectorVariablesMap.put(CONNECTOR_ID, connectorVariables);
 		final Map<String, Connector> customConnectorsMap = connectorTemplateLibraryParser.parse(
 			yamlTestPath,
-			Map.of(CONNECTOR_ID, connectorVariables)
+			connectorVariablesMap
 		);
 
 		// Check that only the connector containing variables is returned in the map
 		assertEquals(1, customConnectorsMap.size());
 
-		// Check that the connector variable value was successfully replaced
+		// Check that the connector variable value was successfully replaced.
 		final Connector customConnector = customConnectorsMap.get(CONNECTOR_ID);
-		assertEquals("snmpGetNext", customConnector.getConnectorIdentity().getDetection().getCriteria().get(0).getType());
+		final Detection detection = customConnector.getConnectorIdentity().getDetection();
+		// Both user's and default values are set, the priority is for the user's variable value.
+		assertEquals("snmpGetNext", detection.getCriteria().get(0).getType());
+		// User's value set, no default value.
+		assertEquals(Set.of(REMOTE, LOCAL), detection.getConnectionTypes());
+		// User's value not set, default value is set.
+		SnmpGetNextCriterion criterion = (SnmpGetNextCriterion) detection.getCriteria().get(0);
+		assertEquals("1.3.6.1.4.1.795.10.1.1.3.1.1", criterion.getOid());
+		// User's value not set, default value not set, variable remains unchanged.
+		assertEquals(
+			"${var::oid-description}",
+			customConnector.getConnectorIdentity().getVariables().get("oid").getDescription().trim()
+		);
 	}
 }

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/helper/ConnectorTemplateLibraryParserTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/helper/ConnectorTemplateLibraryParserTest.java
@@ -49,7 +49,7 @@ class ConnectorTemplateLibraryParserTest {
 		// User's value set, no default value.
 		assertEquals(Set.of(REMOTE, LOCAL), detection.getConnectionTypes());
 		// User's value not set, default value is set.
-		SnmpGetNextCriterion criterion = (SnmpGetNextCriterion) detection.getCriteria().get(0);
+		final SnmpGetNextCriterion criterion = (SnmpGetNextCriterion) detection.getCriteria().get(0);
 		assertEquals("1.3.6.1.4.1.795.10.1.1.3.1.1", criterion.getOid());
 		// User's value not set, default value not set, variable remains unchanged.
 		assertEquals(

--- a/metricshub-agent/src/test/resources/connectorTemplateLibraryParser/templateVariable.yaml
+++ b/metricshub-agent/src/test/resources/connectorTemplateLibraryParser/templateVariable.yaml
@@ -8,13 +8,20 @@ connector:
   detection:
     connectionTypes:
     - remote
-    - local
+    - ${var::local-variable}
     appliesTo:
     - NT
     - Linux
     criteria:
     - type: ${var::snmp-get-next}
-      oid: 1.3.6.1.4.1.795.10.1.1.3.1.1
+      oid: ${var::oid}
+  variables:
+    oid:
+      description: ${var::oid-description}
+      defaultValue: 1.3.6.1.4.1.795.10.1.1.3.1.1
+    snmp-get-next:
+      description: the detection SNMP operation, for the sake of testing, it is different from the user's specified value in the test. The purpose is to ensure that the user's values are more of a priority than the default values.
+      defaultValue: wrongSnmpGetNextValue
 monitors:
   disk_controller:
     discovery:

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorDefaultVariable.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorDefaultVariable.java
@@ -1,0 +1,46 @@
+package org.sentrysoftware.metricshub.engine.connector.model.identity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Engine
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+/**
+ * Represents the connector default variables that can be defined on a Connector Template.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class ConnectorDefaultVariable {
+
+	/**
+	 * The default connector variable description.
+	 */
+	private String description;
+	/**
+	 * The default connector variable default value.
+	 */
+	private String defaultValue;
+}

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorIdentity.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorIdentity.java
@@ -22,6 +22,7 @@ package org.sentrysoftware.metricshub.engine.connector.model.identity;
  */
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -82,5 +83,5 @@ public class ConnectorIdentity implements Serializable {
 	/**
 	 * The connector default variables that can be specified.
 	 */
-	private Map<String, ConnectorDefaultVariable> variables;
+	private final Map<String, ConnectorDefaultVariable> variables = new HashMap<>();
 }

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorIdentity.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorIdentity.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -83,5 +84,6 @@ public class ConnectorIdentity implements Serializable {
 	/**
 	 * The connector default variables that can be specified.
 	 */
-	private final Map<String, ConnectorDefaultVariable> variables = new HashMap<>();
+	@Default
+	private Map<String, ConnectorDefaultVariable> variables = new HashMap<>();
 }

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorIdentity.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorIdentity.java
@@ -22,6 +22,7 @@ package org.sentrysoftware.metricshub.engine.connector.model.identity;
  */
 
 import java.io.Serializable;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -77,4 +78,9 @@ public class ConnectorIdentity implements Serializable {
 	 * The detection information of the connector.
 	 */
 	private Detection detection;
+
+	/**
+	 * The connector default variables that can be specified.
+	 */
+	private Map<String, ConnectorDefaultVariable> variables;
 }

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/parser/ConnectorLibraryParser.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/parser/ConnectorLibraryParser.java
@@ -203,7 +203,7 @@ public class ConnectorLibraryParser {
 		final long startTime = System.currentTimeMillis();
 		final ConnectorFileVisitor fileVisitor = new ConnectorFileVisitor();
 		Files.walkFileTree(yamlParentDirectory, fileVisitor);
-		log.info("Yaml loading duration: {} seconds", (System.currentTimeMillis() - startTime) / 1000);
+		log.info("Connectors parsing duration: {} seconds", (System.currentTimeMillis() - startTime) / 1000);
 		return fileVisitor.getConnectorsMap();
 	}
 }

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/connector/parser/TemplateVariableProcessorTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/connector/parser/TemplateVariableProcessorTest.java
@@ -2,15 +2,20 @@ package org.sentrysoftware.metricshub.engine.connector.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.sentrysoftware.metricshub.engine.connector.model.identity.ConnectionType.LOCAL;
+import static org.sentrysoftware.metricshub.engine.connector.model.identity.ConnectionType.REMOTE;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.sentrysoftware.metricshub.engine.connector.model.Connector;
+import org.sentrysoftware.metricshub.engine.connector.model.identity.Detection;
 
 class TemplateVariableProcessorTest {
 
@@ -33,10 +38,14 @@ class TemplateVariableProcessorTest {
 		// Retrieve the json node from the json test file
 		final JsonNode connectorNode = mapper.readTree(jsonTestFilePath.toFile());
 
+		Map<String, String> connectorVariables = new HashMap<>();
+		connectorVariables.put("snmp-get-next", "snmpGetNext");
+		connectorVariables.put("local-connection-type", "local");
+
 		// Init TemplateVariableProcessor with the connector variables map and a node processor
 		final TemplateVariableProcessor templateVariableProcessor = TemplateVariableProcessor
 			.builder()
-			.connectorVariables(Map.of("snmp-get-next", "snmpGetNext"))
+			.connectorVariables(connectorVariables)
 			.next(new ConstantsProcessor(new SourceKeyProcessor()))
 			.build();
 
@@ -48,7 +57,11 @@ class TemplateVariableProcessorTest {
 		// Retrieve the processed connector node
 		final Connector customConnector = mapper.treeToValue(nodeProcessingResult, Connector.class);
 
+		final Detection detection = customConnector.getConnectorIdentity().getDetection();
+
 		// Check that the variable value was successfully replaced
-		assertEquals("snmpGetNext", customConnector.getConnectorIdentity().getDetection().getCriteria().get(0).getType());
+		assertEquals("snmpGetNext", detection.getCriteria().get(0).getType());
+
+		assertEquals(Set.of(REMOTE, LOCAL), detection.getConnectionTypes());
 	}
 }

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/connector/parser/TemplateVariableProcessorTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/connector/parser/TemplateVariableProcessorTest.java
@@ -38,7 +38,7 @@ class TemplateVariableProcessorTest {
 		// Retrieve the json node from the json test file
 		final JsonNode connectorNode = mapper.readTree(jsonTestFilePath.toFile());
 
-		Map<String, String> connectorVariables = new HashMap<>();
+		final Map<String, String> connectorVariables = new HashMap<>();
 		connectorVariables.put("snmp-get-next", "snmpGetNext");
 		connectorVariables.put("local-connection-type", "local");
 

--- a/metricshub-engine/src/test/resources/test-files/connector/templateVariable/templateVariable.json
+++ b/metricshub-engine/src/test/resources/test-files/connector/templateVariable/templateVariable.json
@@ -8,7 +8,7 @@
     "detection": {
       "connectionTypes": [
         "remote",
-        "local"
+        "${var::local-connection-type}"
       ],
       "appliesTo": [
         "NT",

--- a/metricshub-jawk-extension/src/main/java/org/sentrysoftware/metricshub/extension/jawk/MetricsHubExtensionForJawk.java
+++ b/metricshub-jawk-extension/src/main/java/org/sentrysoftware/metricshub/extension/jawk/MetricsHubExtensionForJawk.java
@@ -338,6 +338,14 @@ public class MetricsHubExtensionForJawk extends AbstractExtension implements Jaw
 		if (connectorVariables != null) {
 			return connectorVariables.getVariableValues().get(variableName);
 		}
-		return null;
+		return sourceProcessor
+				.getTelemetryManager()
+				.getConnectorStore()
+				.getStore()
+				.get(connectorId)
+				.getConnectorIdentity()
+				.getVariables()
+				.get(variableName)
+				.getDefaultValue();
 	}
 }

--- a/metricshub-jawk-extension/src/main/java/org/sentrysoftware/metricshub/extension/jawk/MetricsHubExtensionForJawk.java
+++ b/metricshub-jawk-extension/src/main/java/org/sentrysoftware/metricshub/extension/jawk/MetricsHubExtensionForJawk.java
@@ -339,13 +339,13 @@ public class MetricsHubExtensionForJawk extends AbstractExtension implements Jaw
 			return connectorVariables.getVariableValues().get(variableName);
 		}
 		return sourceProcessor
-				.getTelemetryManager()
-				.getConnectorStore()
-				.getStore()
-				.get(connectorId)
-				.getConnectorIdentity()
-				.getVariables()
-				.get(variableName)
-				.getDefaultValue();
+			.getTelemetryManager()
+			.getConnectorStore()
+			.getStore()
+			.get(connectorId)
+			.getConnectorIdentity()
+			.getVariables()
+			.get(variableName)
+			.getDefaultValue();
 	}
 }


### PR DESCRIPTION

* Added support for default connector variables.
* Added unit tests for both the engine and the agent.
* Functionally tested on the MetricsHub agent.
* Minor adjustments on the connector variable parser when encountering
exceptions.

# Tests
## Both default connector variables & user's template variable values are specified.
<img width="1149" alt="Both user's and default" src="https://github.com/user-attachments/assets/5b7a6f69-78f2-4740-b753-88aea065e9f3">

## Default connector variables only
<img width="1150" alt="default only" src="https://github.com/user-attachments/assets/750989ca-037d-4285-b9e3-9abbaa126860">

## User's variables only
<img width="1159" alt="user's only" src="https://github.com/user-attachments/assets/f66e7ae0-10f5-4a6a-95da-3d8b229031c6">
