### PR TITLE
Issue #450: Moved the localhost resource configuration

### DIFF
--- a/metricshub-linux/src/main/resources/jpackage/metricshub/config/metricshub-example.yaml
+++ b/metricshub-linux/src/main/resources/jpackage/metricshub/config/metricshub-example.yaml
@@ -20,13 +20,13 @@ otel:
   
 # Simple resource configuration
 resources:
-  localhost:
-    attributes:
-      host.name: localhost
-      host.type: linux
-    protocols:
-      osCommand:
-        timeout: 120
+  # localhost:
+  #   attributes:
+  #     host.name: localhost
+  #     host.type: linux
+  #   protocols:
+  #     osCommand:
+  #       timeout: 120
 
   #═══════════════════════════════════════════════════
   # SNMP v1 protocol configuration
@@ -76,6 +76,13 @@ resourceGroups:
 
     # Some resource templates can be found below:
     resources:
+      localhost:
+        attributes:
+          host.name: localhost
+          host.type: linux
+        protocols:
+          osCommand:
+            timeout: 120
 
       #═══════════════════════════════════════════════════
       # IPMI protocol configuration    

--- a/metricshub-windows/src/main/resources/jpackage/MetricsHub/config/metricshub-example.yaml
+++ b/metricshub-windows/src/main/resources/jpackage/MetricsHub/config/metricshub-example.yaml
@@ -20,13 +20,13 @@ otel:
   
 # Simple resource configuration
 resources:
-  localhost:
-    attributes:
-      host.name: localhost
-      host.type: windows
-    protocols:
-      wmi:
-        timeout: 120
+  # localhost:
+  #   attributes:
+  #     host.name: localhost
+  #     host.type: windows
+  #   protocols:
+  #     wmi:
+  #       timeout: 120
 
   #═══════════════════════════════════════════════════
   # SNMP v1 protocol configuration
@@ -76,6 +76,13 @@ resourceGroups:
 
     # Some resource templates can be found below:
     resources:
+      localhost:
+        attributes:
+          host.name: localhost
+          host.type: windows
+        protocols:
+          wmi:
+            timeout: 120
 
       #═══════════════════════════════════════════════════
       # IPMI protocol configuration    


### PR DESCRIPTION
* Moved the localhost resource configuration to the data center 1 resource group in `metricshub-example.yaml`.
* Tested on Windows.