### PR TITLE
Issue #432: Standardize the messages for all the criteria tests

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractStrategy.java
@@ -50,6 +50,7 @@ import org.sentrysoftware.metricshub.engine.connector.model.monitor.task.source.
 import org.sentrysoftware.metricshub.engine.extension.ExtensionManager;
 import org.sentrysoftware.metricshub.engine.strategy.detection.ConnectorSelection;
 import org.sentrysoftware.metricshub.engine.strategy.detection.ConnectorTestResult;
+import org.sentrysoftware.metricshub.engine.strategy.detection.CriterionTestResult;
 import org.sentrysoftware.metricshub.engine.strategy.source.ISourceProcessor;
 import org.sentrysoftware.metricshub.engine.strategy.source.SourceProcessor;
 import org.sentrysoftware.metricshub.engine.strategy.source.SourceTable;
@@ -441,31 +442,18 @@ public abstract class AbstractStrategy implements IStrategy {
 	 */
 	protected String buildStatusInformation(final String hostname, final ConnectorTestResult testResult) {
 		final StringBuilder value = new StringBuilder();
-
 		final String builtTestResult = testResult
 			.getCriterionTestResults()
 			.stream()
 			.filter(criterionTestResult ->
 				!(criterionTestResult.getResult() == null && criterionTestResult.getMessage() == null)
 			)
-			.map(criterionResult -> {
-				final String result = criterionResult.getResult();
-				final String message = criterionResult.getMessage();
-				return String.format(
-					"Received Result: %s. %s",
-					result != null ? result : "N/A",
-					message != null ? message : "N/A"
-				);
-			})
+			.map(CriterionTestResult::displayCriterionMessage)
 			.collect(Collectors.joining("\n"));
 		value
 			.append(builtTestResult)
-			.append("\nConclusion: ")
-			.append("Test on ")
-			.append(hostname)
-			.append(" ")
-			.append(testResult.isSuccess() ? "SUCCEEDED" : "FAILED");
-
+			.append("Conclusion:\n")
+			.append(String.format("Test on %s %s", hostname, testResult.isSuccess() ? "SUCCEEDED" : "FAILED"));
 		return value.toString();
 	}
 

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionProcessor.java
@@ -282,7 +282,8 @@ public class CriterionProcessor {
 		final CriterionTestResult result = localOSVisitor.getCriterionTestResult();
 
 		if (result != null) {
-			return result.setCriterion(processCriterion);
+			result.setCriterion(processCriterion);
+			return result;
 		} else {
 			return CriterionTestResult.error(
 				processCriterion,
@@ -363,7 +364,10 @@ public class CriterionProcessor {
 		return maybeExtension
 			.map(extension -> {
 				CriterionTestResult result = extension.processCriterion(criterion, connectorId, telemetryManager);
-				return result != null ? result.setCriterion(criterion) : null;
+				if (result != null) {
+					result.setCriterion(criterion);
+				}
+				return result;
 			})
 			.orElseGet(CriterionTestResult::empty);
 	}

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionProcessor.java
@@ -126,6 +126,7 @@ public class CriterionProcessor {
 				.message("Failed OS detection operation")
 				.result(CONFIGURE_OS_TYPE_MESSAGE + deviceKind.name())
 				.success(false)
+				.criterion(deviceTypeCriterion)
 				.build();
 		}
 
@@ -134,6 +135,7 @@ public class CriterionProcessor {
 			.message(SUCCESSFUL_OS_DETECTION_MESSAGE)
 			.result(CONFIGURE_OS_TYPE_MESSAGE + deviceKind.name())
 			.success(true)
+			.criterion(deviceTypeCriterion)
 			.build();
 	}
 
@@ -243,6 +245,7 @@ public class CriterionProcessor {
 				.success(true)
 				.message("Process presence check: No test will be performed.")
 				.result(null)
+				.criterion(processCriterion)
 				.build();
 		}
 
@@ -253,6 +256,7 @@ public class CriterionProcessor {
 				.success(true)
 				.message("Process presence check: No test will be performed remotely.")
 				.result(null)
+				.criterion(processCriterion)
 				.build();
 		}
 
@@ -264,6 +268,7 @@ public class CriterionProcessor {
 				.success(true)
 				.message("Process presence check: OS unknown, no test will be performed.")
 				.result(null)
+				.criterion(processCriterion)
 				.build();
 		}
 
@@ -277,7 +282,7 @@ public class CriterionProcessor {
 		final CriterionTestResult result = localOSVisitor.getCriterionTestResult();
 
 		if (result != null) {
-			return result;
+			return result.setCriterion(processCriterion);
 		} else {
 			return CriterionTestResult.error(
 				processCriterion,
@@ -302,7 +307,7 @@ public class CriterionProcessor {
 			productRequirementsCriterion.getEngineVersion() == null ||
 			productRequirementsCriterion.getEngineVersion().isBlank()
 		) {
-			return CriterionTestResult.builder().success(true).build();
+			return CriterionTestResult.builder().success(true).criterion(productRequirementsCriterion).build();
 		}
 
 		return CriterionTestResult
@@ -313,6 +318,7 @@ public class CriterionProcessor {
 					VersionHelper.getClassVersion()
 				)
 			)
+			.criterion(productRequirementsCriterion)
 			.build();
 	}
 
@@ -355,7 +361,10 @@ public class CriterionProcessor {
 			telemetryManager
 		);
 		return maybeExtension
-			.map(extension -> extension.processCriterion(criterion, connectorId, telemetryManager))
+			.map(extension -> {
+				CriterionTestResult result = extension.processCriterion(criterion, connectorId, telemetryManager);
+				return result != null ? result.setCriterion(criterion) : null;
+			})
 			.orElseGet(CriterionTestResult::empty);
 	}
 

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionTestResult.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionTestResult.java
@@ -155,7 +155,7 @@ public class CriterionTestResult {
 
 	/**
 	 * Formats and displays the criterion message in a structured, readable format.
-	 * The output includes information about the executed criterion, its details, 
+	 * The output includes information about the executed criterion, its details,
 	 * the result, and an additional message, each presented in distinct sections.
 	 * @return a formatted string that displays the criterion name, details, result, and message.
 	 */

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionTestResult.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionTestResult.java
@@ -153,6 +153,12 @@ public class CriterionTestResult {
 		return CriterionTestResult.builder().success(true).message(message).result(result).criterion(criterion).build();
 	}
 
+	/**
+	 * Formats and displays the criterion message in a structured, readable format.
+	 * The output includes information about the executed criterion, its details, 
+	 * the result, and an additional message, each presented in distinct sections.
+	 * @return a formatted string that displays the criterion name, details, result, and message.
+	 */
 	public String displayCriterionMessage() {
 		return String.format(
 			"Executed %s Criterion:\n" +
@@ -171,10 +177,5 @@ public class CriterionTestResult {
 			result != null ? result : "N/A",
 			message != null ? message : "N/A"
 		);
-	}
-
-	public CriterionTestResult setCriterion(final Criterion criterion) {
-		this.criterion = criterion;
-		return this;
 	}
 }

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionTestResult.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionTestResult.java
@@ -44,6 +44,8 @@ public class CriterionTestResult {
 
 	private Throwable exception;
 
+	private Criterion criterion;
+
 	/**
 	 * Creates an empty criterion test result.
 	 *
@@ -68,7 +70,7 @@ public class CriterionTestResult {
 			criterion.toString(),
 			result
 		);
-		return CriterionTestResult.builder().success(false).message(message).result(result).build();
+		return CriterionTestResult.builder().success(false).message(message).result(result).criterion(criterion).build();
 	}
 
 	/**
@@ -93,7 +95,7 @@ public class CriterionTestResult {
 					reason
 				);
 		}
-		return CriterionTestResult.builder().success(false).message(message).exception(t).build();
+		return CriterionTestResult.builder().success(false).message(message).exception(t).criterion(criterion).build();
 	}
 
 	/**
@@ -148,6 +150,31 @@ public class CriterionTestResult {
 			result
 		);
 
-		return CriterionTestResult.builder().success(true).message(message).result(result).build();
+		return CriterionTestResult.builder().success(true).message(message).result(result).criterion(criterion).build();
+	}
+
+	public String displayCriterionMessage() {
+		return String.format(
+			"Executed %s Criterion:\n" +
+			"%s\n" +
+			"\n" +
+			"Result:\n" +
+			"%s\n" +
+			"\n" +
+			"Message:\n" +
+			"====================================\n" +
+			"%s\n" +
+			"====================================\n" +
+			"\n",
+			criterion.getClass().getSimpleName(),
+			criterion.toString(),
+			result != null ? result : "N/A",
+			message != null ? message : "N/A"
+		);
+	}
+
+	public CriterionTestResult setCriterion(final Criterion criterion) {
+		this.criterion = criterion;
+		return this;
 	}
 }

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategyTest.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -212,11 +211,22 @@ class CollectStrategyTest {
 
 		// Check that StatusInformation is collected on the connector monitor
 		assertEquals(
-			"Received Result: 1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest. SnmpGetNextCriterion test succeeded:\n" +
+			"Executed SnmpGetNextCriterion Criterion:\n" +
+			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
+			"\n" +
+			"Result:\n" +
+			"1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
+			"\n" +
+			"Message:\n" +
+			"====================================\n" +
+			"SnmpGetNextCriterion test succeeded:\n" +
 			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
 			"\n" +
 			"Result: 1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
-			"Conclusion: Test on host.name SUCCEEDED",
+			"====================================\n" +
+			"\n" +
+			"Conclusion:\n" +
+			"Test on host.name SUCCEEDED",
 			connectorMonitor.getLegacyTextParameters().get(STATUS_INFORMATION)
 		);
 
@@ -230,12 +240,23 @@ class CollectStrategyTest {
 
 		// Check that StatusInformation is collected on the connector monitor (criterion processing failure case)
 		assertEquals(
-			"Received Result: 1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest. SnmpGetNextCriterion test ran but failed:\n" +
+			"Executed SnmpGetNextCriterion Criterion:\n" +
+			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
+			"\n" +
+			"Result:\n" +
+			"1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
+			"\n" +
+			"Message:\n" +
+			"====================================\n" +
+			"SnmpGetNextCriterion test ran but failed:\n" +
 			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
 			"\n" +
 			"Actual result:\n" +
 			"1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
-			"Conclusion: Test on host.name FAILED",
+			"====================================\n" +
+			"\n" +
+			"Conclusion:\n" +
+			"Test on host.name FAILED",
 			connectorMonitor.getLegacyTextParameters().get(STATUS_INFORMATION)
 		);
 	}

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionProcessorTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/detection/CriterionProcessorTest.java
@@ -614,12 +614,14 @@ class CriterionProcessorTest {
 			.build();
 		doReturn(telemetryManager.getHostConfiguration()).when(telemetryManagerMock).getHostConfiguration();
 
+		final DeviceTypeCriterion deviceTypeCriterion = DeviceTypeCriterion.builder().build();
 		// Init CriterionTestResult success and failure instances
 		final CriterionTestResult successfulTestResult = CriterionTestResult
 			.builder()
 			.message(SUCCESSFUL_OS_DETECTION)
 			.result(CONFIGURED_OS_NT_MESSAGE)
 			.success(true)
+			.criterion(deviceTypeCriterion)
 			.build();
 
 		final CriterionTestResult failedTestResult = CriterionTestResult
@@ -627,11 +629,11 @@ class CriterionProcessorTest {
 			.message(FAILED_OS_DETECTION)
 			.result(CONFIGURED_OS_NT_MESSAGE)
 			.success(false)
+			.criterion(deviceTypeCriterion)
 			.build();
 
 		// Test configured NETWORK OS
 
-		final DeviceTypeCriterion deviceTypeCriterion = DeviceTypeCriterion.builder().build();
 		assertEquals(successfulTestResult, criterionProcessor.process(deviceTypeCriterion));
 
 		// Include NETWORK OS
@@ -824,6 +826,7 @@ class CriterionProcessorTest {
 				.result(SYSTEM_POWER_UP_MESSAGE)
 				.message(IPMI_CONNECTION_SUCCESS_WITH_IMPI_OVER_LAN_MESSAGE)
 				.success(true)
+				.criterion(ipmiCriterion)
 				.build(),
 			criterionProcessor.process(new IpmiCriterion())
 		);
@@ -856,7 +859,6 @@ class CriterionProcessorTest {
 			MY_CONNECTOR_1_NAME,
 			extensionManager
 		);
-
 		assertEquals(CriterionTestResult.empty(), criterionProcessor.process(new IpmiCriterion()));
 	}
 

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/discovery/DiscoveryStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/discovery/DiscoveryStrategyTest.java
@@ -6,8 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.sentrysoftware.metricshub.engine.common.helpers.KnownMonitorType.CONNECTOR;
 import static org.sentrysoftware.metricshub.engine.common.helpers.KnownMonitorType.DISK_CONTROLLER;
 import static org.sentrysoftware.metricshub.engine.common.helpers.KnownMonitorType.HOST;
@@ -26,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -216,11 +213,22 @@ class DiscoveryStrategyTest {
 
 		// Check that StatusInformation is collected on the connector monitor (criterion processing success case)
 		assertEquals(
-			"Received Result: 1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest. SnmpGetNextCriterion test succeeded:\n" +
+			"Executed SnmpGetNextCriterion Criterion:\n" +
+			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
+			"\n" +
+			"Result:\n" +
+			"1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
+			"\n" +
+			"Message:\n" +
+			"====================================\n" +
+			"SnmpGetNextCriterion test succeeded:\n" +
 			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
 			"\n" +
 			"Result: 1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
-			"Conclusion: Test on host.name SUCCEEDED",
+			"====================================\n" +
+			"\n" +
+			"Conclusion:\n" +
+			"Test on host.name SUCCEEDED",
 			connectorMonitor.getLegacyTextParameters().get(STATUS_INFORMATION)
 		);
 
@@ -234,12 +242,23 @@ class DiscoveryStrategyTest {
 
 		// Check that StatusInformation is collected on the connector monitor (criterion processing failure case)
 		assertEquals(
-			"Received Result: 1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest. SnmpGetNextCriterion test ran but failed:\n" +
+			"Executed SnmpGetNextCriterion Criterion:\n" +
+			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
+			"\n" +
+			"Result:\n" +
+			"1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
+			"\n" +
+			"Message:\n" +
+			"====================================\n" +
+			"SnmpGetNextCriterion test ran but failed:\n" +
 			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
 			"\n" +
 			"Actual result:\n" +
 			"1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
-			"Conclusion: Test on host.name FAILED",
+			"====================================\n" +
+			"\n" +
+			"Conclusion:\n" +
+			"Test on host.name FAILED",
 			connectorMonitor.getLegacyTextParameters().get(STATUS_INFORMATION)
 		);
 	}

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/simple/SimpleStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/simple/SimpleStrategyTest.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -181,11 +180,22 @@ class SimpleStrategyTest {
 
 		// Check that StatusInformation is collected on the connector monitor (criterion processing success case)
 		assertEquals(
-			"Received Result: 1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest. SnmpGetNextCriterion test succeeded:\n" +
+			"Executed SnmpGetNextCriterion Criterion:\n" +
+			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
+			"\n" +
+			"Result:\n" +
+			"1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
+			"\n" +
+			"Message:\n" +
+			"====================================\n" +
+			"SnmpGetNextCriterion test succeeded:\n" +
 			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
 			"\n" +
 			"Result: 1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
-			"Conclusion: Test on ec-02 SUCCEEDED",
+			"====================================\n" +
+			"\n" +
+			"Conclusion:\n" +
+			"Test on ec-02 SUCCEEDED",
 			connectorMonitor.getLegacyTextParameters().get(STATUS_INFORMATION)
 		);
 
@@ -199,12 +209,23 @@ class SimpleStrategyTest {
 
 		// Check that StatusInformation is collected on the connector monitor (criterion processing failure case)
 		assertEquals(
-			"Received Result: 1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest. SnmpGetNextCriterion test ran but failed:\n" +
+			"Executed SnmpGetNextCriterion Criterion:\n" +
+			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
+			"\n" +
+			"Result:\n" +
+			"1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
+			"\n" +
+			"Message:\n" +
+			"====================================\n" +
+			"SnmpGetNextCriterion test ran but failed:\n" +
 			"- OID: 1.3.6.1.4.1.795.10.1.1.3.1.1\n" +
 			"\n" +
 			"Actual result:\n" +
 			"1.3.6.1.4.1.795.10.1.1.3.1.1.0\tASN_OCTET_STR\tTest\n" +
-			"Conclusion: Test on ec-02 FAILED",
+			"====================================\n" +
+			"\n" +
+			"Conclusion:\n" +
+			"Test on ec-02 FAILED",
 			connectorMonitor.getLegacyTextParameters().get(STATUS_INFORMATION)
 		);
 	}


### PR DESCRIPTION
* Added a displayCriterionMessage method that displays the same message format for all the CriterionTestResult.
* Adapted unit tests.
* Tested on MetricsHub.

# Test Result
![image](https://github.com/user-attachments/assets/20347da4-777e-41be-8bb3-a9d8cc5f9aab)
