### PR TITLE
Issue #472: Prevent sensitive configuration details from being displayed in error logs

### DIFF
--- a/metricshub-http-extension/src/main/java/org/sentrysoftware/metricshub/extension/http/HttpExtension.java
+++ b/metricshub-http-extension/src/main/java/org/sentrysoftware/metricshub/extension/http/HttpExtension.java
@@ -186,13 +186,9 @@ public class HttpExtension implements IProtocolExtension {
 
 			return httpConfiguration;
 		} catch (Exception e) {
-			final String errorMessage = String.format(
-				"Error while reading HTTP Configuration: %s. Error: %s",
-				jsonNode,
-				e.getMessage()
-			);
+			final String errorMessage = String.format("Error while reading HTTP Configuration. Error: %s", e.getMessage());
 			log.error(errorMessage);
-			log.debug("Error while reading HTTP Configuration: {}. Stack trace:", jsonNode, e);
+			log.debug("Error while reading HTTP Configuration. Stack trace:", e);
 			throw new InvalidConfigurationException(errorMessage, e);
 		}
 	}

--- a/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiExtension.java
+++ b/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiExtension.java
@@ -228,13 +228,9 @@ public class IpmiExtension implements IProtocolExtension {
 
 			return ipmiConfiguration;
 		} catch (Exception e) {
-			final String errorMessage = String.format(
-				"Error while reading IPMI Configuration: %s. Error: %s",
-				jsonNode,
-				e.getMessage()
-			);
+			final String errorMessage = String.format("Error while reading IPMI Configuration. Error: %s", e.getMessage());
 			log.error(errorMessage);
-			log.debug("Error while reading IPMI Configuration: {}. Stack trace:", jsonNode, e);
+			log.debug("Error while reading IPMI Configuration. Stack trace:", e);
 			throw new InvalidConfigurationException(errorMessage, e);
 		}
 	}

--- a/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtension.java
+++ b/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtension.java
@@ -192,13 +192,9 @@ public class OsCommandExtension implements IProtocolExtension {
 
 				return sshConfiguration;
 			} catch (Exception e) {
-				final String errorMessage = String.format(
-					"Error while reading SSH Configuration: %s. Error: %s",
-					jsonNode,
-					e.getMessage()
-				);
+				final String errorMessage = String.format("Error while reading SSH Configuration. Error: %s", e.getMessage());
 				log.error(errorMessage);
-				log.debug("Error while reading SSH Configuration: {}. Stack trace:", jsonNode, e);
+				log.debug("Error while reading SSH Configuration. Stack trace:", e);
 				throw new InvalidConfigurationException(errorMessage, e);
 			}
 		} else if (configurationType.equalsIgnoreCase("oscommand")) {
@@ -206,12 +202,11 @@ public class OsCommandExtension implements IProtocolExtension {
 				return newObjectMapper().treeToValue(jsonNode, OsCommandConfiguration.class);
 			} catch (Exception e) {
 				final String errorMessage = String.format(
-					"Error while reading OsCommand Configuration: %s. Error: %s",
-					jsonNode,
+					"Error while reading OsCommand Configuration. Error: %s",
 					e.getMessage()
 				);
 				log.error(errorMessage);
-				log.debug("Error while reading OsCommand Configuration: {}. Stack trace:", jsonNode, e);
+				log.debug("Error while reading OsCommand Configuration. Stack trace:", e);
 				throw new InvalidConfigurationException(errorMessage, e);
 			}
 		}

--- a/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingExtension.java
+++ b/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingExtension.java
@@ -136,13 +136,9 @@ public class PingExtension implements IProtocolExtension {
 		try {
 			return newObjectMapper().treeToValue(jsonNode, PingConfiguration.class);
 		} catch (Exception e) {
-			final String errorMessage = String.format(
-				"Error while reading Ping Configuration: %s. Error: %s",
-				jsonNode,
-				e.getMessage()
-			);
+			final String errorMessage = String.format("Error while reading Ping Configuration. Error: %s", e.getMessage());
 			log.error(errorMessage);
-			log.debug("Error while reading Ping Configuration: {}. Stack trace:", jsonNode, e);
+			log.debug("Error while reading Ping Configuration. Stack trace:", e);
 			throw new InvalidConfigurationException(errorMessage, e);
 		}
 	}

