### PR TITLE
Issue #456: Fix missing dom4j dependency in the WBEM extension

### DIFF
--- a/metricshub-wbem-extension/pom.xml
+++ b/metricshub-wbem-extension/pom.xml
@@ -179,6 +179,7 @@
 									<include>org.sentrysoftware:wbem</include>
 									<include>org.sentrysoftware:vcenter</include>
 									<include>com.vmware:vijava</include>
+									<include>dom4j:dom4j</include>
 									<include>org.sentrysoftware:metricshub-wbem-extension</include>
 								</includes>
 								<excludes>

--- a/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemRequestExecutor.java
+++ b/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemRequestExecutor.java
@@ -186,7 +186,8 @@ public class WbemRequestExecutor {
 			if (e instanceof InterruptedException) {
 				Thread.currentThread().interrupt();
 			}
-			log.error("Hostname {} - Vcenter ticket refresh query failed. Exception: {}", e);
+			log.error("Hostname {} - vCenter ticket refresh query failed. Error message: {}", hostname, e.getMessage());
+			log.debug("Hostname {} - vCenter ticket refresh query failed.", hostname, e);
 			throw new ClientException("vCenter refresh ticket query failed on " + hostname + ".", e);
 		}
 	}


### PR DESCRIPTION
**Updates**
* Corrected exception message.
* Updated shade plugin to include the missing dom4j dependency.

**Summary**
This pull request includes changes to the `metricshub-wbem-extension` project, focusing on dependency updates and improved error logging. The most important changes include adding a new dependency in the `pom.xml` file and enhancing the logging details in the `refreshVCenterTicket` method.

Dependency updates:

* [`metricshub-wbem-extension/pom.xml`](diffhunk://#diff-75aa1f5fd111652d256f97eb7d5d9591a24d639e24bd343738ed12c6797c3b86R182): Added `dom4j:dom4j` to the list of included dependencies.

Error logging improvements:

* [`metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemRequestExecutor.java`](diffhunk://#diff-6cd43ad979f6094e9bf86ce53c8af4d56694d1c4b95c7dc8d4c73b1fe2054011L189-R190): Enhanced the error logging in the `refreshVCenterTicket` method by including the hostname and error message in the log, and adding a debug log for more detailed information.

-------

Testing:

![image](https://github.com/user-attachments/assets/6759f142-95b8-4790-bea1-64db23dff9cd)
