### PR TITLE
Issue #439: Connector default variables are not serializable

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorDefaultVariable.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorDefaultVariable.java
@@ -1,10 +1,5 @@
 package org.sentrysoftware.metricshub.engine.connector.model.identity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * MetricsHub Engine
@@ -26,6 +21,12 @@ import lombok.NoArgsConstructor;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
  * Represents the connector default variables that can be defined on a Connector Template.
  */
@@ -33,7 +34,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 @Builder
-public class ConnectorDefaultVariable {
+public class ConnectorDefaultVariable implements Serializable {
+
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * The default connector variable description.


### PR DESCRIPTION
## Update
* ConnectorDefaultVariable implements Serializable

## Summary
This pull request includes changes to the `ConnectorDefaultVariable` class in the `metricshub-engine` to add serialization support.

Serialization support and Lombok annotations:

* [`metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/identity/ConnectorDefaultVariable.java`](diffhunk://#diff-480b199819a934d0cf2c58fd78c2a898f19cdf5cc08d43efe4686133ae66cf68R24-R39): Added `Serializable` interface to the `ConnectorDefaultVariable` class and moved imports to the right location.