### PR TITLE
Issue #468: Support shared-characteristics for centralized resources

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/deserialization/PostConfigDeserializer.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/deserialization/PostConfigDeserializer.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import org.sentrysoftware.metricshub.agent.config.AgentConfig;
 import org.sentrysoftware.metricshub.agent.config.ResourceConfig;
 import org.sentrysoftware.metricshub.agent.config.ResourceGroupConfig;
 
@@ -76,6 +77,11 @@ public class PostConfigDeserializer extends DelegatingDeserializer {
 			resolveMultiHostResourceConfigurations(resourceGroupConfig);
 		}
 
+		// Manage ResourceConfig instances that define multiple hosts sharing the same configuration under the AgentConfig
+		if (deserializedObject instanceof AgentConfig agentConfig) {
+			resolveResources(agentConfig.getResources());
+		}
+
 		return deserializedObject;
 	}
 
@@ -86,10 +92,17 @@ public class PostConfigDeserializer extends DelegatingDeserializer {
 	 *                            the {@link ResourceConfig} instances belong
 	 */
 	private void resolveMultiHostResourceConfigurations(final ResourceGroupConfig resourceGroupConfig) {
+		resolveResources(resourceGroupConfig.getResources());
+	}
+
+	/**
+	 * Resolves the multiple host configurations of the given {@link ResourceConfig} map.
+	 * <br>It creates new {@link ResourceConfig} instances for each host and updates the map accordingly.
+	 * @param existingResourceConfigMap Map containing the existing {@link ResourceConfig} instances
+	 */
+	private void resolveResources(final Map<String, ResourceConfig> existingResourceConfigMap) {
 		final Set<String> resolvedMultiResourceConfigKeys = new HashSet<>();
 		final Map<String, ResourceConfig> newResourceConfigMap = new HashMap<>();
-		final Map<String, ResourceConfig> existingResourceConfigMap = resourceGroupConfig.getResources();
-
 		// Loop over each multiple host configuration and resolve it
 		existingResourceConfigMap
 			.entrySet()


### PR DESCRIPTION
**Update**

* Extended the feature to `AgentConfig` resources.

**Details**
This pull request to `metricshub-agent` introduces changes to the `PostConfigDeserializer` class to manage ResourceConfig instances more effectively by resolving multiple host configurations. The most important changes include adding a new method to handle ResourceConfig instances and updating the deserialization logic to incorporate this method.

Enhancements to deserialization logic:

* [`metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/deserialization/PostConfigDeserializer.java`](diffhunk://#diff-347083d86da737255b9cc7affc2b4b0634e380c57ef753a1517367e968ab3cedR38): Imported `AgentConfig` to manage ResourceConfig instances under the AgentConfig.
* [`metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/deserialization/PostConfigDeserializer.java`](diffhunk://#diff-347083d86da737255b9cc7affc2b4b0634e380c57ef753a1517367e968ab3cedR80-R84): Updated the `deserialize` method to handle `AgentConfig` instances and resolve their resources.

New method for ResourceConfig resolution:

* [`metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/deserialization/PostConfigDeserializer.java`](diffhunk://#diff-347083d86da737255b9cc7affc2b4b0634e380c57ef753a1517367e968ab3cedR95-L92): Added `resolveResources` method to create new `ResourceConfig` instances for each host and update the map accordingly.

Tests
![image](https://github.com/user-attachments/assets/ffdb9e55-117a-452a-b93c-3d7863c67adb)
