### PR TITLE
Issue #448: Document MetricsHub Enterprise upgrade procedure

### DIFF
--- a/metricshub-doc/src/site/markdown/installation/debian-linux.md
+++ b/metricshub-doc/src/site/markdown/installation/debian-linux.md
@@ -57,6 +57,25 @@ To uninstall **MetricsHub Enterprise**, run the command below:
 sudo dpkg -r metricshub
 ```
 
+### Upgrade
+
+If you have installed a previous version of **MetricsHub Enterprise** and want to upgrade to the latest version **${enterpriseVersion}**, follow these steps:
+
+1. From [MetricsHub's Web site](https://metricshub.com/downloads), download **metricshub-enterprise-debian-${enterpriseVersion}-amd64.deb** and copy the file into the `/usr/local` directory.
+
+2. Run the following command to stop the **MetricsHub Enterprise** service:
+
+   ```shell-session
+   systemctl stop metricshub-enterprise-service
+   ```
+
+3. Run the following `dpkg` command:
+
+   ```shell-session
+   cd /usr/local
+   sudo dpkg -i metricshub-enterprise-debian-${enterpriseVersion}-amd64.deb
+   ```
+
 ## Community Edition
 
 ### Download

--- a/metricshub-doc/src/site/markdown/installation/docker.md
+++ b/metricshub-doc/src/site/markdown/installation/docker.md
@@ -26,6 +26,7 @@ Then, build the docker image using the following command:
 cd /docker/metricshub
 sudo docker build -t metricshub:latest .
 ```
