### PR TITLE
Issue #456: Fix missing dom4j dependency in the WBEM extension

### DIFF
--- a/metricshub-wbem-extension/pom.xml
+++ b/metricshub-wbem-extension/pom.xml
@@ -179,6 +179,7 @@
 									<include>org.sentrysoftware:wbem</include>
 									<include>org.sentrysoftware:vcenter</include>
 									<include>com.vmware:vijava</include>
+									<include>dom4j:dom4j</include>
 									<include>org.sentrysoftware:metricshub-wbem-extension</include>
 								</includes>
 								<excludes>

--- a/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemRequestExecutor.java
+++ b/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemRequestExecutor.java
@@ -186,7 +186,7 @@ public class WbemRequestExecutor {
 			if (e instanceof InterruptedException) {
 				Thread.currentThread().interrupt();
 			}
-			log.error("Hostname {} - Vcenter ticket refresh query failed. Exception: {}", e);
+			log.error("Hostname {} - vCenter ticket refresh query failed. Exception", hostname, e);
 			throw new ClientException("vCenter refresh ticket query failed on " + hostname + ".", e);
 		}
 	}


### PR DESCRIPTION
* Corrected exception message.
* Updated shade plugin to include the missing dom4j dependency.