--- a/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpExtension.java
+++ b/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpExtension.java
@@ -81,13 +81,9 @@ public class SnmpExtension extends AbstractSnmpExtension {
 
 			return snmpConfiguration;
 		} catch (Exception e) {
-			final String errorMessage = String.format(
-				"Error while reading SNMP Configuration: %s. Error: %s",
-				jsonNode,
-				e.getMessage()
-			);
+			final String errorMessage = String.format("Error while reading SNMP Configuration. Error: %s", e.getMessage());
 			log.error(errorMessage);
-			log.debug("Error while reading SNMP Configuration: {}. Stack trace:", jsonNode, e);
+			log.debug("Error while reading SNMP Configuration. Stack trace:", e);
 			throw new InvalidConfigurationException(errorMessage, e);
 		}
 	}

--- a/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Extension.java
+++ b/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Extension.java
@@ -81,13 +81,9 @@ public class SnmpV3Extension extends AbstractSnmpExtension {
 
 			return snmpV3Configuration;
 		} catch (Exception e) {
-			final String errorMessage = String.format(
-				"Error while reading SNMP V3 Configuration: %s. Error: %s",
-				jsonNode,
-				e.getMessage()
-			);
+			final String errorMessage = String.format("Error while reading SNMP V3 Configuration. Error: %s", e.getMessage());
 			log.error(errorMessage);
-			log.debug("Error while reading SNMP V3 Configuration: {}. Stack trace:", jsonNode, e);
+			log.debug("Error while reading SNMP V3 Configuration. Stack trace:", e);
 			throw new InvalidConfigurationException(errorMessage, e);
 		}
 	}

--- a/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemExtension.java
+++ b/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemExtension.java
@@ -208,13 +208,9 @@ public class WbemExtension implements IProtocolExtension {
 
 			return wbemConfiguration;
 		} catch (Exception e) {
-			final String errorMessage = String.format(
-				"Error while reading WBEM Configuration: %s. Error: %s",
-				jsonNode,
-				e.getMessage()
-			);
+			final String errorMessage = String.format("Error while reading WBEM Configuration. Error: %s", e.getMessage());
 			log.error(errorMessage);
-			log.debug("Error while reading WBEM Configuration: {}. Stack trace:", jsonNode, e);
+			log.debug("Error while reading WBEM Configuration. Stack trace:", e);
 			throw new InvalidConfigurationException(errorMessage, e);
 		}
 	}

--- a/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtension.java
+++ b/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmExtension.java
@@ -241,13 +241,9 @@ public class WinRmExtension implements IProtocolExtension {
 
 			return winRmConfiguration;
 		} catch (Exception e) {
-			final String errorMessage = String.format(
-				"Error while reading WinRm Configuration: %s. Error: %s",
-				jsonNode,
-				e.getMessage()
-			);
+			final String errorMessage = String.format("Error while reading WinRm Configuration. Error: %s", e.getMessage());
 			log.error(errorMessage);
-			log.debug("Error while reading WinRm Configuration: {}. Stack trace:", jsonNode, e);
+			log.debug("Error while reading WinRm Configuration. Stack trace:", e);
 			throw new InvalidConfigurationException(errorMessage, e);
 		}
 	}

--- a/metricshub-wmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtension.java
+++ b/metricshub-wmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/wmi/WmiExtension.java
@@ -244,13 +244,9 @@ public class WmiExtension implements IProtocolExtension {
 
 			return wmiConfiguration;
 		} catch (Exception e) {
-			final String errorMessage = String.format(
-				"Error while reading WMI Configuration: %s. Error: %s",
-				jsonNode,
-				e.getMessage()
-			);
+			final String errorMessage = String.format("Error while reading WMI Configuration. Error: %s", e.getMessage());
 			log.error(errorMessage);
-			log.debug("Error while reading WMI Configuration: {}. Stack trace:", jsonNode, e);
+			log.debug("Error while reading WMI Configuration. Stack trace:", e);
 			throw new InvalidConfigurationException(errorMessage, e);
 		}
 	}


### PR DESCRIPTION

* Removed configuration details from logs across all extensions when an exception occurs.
* Tested on MetricsHub.

# Test
![image](https://github.com/user-attachments/assets/85919a6c-9125-407d-8c4d-6031e66ad0f2)