+
 ### Configure
 
 *  In the **./lib/config/metricshub.yaml** file, located under the `/docker/metricshub` installation directory, configure the [resources to be monitored](../configuration/configure-monitoring.html#configure-resources).
@@ -74,6 +75,51 @@ services:
       - ./lib/security:/opt/metricshub/lib/security        # Mount the volume ./lib/security into /opt/metricshub/lib/security in the container
     restart: unless-stopped
 ```
+
+### Upgrade
+
+If you have installed a previous version of **MetricsHub Enterprise** and want to upgrade to the latest version **${enterpriseVersion}**, follow these steps:
+
+1. From [MetricsHub's website](https://metricshub.com/downloads), download **metricshub-enterprise-debian-${enterpriseVersion}-docker.tar.gz** and copy it into the `/tmp` directory.
+
+2. Stop and remove the currently running **MetricsHub** container:
+
+   ```shell-session
+   sudo docker stop metricshub
+   sudo docker rm metricshub
+   ```
+
+3. Before upgrading, rename the current **metricshub** directory to **metricshub-previous** to backup your configuration files and preserve any custom settings. Ensure that there isn't already a directory named **metricshub-previous**; if there is, you may need to choose a different name:
+
+   ```shell-session
+   sudo mv /docker/metricshub /docker/metricshub-previous
+   ```
+
+4. Unzip the new version into the same directory where the previous version was installed:
+
+   ```shell-session
+   sudo tar xzf /tmp/metricshub-enterprise-debian-${enterpriseVersion}-docker.tar.gz -C /docker
+   ```
+
+5. Rebuild the **MetricsHub** Docker image with the latest version:
+
+   ```shell-session
+   cd /docker/metricshub
+   sudo docker build -t metricshub:latest .
+   ```
+
+6. Restore the configuration files to the correct locations:
+
+   ```shell-session
+   sudo cp /docker/metricshub-previous/lib/config/metricshub.yaml /docker/metricshub/lib/config/metricshub.yaml
+   sudo cp /docker/metricshub-previous/lib/otel/otel-config.yaml /docker/metricshub/lib/otel/otel-config.yaml
+   ```
+
+7. Start the **MetricsHub** container using the upgraded image:
+
+   ```shell-session
+   sudo docker run -d --name=metricshub -p 24375:24375 -p 13133:13133 -v /docker/metricshub/lib/config:/opt/metricshub/lib/config -v /docker/metricshub/lib/otel:/opt/metricshub/lib/otel -v /docker/metricshub/lib/logs:/opt/metricshub/lib/logs -v /docker/metricshub/lib/security:/opt/metricshub/lib/security metricshub:latest
+   ```
 
 ## Community Edition
 

--- a/metricshub-doc/src/site/markdown/installation/redhat-linux.md
+++ b/metricshub-doc/src/site/markdown/installation/redhat-linux.md
@@ -69,6 +69,25 @@ To uninstall **MetricsHub Enterprise**, run the command below:
 sudo rpm -e metricshub-${enterpriseVersion}-1.x86_64
 ```
 
+### Upgrade
+
+If you have installed a previous version of **MetricsHub Enterprise** and want to upgrade to the latest version **${enterpriseVersion}**, follow these steps:
+
+1. From [MetricsHub's Web site](https://metricshub.com/downloads), download **metricshub-enterprise-rhel-${enterpriseVersion}-1.x86_64.rpm** and copy the file into the `/usr/local` directory.
+
+2. Run the following command to stop the **MetricsHub Enterprise** service:
+
+   ```shell-session
+   systemctl stop metricshub-enterprise-service
+   ```
+
+3. Run the following `rpm` command:
+
+   ```shell-session
+   cd /usr/local
+   sudo rpm -U metricshub-enterprise-rhel-${enterpriseVersion}-1.x86_64.rpm
+   ```
+
 ## Community Edition
 
 ### Download

--- a/metricshub-doc/src/site/markdown/installation/windows.md
+++ b/metricshub-doc/src/site/markdown/installation/windows.md
@@ -42,7 +42,7 @@ If you have installed a previous version of **MetricsHub Enterprise** and want t
 
 1. From [MetricsHub's Web site](https://metricshub.com/downloads), download **metricshub-enterprise-windows-${enterpriseVersion}.msi**.
 2. Open **services.msc** and stop the **MetricsHub Enterprise** service.
-3. Double-click the `.msi` file you previously downloaded. The Installation Wizard will automatically start and guide you through the installation process.
+3. Double-click the `.msi` file you previously downloaded. The Installation Wizard will automatically start and guide you through the upgrade process.
 
 ## Community Edition
 

--- a/metricshub-doc/src/site/markdown/installation/windows.md
+++ b/metricshub-doc/src/site/markdown/installation/windows.md
@@ -36,6 +36,14 @@ To start the **MetricsHub Enterprise** service, open **services.msc** and start 
 
 To uninstall **MetricsHub Enterprise**, double-click the **metricshub-enterprise-windows-${enterpriseVersion}.msi** file and click **Remove** when prompted.
 
+### Upgrade
+
+If you have installed a previous version of **MetricsHub Enterprise** and want to upgrade to the latest version **${enterpriseVersion}**, follow these steps:
+
+1. From [MetricsHub's Web site](https://metricshub.com/downloads), download **metricshub-enterprise-windows-${enterpriseVersion}.msi**.
+2. Open **services.msc** and stop the **MetricsHub Enterprise** service.
+3. Double-click the `.msi` file you previously downloaded. The Installation Wizard will automatically start and guide you through the installation process.
+
 ## Community Edition
 
 ### Download


### PR DESCRIPTION
**Updates**
* Updated debian-linux.md
* Updated redhat-linux.md
* Updated windows.md
* Updated docker.md

**Summary**
This pull request updates the documentation for installing and upgrading MetricsHub Enterprise across various platforms. The most important changes include adding upgrade instructions for Debian Linux, Docker, RedHat Linux, and Windows.

Upgrade instructions added:

* `metricshub-doc/src/site/markdown/installation/debian-linux.md`: Added detailed steps to upgrade MetricsHub Enterprise on Debian Linux, including stopping the service and using `dpkg` to install the new version.
* `metricshub-doc/src/site/markdown/installation/docker.md`: Provided comprehensive steps to upgrade MetricsHub Enterprise in a Docker environment, including stopping and removing the container, backing up configuration files, and rebuilding the Docker image.
* `metricshub-doc/src/site/markdown/installation/redhat-linux.md`: Included instructions to upgrade MetricsHub Enterprise on RedHat Linux, such as stopping the service and using `rpm` to update the package.
* `metricshub-doc/src/site/markdown/installation/windows.md`: Added steps to upgrade MetricsHub Enterprise on Windows, including stopping the service and running the new `.msi` installer.