### PR TITLE
Issue #414: Link to MetricsHub Community Connectors 1.0.06

### DIFF
--- a/metricshub-doc/pom.xml
+++ b/metricshub-doc/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<communityVersion>${project.version}</communityVersion>
-		<enterpriseVersion>1.0.00</enterpriseVersion>
+		<enterpriseVersion>1.0.01</enterpriseVersion>
 		<otelVersion>0.102.0</otelVersion>
 	</properties>
 
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.sentrysoftware.maven</groupId>
 				<artifactId>metricshub-connector-maven-plugin</artifactId>
-				<version>1.0.05</version>
+				<version>1.0.06</version>
 				<configuration>
 					<sourceDirectory>${project.basedir}/../metricshub-agent/target/connectors</sourceDirectory>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 	</developers>
 
 	<properties>
-		<community-connectors.version>1.0.06-SNAPSHOT</community-connectors.version>
+		<community-connectors.version>1.0.06</community-connectors.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>
 		<hwgraf.version>4</hwgraf.version>


### PR DESCRIPTION
* Upgraded `metricshub-community-connectors` to 1.0.06
* Upgraded  `metricshub-connector-maven-plugin` to 1.0.06
* The `enterpriseVersion` property is set to 1.0.01

This pull request includes version updates in the `pom.xml` files to ensure compatibility and stability across different components.

Version updates:

* [`metricshub-doc/pom.xml`](diffhunk://#diff-77ee4fa86779ba8e7a1d78405285cd8eafedbfc46b476339cb8c7d2d6a40b23aL19-R19): Updated `enterpriseVersion` from `1.0.00` to `1.0.01`.
* [`metricshub-doc/pom.xml`](diffhunk://#diff-77ee4fa86779ba8e7a1d78405285cd8eafedbfc46b476339cb8c7d2d6a40b23aL122-R122): Updated `metricshub-connector-maven-plugin` version from `1.0.05` to `1.0.06`.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L95-R95): Updated `community-connectors.version` from `1.0.06-SNAPSHOT` to `1.0.06`.