### PR TITLE
Issue #476 Process empty values the same way as null values when creating INSERT queries for localSql Sources instead of blank values.

### DIFF
--- a/metricshub-localsql-source-extension/src/main/java/org/sentrysoftware/metricshub/extension/sql/SqlClientExecutor.java
+++ b/metricshub-localsql-source-extension/src/main/java/org/sentrysoftware/metricshub/extension/sql/SqlClientExecutor.java
@@ -280,7 +280,7 @@ public class SqlClientExecutor {
 			for (final SqlColumn sqlColumn : sqlColumns) {
 				final String separator = sqlColumn.getType().contains("CHAR") ? "'" : "";
 				final String value = row.get(sqlColumn.getNumber() - 1);
-				rowValues.add(value != null && !value.isBlank() ? (separator + value + separator) : "NULL");
+				rowValues.add(value != null && !value.isEmpty() ? (separator + value + separator) : "NULL");
 			}
 			columnValues.add("(" + String.join(",", rowValues) + ")");
 		}


### PR DESCRIPTION
Process empty values the same way as null values when creating INSERT queries for localSql Sources instead of blank values.