### PR TITLE
Issue #470: Add support for `host.id`, `host.name`, and other attributes as arrays in resource configuration

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/deserialization/AttributesDeserializer.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/deserialization/AttributesDeserializer.java
@@ -21,6 +21,8 @@ package org.sentrysoftware.metricshub.agent.deserialization;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.MULTI_VALUE_SEPARATOR;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -60,7 +62,7 @@ public class AttributesDeserializer extends JsonDeserializer<Map<String, String>
 			.collect(
 				Collectors.toMap(
 					Map.Entry::getKey,
-					value -> StringHelper.stringify(value.getValue()),
+					value -> StringHelper.stringify(value.getValue(), MULTI_VALUE_SEPARATOR),
 					(oldValue, newValue) -> oldValue,
 					LinkedHashMap::new
 				)

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/deserialization/PostConfigDeserializer.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/deserialization/PostConfigDeserializer.java
@@ -21,35 +21,42 @@ package org.sentrysoftware.metricshub.agent.deserialization;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.COMMA;
-import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.HOST_NAME;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_HOST_ID_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY;
+import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.MULTI_VALUE_SEPARATOR;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.sentrysoftware.metricshub.agent.config.AgentConfig;
 import org.sentrysoftware.metricshub.agent.config.ResourceConfig;
 import org.sentrysoftware.metricshub.agent.config.ResourceGroupConfig;
+import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 
 /**
- * Custom JSON deserializer for post-processing the deserialization of {@link ResourceGroupConfig} instances.
+ * Custom JSON deserializer for post-processing {@link ResourceConfig} instances.
  *
  * <p>The {@code PostConfigDeserializer} extends {@link DelegatingDeserializer} to allow additional processing
- * after the default deserialization. It specifically handles cases where a {@code ResourceGroupConfig} contains
- * {@code ResourceConfig} instances with a special attribute "host.names," indicating multiple hosts sharing
+ * after the default deserialization. It specifically handles cases where {@code ResourceConfig} instances define
+ * special array attributes (E.g host.name), indicating multiple resources sharing
  * the same configuration. This deserializer resolves such configurations by creating new {@code ResourceConfig}
- * instances for each host and updating the configuration map accordingly.
+ * instances for each resource and updating the configuration map accordingly.
+ * </p>
  */
 public class PostConfigDeserializer extends DelegatingDeserializer {
 
+	@Deprecated(since = "0.9.08", forRemoval = true)
 	private static final String MULTI_HOST_ATTRIBUTE_KEY = "host.names";
 
 	private static final long serialVersionUID = 1L;
@@ -72,12 +79,12 @@ public class PostConfigDeserializer extends DelegatingDeserializer {
 	public Object deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
 		final Object deserializedObject = super.deserialize(jsonParser, ctxt);
 
-		// Manage ResourceConfig instances that define multiple hosts sharing the same configuration
+		// Manage ResourceConfig instances that define multiple resources sharing the same configuration
 		if (deserializedObject instanceof ResourceGroupConfig resourceGroupConfig) {
-			resolveMultiHostResourceConfigurations(resourceGroupConfig);
+			resolveMultiResourceConfigurations(resourceGroupConfig);
 		}
 
-		// Manage ResourceConfig instances that define multiple hosts sharing the same configuration under the AgentConfig
+		// Manage ResourceConfig instances that define multiple resources sharing the same configuration under the AgentConfig
 		if (deserializedObject instanceof AgentConfig agentConfig) {
 			resolveResources(agentConfig.getResources());
 		}
@@ -86,39 +93,45 @@ public class PostConfigDeserializer extends DelegatingDeserializer {
 	}
 
 	/**
-	 * Resolves {@link ResourceConfig} defining multiple hosts that share the same configuration
+	 * Resolves {@link ResourceConfig} defining multiple resources that share the same configuration
 	 *
-	 * @param resourceGroupConfig {@link ResourceGroupConfig} instance where all
-	 *                            the {@link ResourceConfig} instances belong
+	 * @param resourceGroupConfig {@link ResourceGroupConfig} instance where all the {@link ResourceConfig} instances belong
 	 */
-	private void resolveMultiHostResourceConfigurations(final ResourceGroupConfig resourceGroupConfig) {
+	private void resolveMultiResourceConfigurations(final ResourceGroupConfig resourceGroupConfig) {
 		resolveResources(resourceGroupConfig.getResources());
 	}
 
 	/**
-	 * Resolves the multiple host configurations of the given {@link ResourceConfig} map.
+	 * Resolves the multiple resource configurations of the given {@link ResourceConfig} map.
 	 * <br>It creates new {@link ResourceConfig} instances for each host and updates the map accordingly.
+	 *
 	 * @param existingResourceConfigMap Map containing the existing {@link ResourceConfig} instances
 	 */
 	private void resolveResources(final Map<String, ResourceConfig> existingResourceConfigMap) {
 		final Set<String> resolvedMultiResourceConfigKeys = new HashSet<>();
 		final Map<String, ResourceConfig> newResourceConfigMap = new HashMap<>();
-		// Loop over each multiple host configuration and resolve it
+		// Loop over each multiple resource configuration and resolve it
 		existingResourceConfigMap
 			.entrySet()
 			.stream()
 			.filter(resourceConfigEntry ->
 				Objects.nonNull(resourceConfigEntry.getValue()) &&
-				resourceConfigEntry.getValue().getAttributes().containsKey(MULTI_HOST_ATTRIBUTE_KEY)
+				resourceConfigEntry
+					.getValue()
+					.getAttributes()
+					.values()
+					.stream()
+					.filter(Objects::nonNull)
+					.anyMatch(s -> s.contains(MULTI_VALUE_SEPARATOR))
 			)
 			.forEach(resourceConfigEntry ->
-				resolveMultiHostResourceConfig(resolvedMultiResourceConfigKeys, newResourceConfigMap, resourceConfigEntry)
+				resolveMultiResourceConfig(resolvedMultiResourceConfigKeys, newResourceConfigMap, resourceConfigEntry)
 			);
 
 		// Put the new resource configuration (one per host)
 		existingResourceConfigMap.putAll(newResourceConfigMap);
 
-		// Removed resolved resouce configurations that define multiple host
+		// Removed resolved resouce configurations that define multiple resource
 		resolvedMultiResourceConfigKeys.forEach(existingResourceConfigMap::remove);
 	}
 
@@ -128,39 +141,127 @@ public class PostConfigDeserializer extends DelegatingDeserializer {
 	 *
 	 * @param resolvedMultiResourceKeys Set of keys that are resolved
 	 * @param newResourceConfigMap      Map containing the new {@link ResourceConfig} instances
-	 * @param multiResourceConfigEntry  {@link ResourceConfig} entry containing the multiple hosts resource configuration
+	 * @param multiResourceConfigEntry  {@link ResourceConfig} entry containing the multiple resources resource configuration
 	 */
-	private void resolveMultiHostResourceConfig(
+	private void resolveMultiResourceConfig(
 		final Set<String> resolvedMultiResourceKeys,
 		final Map<String, ResourceConfig> newResourceConfigMap,
 		final Entry<String, ResourceConfig> multiResourceConfigEntry
 	) {
 		final String multiResourceConfigKey = multiResourceConfigEntry.getKey();
-		// Save the key for removal
+		// Mark the original key for removal after processing
 		resolvedMultiResourceKeys.add(multiResourceConfigKey);
 
-		// Get the multiple ResourceConfig instance
+		// Retrieve the original ResourceConfig and its attributes
 		final ResourceConfig multiResourceConfig = multiResourceConfigEntry.getValue();
+		final Map<String, String> originalAttributes = multiResourceConfig.getAttributes();
 
-		// Get host.names values which is already prepared as CSV
-		final String hostnamesCsv = multiResourceConfig.getAttributes().get(MULTI_HOST_ATTRIBUTE_KEY);
+		// Handle deprecated legacy attribute key (e.g., host.names)
+		final String legacyHostnames = originalAttributes.get(MULTI_HOST_ATTRIBUTE_KEY);
+		if (legacyHostnames != null) {
+			// Map legacy host.names to host.name and remove the deprecated key
+			originalAttributes.put(AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY, legacyHostnames);
+			originalAttributes.remove(MULTI_HOST_ATTRIBUTE_KEY);
+		}
 
-		// Loop over each host name value and create a new ResourceConfig using the same configuration
-		for (final String hostnameValue : hostnamesCsv.split(COMMA)) {
-			// Shallow copy the resource configuration except its attributes map
+		// Prepare a map to hold split attribute values, skipping null values
+		final Map<String, List<String>> attributeValues = determineAttributeValues(originalAttributes);
+
+		// Determine the maximum number of resources to create based on the largest attribute list
+		final int maxSize = attributeValues.values().stream().mapToInt(List::size).max().orElse(1);
+
+		// Create individual resources
+		for (int i = 0; i < maxSize; i++) {
+			// Create a copy of the original ResourceConfig
 			final ResourceConfig newResourceConfig = multiResourceConfig.copy();
-
 			final Map<String, String> newAttributes = newResourceConfig.getAttributes();
 
-			// host.names is no more required
-			newAttributes.remove(MULTI_HOST_ATTRIBUTE_KEY);
-			final String hostname = hostnameValue.trim();
+			normalizeProtocolHostnames(newResourceConfig.getProtocols(), i);
 
-			// Add the host.name attribute
-			newAttributes.put(HOST_NAME, hostname);
+			// Assign values for each attribute based on the current index
+			for (Map.Entry<String, List<String>> attrEntry : attributeValues.entrySet()) {
+				final String key = attrEntry.getKey();
+				final List<String> values = attrEntry.getValue();
 
-			// Build a new unique identifier and save the new resource configuration
-			newResourceConfigMap.put(String.format("%s-%s", multiResourceConfigKey, hostname), newResourceConfig);
+				// Determine the value to assign: use the value at index i if available, else the last value
+				final String assignedValue;
+				if (i < values.size()) {
+					assignedValue = values.get(i);
+				} else {
+					assignedValue = values.get(values.size() - 1);
+				}
+
+				newAttributes.put(key, assignedValue);
+			}
+
+			// Generate a unique key for the new resource configuration
+			String additionalIdentification = null;
+			final String hostname = newAttributes.get(AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY);
+			if (hostname != null) {
+				additionalIdentification = hostname;
+			} else {
+				additionalIdentification = newAttributes.get(AGENT_RESOURCE_HOST_ID_ATTRIBUTE_KEY);
+			}
+
+			// Make sure the key is unique in case the host.name or host.id attribute is not available
+			String uniqueKey = String.format("%s-%d", multiResourceConfigKey, i + 1);
+			if (additionalIdentification != null) {
+				uniqueKey = String.format("%s-%s", uniqueKey, additionalIdentification);
+			}
+			newResourceConfigMap.put(uniqueKey, newResourceConfig);
 		}
+	}
+
+	/**
+	 * Normalize the protocol hostnames based on the given resource index.
+	 * <br>For each protocol, the hostname is split and the value at the given index is assigned.
+	 *
+	 * @param protocols     Map of protocols containing the hostname to normalize
+	 * @param resourceIndex Index of the resource to assign the hostname
+	 */
+	private void normalizeProtocolHostnames(final Map<String, IConfiguration> protocols, final int resourceIndex) {
+		if (protocols == null) {
+			return;
+		}
+
+		for (IConfiguration protocol : protocols.values()) {
+			final String hostname = protocol.getHostname();
+			if (hostname != null && hostname.contains(MULTI_VALUE_SEPARATOR)) {
+				final String[] hostnames = hostname.split(MULTI_VALUE_SEPARATOR);
+				if (resourceIndex < hostnames.length) {
+					protocol.setHostname(hostnames[resourceIndex]);
+				} else {
+					protocol.setHostname(hostnames[hostnames.length - 1]);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Split multi-valued attributes into separate values.
+	 *
+	 * @param originalAttributes Original attributes to split
+	 * @return Map of attribute names to lists of values
+	 */
+	private Map<String, List<String>> determineAttributeValues(final Map<String, String> originalAttributes) {
+		final Map<String, List<String>> attributeValues = new HashMap<>();
+
+		// Iterate over each attribute to split multi-valued attributes
+		for (Map.Entry<String, String> entry : originalAttributes.entrySet()) {
+			final String key = entry.getKey();
+			final String value = entry.getValue();
+
+			// Skip any attributes with null value
+			if (value == null) {
+				continue;
+			}
+
+			// Split the value by the multi value separator
+			final List<String> splitValues = Arrays.stream(value.split(MULTI_VALUE_SEPARATOR)).collect(Collectors.toList());
+
+			attributeValues.put(key, splitValues);
+		}
+
+		return attributeValues;
 	}
 }

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/context/AgentContextTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/context/AgentContextTest.java
@@ -122,10 +122,10 @@ class AgentContextTest {
 		assertEquals(expectedMonitors, grafanaServiceResourceConfig.getMonitors());
 
 		// Multi-hosts checks
-		final ResourceConfig server2ResourceConfig = resourcesConfigInTheGroup.get("snmp-resources-server-2");
+		final ResourceConfig server2ResourceConfig = resourcesConfigInTheGroup.get("snmp-resources-1-server-2");
 		assertNotNull(server2ResourceConfig);
 		assertEquals("server-2", server2ResourceConfig.getAttributes().get(HOST_NAME));
-		final ResourceConfig server3ResourceConfig = resourcesConfigInTheGroup.get("snmp-resources-server-3");
+		final ResourceConfig server3ResourceConfig = resourcesConfigInTheGroup.get("snmp-resources-2-server-3");
 		assertEquals("server-3", server3ResourceConfig.getAttributes().get(HOST_NAME));
 		assertNotNull(server3ResourceConfig);
 

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/deserialization/AttributesDeserializerTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/deserialization/AttributesDeserializerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants;
 
 @ExtendWith(MockitoExtension.class)
 class AttributesDeserializerTest {
@@ -28,11 +29,9 @@ class AttributesDeserializerTest {
 
 	@Test
 	void testDeserialize() throws IOException {
-		doReturn(Map.of("host.names", List.of("host1", "host2")))
-			.when(yamlParserMock)
-			.readValueAs(any(TypeReference.class));
+		doReturn(Map.of("host.name", List.of("host1", "host2"))).when(yamlParserMock).readValueAs(any(TypeReference.class));
 
-		Map<String, String> result = new AttributesDeserializer().deserialize(yamlParserMock, null);
-		assertEquals(Map.of("host.names", "host1,host2"), result);
+		final Map<String, String> result = new AttributesDeserializer().deserialize(yamlParserMock, null);
+		assertEquals(Map.of("host.name", String.format("host1%shost2", MetricsHubConstants.MULTI_VALUE_SEPARATOR)), result);
 	}
 }

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/deserialization/PostConfigDeserializerTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/deserialization/PostConfigDeserializerTest.java
@@ -1,0 +1,218 @@
+package org.sentrysoftware.metricshub.agent.deserialization;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.sentrysoftware.metricshub.agent.config.AgentConfig;
+import org.sentrysoftware.metricshub.agent.config.ResourceConfig;
+import org.sentrysoftware.metricshub.agent.config.ResourceGroupConfig;
+import org.sentrysoftware.metricshub.agent.context.AgentContext;
+import org.sentrysoftware.metricshub.engine.common.helpers.JsonHelper;
+import org.sentrysoftware.metricshub.engine.extension.ExtensionManager;
+import org.sentrysoftware.metricshub.extension.oscommand.OsCommandExtension;
+import org.sentrysoftware.metricshub.extension.oscommand.SshConfiguration;
+import org.sentrysoftware.metricshub.extension.snmp.SnmpConfiguration;
+import org.sentrysoftware.metricshub.extension.snmp.SnmpExtension;
+
+class PostConfigDeserializerTest {
+
+	// Initialize the extension manager required by ther deserializer
+	final ExtensionManager extensionManager = ExtensionManager
+		.builder()
+		.withProtocolExtensions(List.of(new OsCommandExtension(), new SnmpExtension()))
+		.build();
+
+	@Test
+	void testDeserialize() throws IOException {
+		final ObjectMapper mapper = AgentContext.newAgentConfigObjectMapper(extensionManager);
+
+		final AgentConfig configuration = JsonHelper.deserialize(
+			mapper,
+			mapper.readTree(new FileInputStream("src/test/resources/config/metricshub-multi-hosts.yaml")),
+			AgentConfig.class
+		);
+
+		final Map<String, ResourceGroupConfig> resourceGroups = configuration.getResourceGroups();
+
+		assertNotNull(resourceGroups);
+		final ResourceGroupConfig sentryParisResourceGroup = resourceGroups.get("sentry-paris");
+
+		assertNotNull(sentryParisResourceGroup);
+
+		final Map<String, ResourceConfig> sentryParisResources = sentryParisResourceGroup.getResources();
+
+		assertNotNull(sentryParisResources);
+
+		assertSshResourceConfig(sentryParisResources, "ssh-resources1-1-server-1", "server-1", "server-1-id", null);
+		assertSshResourceConfig(sentryParisResources, "ssh-resources1-2-server-2", "server-2", "server-2-id", null);
+		assertSshResourceConfig(sentryParisResources, "ssh-resources2", "server-3", "server-3-id", null);
+		assertSshResourceConfig(sentryParisResources, "ssh-resources3-1-server-4", "server-4", "server-id", null);
+		assertSshResourceConfig(sentryParisResources, "ssh-resources3-2-server-5", "server-5", "server-id", null);
+		assertSshResourceConfig(sentryParisResources, "ssh-resources4-1-server-6", "server-6", "server-6-id", null);
+		assertSshResourceConfig(sentryParisResources, "ssh-resources4-2-server-7", "server-7", "server-7-id", null);
+		assertSshResourceConfig(sentryParisResources, "ssh-resources4-3-server-7", "server-7", "server-8-id", null);
+		assertSshResourceConfig(
+			sentryParisResources,
+			"ssh-resources5-1-server-8",
+			"server-8",
+			"server-8-id",
+			"server-8-card"
+		);
+		assertSshResourceConfig(
+			sentryParisResources,
+			"ssh-resources5-2-server-9",
+			"server-9",
+			"server-9-id",
+			"server-9-card"
+		);
+		assertSshResourceConfig(
+			sentryParisResources,
+			"ssh-resources6-1-server-10",
+			"server-10",
+			"server-10-id",
+			"server-card"
+		);
+		assertSshResourceConfig(
+			sentryParisResources,
+			"ssh-resources6-2-server-11",
+			"server-11",
+			"server-11-id",
+			"server-card"
+		);
+		assertSshResourceConfig(
+			sentryParisResources,
+			"ssh-resources7-1-server-12",
+			"server-12",
+			"server-12-id",
+			"server-12-card"
+		);
+		assertSshResourceConfig(
+			sentryParisResources,
+			"ssh-resources7-2-server-13",
+			"server-13",
+			"server-13-id",
+			"server-13-card"
+		);
+
+		final Map<String, ResourceConfig> resources = configuration.getResources();
+		assertSnmpResourceConfig(
+			resources,
+			"snmp-resources-1-snmp-agent-1",
+			"snmp-agent-1",
+			"snmp-agent-1-id",
+			"snmp-agent-1-card"
+		);
+		assertSnmpResourceConfig(
+			resources,
+			"snmp-resources-2-snmp-agent-2",
+			"snmp-agent-2",
+			"snmp-agent-2-id",
+			"snmp-agent-2-card"
+		);
+	}
+
+	/**
+	 * Asserts the SSH resource configuration.
+	 *
+	 * @param sentryParisResources     The resource group from which the resources are extracted
+	 * @param expectedResourceKey      The key of the resource to assert
+	 * @param expectedHostName         The expected hostname
+	 * @param expectedHostId           The expected host id
+	 * @param expectedProtocolHostname The expected hostname for the protocol
+	 */
+	private void assertSshResourceConfig(
+		final Map<String, ResourceConfig> sentryParisResources,
+		String expectedResourceKey,
+		String expectedHostName,
+		String expectedHostId,
+		String expectedProtocolHostname
+	) {
+		final ResourceConfig resourceConfig = sentryParisResources.get(expectedResourceKey);
+
+		assertResourceConfigAttributes(expectedResourceKey, expectedHostName, expectedHostId, resourceConfig);
+		final SshConfiguration sshProtocol = (SshConfiguration) resourceConfig.getProtocols().get("ssh");
+		assertEquals("username", sshProtocol.getUsername(), "Unexpected protocol username for " + expectedResourceKey);
+		assertArrayEquals(
+			new char[] { 'p', 'a', 's', 's' },
+			sshProtocol.getPassword(),
+			"Unexpected protocol password for " + expectedResourceKey
+		);
+		assertEquals(
+			expectedProtocolHostname,
+			sshProtocol.getHostname(),
+			"Unexpected protocol hostname for " + expectedResourceKey
+		);
+	}
+
+	/**
+	 * Asserts the SNMP resource configuration.
+	 *
+	 * @param sentryParisResources     The resource group from which the resources are extracted
+	 * @param expectedResourceKey      The key of the resource to assert
+	 * @param expectedHostName         The expected hostname
+	 * @param expectedHostId           The expected host id
+	 * @param expectedProtocolHostname The expected hostname for the protocol
+	 */
+	private void assertSnmpResourceConfig(
+		final Map<String, ResourceConfig> sentryParisResources,
+		String expectedResourceKey,
+		String expectedHostName,
+		String expectedHostId,
+		String expectedProtocolHostname
+	) {
+		final ResourceConfig resourceConfig = sentryParisResources.get(expectedResourceKey);
+
+		assertResourceConfigAttributes(expectedResourceKey, expectedHostName, expectedHostId, resourceConfig);
+		final SnmpConfiguration snmpProtocol = (SnmpConfiguration) resourceConfig.getProtocols().get("snmp");
+		assertEquals(
+			SnmpConfiguration.SnmpVersion.V2C,
+			snmpProtocol.getVersion(),
+			"Unexpected protocol version for " + expectedResourceKey
+		);
+		assertEquals(
+			expectedProtocolHostname,
+			snmpProtocol.getHostname(),
+			"Unexpected protocol hostname for " + expectedResourceKey
+		);
+	}
+
+	/**
+	 * Asserts the resource configuration attributes.
+	 *
+	 * @param expectedResourceKey The key of the resource to assert
+	 * @param expectedHostName    The expected hostname
+	 * @param expectedHostId      The expected host id
+	 * @param resourceConfig      The resource configuration to assert
+	 */
+	private void assertResourceConfigAttributes(
+		final String expectedResourceKey,
+		final String expectedHostName,
+		final String expectedHostId,
+		final ResourceConfig resourceConfig
+	) {
+		assertNotNull(resourceConfig, "Resource not found: " + expectedResourceKey);
+		final Map<String, String> resourceAttributes = resourceConfig.getAttributes();
+		assertEquals(
+			expectedHostName,
+			resourceAttributes.get("host.name"),
+			"Unexpected host.name attribute value " + expectedResourceKey
+		);
+		assertEquals(
+			expectedHostId,
+			resourceAttributes.get("host.id"),
+			"Unexpected host.id attribute value " + expectedResourceKey
+		);
+		assertEquals(
+			"storage",
+			resourceAttributes.get("host.type"),
+			"Unexpected host.type attribute value " + expectedResourceKey
+		);
+	}
+}

--- a/metricshub-agent/src/test/resources/config/metricshub-multi-hosts.yaml
+++ b/metricshub-agent/src/test/resources/config/metricshub-multi-hosts.yaml
@@ -1,0 +1,93 @@
+resources:
+    # Resource configuration
+  snmp-resources: 
+    # Adds additional static attributes to the resource.
+    attributes:
+      host.name: [ snmp-agent-1, snmp-agent-2 ]
+      host.id: [ snmp-agent-1-id, snmp-agent-2-id ]
+      host.type: storage
+    protocols:
+      snmp:
+        hostname: [ snmp-agent-1-card, snmp-agent-2-card ]
+        version: 2c
+
+# Resource Groups configuration
+resourceGroups:
+    # Resource Group identifier
+  sentry-paris:
+    # Adds additional static metrics to all the resources in the group.
+    resources:
+       # Resource configuration
+      ssh-resources1: 
+        # Adds additional static attributes to the resource.
+        attributes:
+          host.name: [ server-1, server-2 ]
+          host.id: [ server-1-id, server-2-id ]
+          host.type: storage
+        protocols:
+          ssh:
+            username: username
+            password: pass
+      ssh-resources2: 
+        # Adds additional static attributes to the resource.
+        attributes:
+          host.name: server-3
+          host.id: [ server-3-id ]
+          host.type: storage
+        protocols:
+          ssh:
+            username: username
+            password: pass
+      ssh-resources3: 
+        # Adds additional static attributes to the resource.
+        attributes:
+          host.name: [ server-4, server-5 ]
+          host.id: [ server-id ]
+          host.type: storage
+        protocols:
+          ssh:
+            username: username
+            password: pass
+      ssh-resources4: 
+        # Adds additional static attributes to the resource.
+        attributes:
+          host.name: [ server-6, server-7 ]
+          host.id: [ server-6-id, server-7-id, server-8-id ]
+          host.type: storage
+        protocols:
+          ssh:
+            username: username
+            password: pass
+      ssh-resources5: 
+        # Adds additional static attributes to the resource.
+        attributes:
+          host.name: [ server-8, server-9 ]
+          host.id: [ server-8-id, server-9-id ]
+          host.type: storage
+        protocols:
+          ssh:
+            username: username
+            password: pass
+            hostname: [ server-8-card, server-9-card ]
+      ssh-resources6: 
+        # Adds additional static attributes to the resource.
+        attributes:
+          host.name: [ server-10, server-11 ]
+          host.id: [ server-10-id, server-11-id ]
+          host.type: storage
+        protocols:
+          ssh:
+            username: username
+            password: pass
+            hostname: [ server-card ]
+      ssh-resources7: 
+        # Adds additional static attributes to the resource.
+        attributes:
+          host.name: [ server-12, server-13 ]
+          host.id: [ server-12-id, server-13-id ]
+          host.type: storage
+        protocols:
+          ssh:
+            username: username
+            password: pass
+            hostname: [ server-12-card, server-13-card, server-14-card ]

--- a/metricshub-agent/src/test/resources/config/metricshub.yaml
+++ b/metricshub-agent/src/test/resources/config/metricshub.yaml
@@ -60,7 +60,7 @@ resourceGroups:
       snmp-resources: 
         # Adds additional static attributes to the resource.
         attributes:
-          host.names: [ server-2, server-3 ]
+          host.names: [ server-2, server-3 ] # Deprecated, change to host.name in the future
           host.type: storage
         metrics:
           hw.host.configured: 1

--- a/metricshub-doc/src/site/markdown/configuration/configure-monitoring.md
+++ b/metricshub-doc/src/site/markdown/configuration/configure-monitoring.md
@@ -103,8 +103,9 @@ resources:
 resources:
   <resource-id>:
     attributes:
-      host.names: [<hostname1>, <hostname2>, etc.]
-      host.type: <type> 
+      host.name: [ <hostname1>, <hostname2>, etc. ]
+      host.type: <type>
+      host.extra.attribute: [ <extra-attribute-for-hostname1>, <extra-attribute-for-hostname2>, etc. ]
     <protocol-configuration>
 ```
 Whatever the syntax adopted, replace:
@@ -530,6 +531,7 @@ By default, the `host.name` attribute is used for both the hostname or IP addres
 If the `hostname` parameter is specified in the protocol configuration, it overrides the `host.name` attribute for client requests. In this case, the `host.name` will only be used as a metric attribute.
 
 #### Example
+
 ```yaml
 resources:
   myHost1:
@@ -546,9 +548,39 @@ resources:
         port: 161
         timeout: 1m
 ```
+
 In the example above:
 * `my-host-01` will be used to send requests to the host
 * `custom-hostname` will be used as the hostname in the metrics.
+
+### Customize Hostnames for shared configurations
+
+When working with configurations that share characteristics across multiple resources, you can define multiple hostnames and metric attributes using lists for `host.name` and `hostname`.
+
+#### Example (Resources sharing similar characteristics)
+
+```yaml
+resources:
+  shared-characteristic-hosts:
+    attributes:
+      # `custom-hostname1` and `custom-hostname2` will set the host.name attribute in the collected metrics.
+      host.name: [ custom-hostname1, custom-hostname2 ]
+      host.type: linux
+    protocols:
+      snmp:
+        # my-host-01 and my-host-02 will be used to send requests to the hosts.
+        hostname: [ my-host-01, my-host-02 ]
+        version: v1
+        community: public
+        port: 161
+        timeout: 1m
+```
+
+In this example:
+* `my-host-01` and `my-host-02` will be used to send requests to the hosts.
+* `custom-hostname1` and `custom-hostname2` will set the `host.name` attribute in the metrics.
+
+> **Note**: The order of values in `host.name` must align exactly with the order in `hostname`. Each entry in `host.name` corresponds to the entry at the same position in `hostname`. Misalignment between these lists will result in mismatched data, causing inconsistencies in the metrics collected for each resource.
 
 ### Customize resource monitoring
 

--- a/metricshub-doc/src/site/markdown/configuration/configure-monitoring.md
+++ b/metricshub-doc/src/site/markdown/configuration/configure-monitoring.md
@@ -524,63 +524,53 @@ resourceGroups:
 
 ## Step 3: Configure additional settings
 
-### Customize the hostname
+### Customize resource hostname
 
-By default, the `host.name` attribute is used for both the hostname or IP address of the resource and as the hostname of each OpenTelemetry metric attached to the host resource.
+By default, the `host.name` attribute specified for a resource determines both:
+* the hostname used to execute requests against the resource for collecting metrics
+* the hostname associated with each OpenTelemetry metric collected for the resource.
 
-If the `hostname` parameter is specified in the protocol configuration, it overrides the `host.name` attribute for client requests. In this case, the `host.name` will only be used as a metric attribute.
+If your resource requires different hostnames for these purposes, you can customize the configuration as follows.
 
-#### Example
+#### Example for unique resources
+
+Here’s an example of customizing the hostname for a unique resource:
 
 ```yaml
 resources:
   myHost1:
     attributes:
-      # `custom-hostname` will be the hostname value in the collected metrics.
-      host.name: custom-hostname
+      host.name: custom-hostname # Hostname applied to the collected metrics 
       host.type: linux
     protocols:
       snmp:
-        # my-host-01 will be used to send requests to the host.
-        hostname: my-host-01
+        hostname: my-host-01 # Hostname used for the SNMP requests
         version: v1
         community: public
         port: 161
         timeout: 1m
 ```
 
-In the example above:
-* `my-host-01` will be used to send requests to the host
-* `custom-hostname` will be used as the hostname in the metrics.
+#### Example for resources sharing similar characteristics
 
-### Customize Hostnames for shared configurations
-
-When working with configurations that share characteristics across multiple resources, you can define multiple hostnames and metric attributes using lists for `host.name` and `hostname`.
-
-#### Example (Resources sharing similar characteristics)
+For resources with shared characteristics, you can define multiple hostnames in the configuration: 
 
 ```yaml
 resources:
   shared-characteristic-hosts:
     attributes:
-      # `custom-hostname1` and `custom-hostname2` will set the host.name attribute in the collected metrics.
-      host.name: [ custom-hostname1, custom-hostname2 ]
+      host.name: [ custom-hostname1, custom-hostname2 ] # Hostnames applied to the collected metrics 
       host.type: linux
     protocols:
       snmp:
-        # my-host-01 and my-host-02 will be used to send requests to the hosts.
-        hostname: [ my-host-01, my-host-02 ]
+        hostname: [ my-host-01, my-host-02 ] # Hostnames used for the SNMP requests
         version: v1
         community: public
         port: 161
         timeout: 1m
 ```
 
-In this example:
-* `my-host-01` and `my-host-02` will be used to send requests to the hosts.
-* `custom-hostname1` and `custom-hostname2` will set the `host.name` attribute in the metrics.
-
-> **Note**: The order of values in `host.name` must align exactly with the order in `hostname`. Each entry in `host.name` corresponds to the entry at the same position in `hostname`. Misalignment between these lists will result in mismatched data, causing inconsistencies in the metrics collected for each resource.
+> **Important**: Ensure the values of `host.name` are listed in the exact same order as those in `hostname`. Each value listed in `host.name` must correspond to the value at the same position in `hostname`. Misaligned orders will result in mismatched data and inconsistencies in the collected metrics for each resource.
 
 ### Customize resource monitoring
 

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/MetricsHubConstants.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/MetricsHubConstants.java
@@ -393,4 +393,9 @@ public class MetricsHubConstants {
 	 * Default keys for monitor jobs
 	 */
 	public static final Set<String> DEFAULT_KEYS = Set.of(MetricsHubConstants.MONITOR_ATTRIBUTE_ID);
+
+	/**
+	 * MetricsHub multi value attribute separator
+	 */
+	public static final String MULTI_VALUE_SEPARATOR = "_@M8B_MULTI_VALUE_SEP@_";
 }

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/StringHelper.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/StringHelper.java
@@ -192,19 +192,34 @@ public class StringHelper {
 	 * @return The string representation of the value, or a CSV string if the value is a collection or an array.
 	 */
 	public static String stringify(final Object value) {
+		return stringify(value, COMMA);
+	}
+
+	/**
+	 * Convert the given value to a string representation. If the value is a collection or an array, it is transformed into a string
+	 * using the specified separator.
+	 *
+	 * @param value     The value to be converted to a string.
+	 * @param separator The separator to be used when converting a collection or an array to a string.
+	 * @return The string representation of the value, or a string using the specified separator if the value is a collection
+	 */
+	public static String stringify(final Object value, final String separator) {
 		if (value == null) {
 			// Handle null input
 			return EMPTY;
 		} else if (value instanceof Collection<?> collection) {
 			// If the input is a List, convert it to a CSV string
-			return collection.stream().map(item -> item != null ? item.toString() : EMPTY).collect(Collectors.joining(COMMA));
+			return collection
+				.stream()
+				.map(item -> item != null ? item.toString() : EMPTY)
+				.collect(Collectors.joining(separator));
 		} else if (value.getClass().isArray()) {
 			// If the input is an array, convert it to a CSV string
 			Object[] array = (Object[]) value;
 			return Arrays
 				.stream(array)
 				.map(item -> item != null ? item.toString() : EMPTY)
-				.collect(Collectors.joining(COMMA));
+				.collect(Collectors.joining(separator));
 		} else {
 			// For any other type of value, simply convert it to a string
 			return value.toString();

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/deserialization/MultiValueDeserializer.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/deserialization/MultiValueDeserializer.java
@@ -1,0 +1,44 @@
+package org.sentrysoftware.metricshub.engine.deserialization;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Engine
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2024 Sentry Software
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants;
+import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
+
+/**
+ * Custom JSON deserializer for converting multi-value collection to a single string.
+ */
+public class MultiValueDeserializer extends JsonDeserializer<String> {
+
+	@Override
+	public String deserialize(JsonParser parser, DeserializationContext ctxt) throws IOException {
+		if (parser == null) {
+			return null;
+		}
+
+		return StringHelper.stringify(parser.readValueAs(Object.class), MetricsHubConstants.MULTI_VALUE_SEPARATOR);
+	}
+}

--- a/metricshub-http-extension/src/main/java/org/sentrysoftware/metricshub/extension/http/HttpConfiguration.java
+++ b/metricshub-http-extension/src/main/java/org/sentrysoftware/metricshub/extension/http/HttpConfiguration.java
@@ -33,6 +33,7 @@ import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
 import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
+import org.sentrysoftware.metricshub.engine.deserialization.MultiValueDeserializer;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 
 /**
@@ -60,6 +61,8 @@ public class HttpConfiguration implements IConfiguration {
 	private String username;
 	private char[] password;
 
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = MultiValueDeserializer.class)
 	private String hostname;
 
 	@Override
@@ -110,6 +113,7 @@ public class HttpConfiguration implements IConfiguration {
 			.https(https)
 			.port(port)
 			.timeout(timeout)
+			.hostname(hostname)
 			.build();
 	}
 }

--- a/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiConfiguration.java
+++ b/metricshub-ipmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/ipmi/IpmiConfiguration.java
@@ -33,6 +33,7 @@ import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
 import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
+import org.sentrysoftware.metricshub.engine.deserialization.MultiValueDeserializer;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 
 /**
@@ -55,6 +56,8 @@ public class IpmiConfiguration implements IConfiguration {
 	private boolean skipAuth;
 	private String bmcKey;
 
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = MultiValueDeserializer.class)
 	private String hostname;
 
 	@Override
@@ -97,6 +100,7 @@ public class IpmiConfiguration implements IConfiguration {
 			.skipAuth(skipAuth)
 			.timeout(timeout)
 			.username(username)
+			.hostname(hostname)
 			.build();
 	}
 }

--- a/metricshub-linux/src/main/resources/jpackage/metricshub/config/metricshub-example.yaml
+++ b/metricshub-linux/src/main/resources/jpackage/metricshub/config/metricshub-example.yaml
@@ -295,7 +295,7 @@ resourceGroups:
 
       # group-1:
       #   attributes:
-      #     host.names: [server-14, server-15, server-16]
+      #     host.name: [server-14, server-15, server-16]
       #     host.type: linux
       #   protocols:
       #     snmp:

--- a/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfiguration.java
+++ b/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandConfiguration.java
@@ -33,6 +33,7 @@ import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
 import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
+import org.sentrysoftware.metricshub.engine.deserialization.MultiValueDeserializer;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 
 /**
@@ -60,7 +61,9 @@ public class OsCommandConfiguration implements IConfiguration {
 	@JsonDeserialize(using = TimeDeserializer.class)
 	Long timeout = DEFAULT_TIMEOUT;
 
-	private String hostname;
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = MultiValueDeserializer.class)
+	String hostname;
 
 	/**
 	 * Creates a new instance of OsCommandConfiguration using the provided parameters.
@@ -114,6 +117,7 @@ public class OsCommandConfiguration implements IConfiguration {
 			.timeout(timeout)
 			.useSudo(useSudo)
 			.useSudoCommands(new HashSet<>(useSudoCommands))
+			.hostname(hostname)
 			.build();
 	}
 }

--- a/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/SshConfiguration.java
+++ b/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/SshConfiguration.java
@@ -141,6 +141,7 @@ public class SshConfiguration extends OsCommandConfiguration {
 			.username(username)
 			.useSudo(useSudo)
 			.useSudoCommands(new HashSet<>(useSudoCommands))
+			.hostname(hostname)
 			.build();
 	}
 }

--- a/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtensionTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/sentrysoftware/metricshub/extension/oscommand/OsCommandExtensionTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;

--- a/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingConfiguration.java
+++ b/metricshub-ping-extension/src/main/java/org/sentrysoftware/metricshub/extension/ping/PingConfiguration.java
@@ -33,6 +33,7 @@ import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
 import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
+import org.sentrysoftware.metricshub.engine.deserialization.MultiValueDeserializer;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 
 /**
@@ -52,6 +53,8 @@ public class PingConfiguration implements IConfiguration {
 	@JsonDeserialize(using = TimeDeserializer.class)
 	private final Long timeout = 5L;
 
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = MultiValueDeserializer.class)
 	private String hostname;
 
 	@Override
@@ -72,6 +75,6 @@ public class PingConfiguration implements IConfiguration {
 
 	@Override
 	public IConfiguration copy() {
-		return PingConfiguration.builder().timeout(timeout).build();
+		return PingConfiguration.builder().timeout(timeout).hostname(hostname).build();
 	}
 }

--- a/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfiguration.java
+++ b/metricshub-snmp-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmp/SnmpConfiguration.java
@@ -35,6 +35,7 @@ import lombok.NonNull;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
 import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
+import org.sentrysoftware.metricshub.engine.deserialization.MultiValueDeserializer;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 
 /**
@@ -68,6 +69,8 @@ public class SnmpConfiguration implements ISnmpConfiguration {
 	@JsonDeserialize(using = TimeDeserializer.class)
 	private final Long timeout = 120L;
 
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = MultiValueDeserializer.class)
 	private String hostname;
 
 	@Override
@@ -173,6 +176,13 @@ public class SnmpConfiguration implements ISnmpConfiguration {
 
 	@Override
 	public IConfiguration copy() {
-		return SnmpConfiguration.builder().community(community).port(port).timeout(timeout).version(version).build();
+		return SnmpConfiguration
+			.builder()
+			.community(community)
+			.port(port)
+			.timeout(timeout)
+			.version(version)
+			.hostname(hostname)
+			.build();
 	}
 }

--- a/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Configuration.java
+++ b/metricshub-snmpv3-extension/src/main/java/org/sentrysoftware/metricshub/extension/snmpv3/SnmpV3Configuration.java
@@ -34,6 +34,7 @@ import lombok.NonNull;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
 import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
+import org.sentrysoftware.metricshub.engine.deserialization.MultiValueDeserializer;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 import org.sentrysoftware.metricshub.extension.snmp.ISnmpConfiguration;
 
@@ -49,6 +50,7 @@ import org.sentrysoftware.metricshub.extension.snmp.ISnmpConfiguration;
 @NoArgsConstructor
 public class SnmpV3Configuration implements ISnmpConfiguration {
 
+	private static final String SNMP_V3_DESCRIPTION = "SNMP V3";
 	private static final int V3 = 3;
 	private static final String INVALID_AUTH_TYPE_EXCEPTION_MESSAGE = "Invalid authentication type: ";
 	private static final String INVALID_PRIVACY_VALUE_EXCEPTION_MESSAGE = "Invalid privacy value: ";
@@ -75,11 +77,13 @@ public class SnmpV3Configuration implements ISnmpConfiguration {
 	private char[] password;
 	private int[] retryIntervals;
 
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = MultiValueDeserializer.class)
 	private String hostname;
 
 	@Override
 	public String toString() {
-		String description = "SNMP V3";
+		String description = SNMP_V3_DESCRIPTION;
 		if (username != null) {
 			description = description + " as " + username;
 		}
@@ -99,7 +103,7 @@ public class SnmpV3Configuration implements ISnmpConfiguration {
 					"Resource %s - Invalid port configured for protocol %s. Port value returned: %s." +
 					" This resource will not be monitored. Please verify the configured port value.",
 					resourceKey,
-					"SNMP V3",
+					SNMP_V3_DESCRIPTION,
 					port
 				)
 		);
@@ -112,7 +116,7 @@ public class SnmpV3Configuration implements ISnmpConfiguration {
 					"Resource %s - Timeout value is invalid for protocol %s." +
 					" Timeout value returned: %s. This resource will not be monitored. Please verify the configured timeout value.",
 					resourceKey,
-					"SNMP V3",
+					SNMP_V3_DESCRIPTION,
 					timeout
 				)
 		);
@@ -221,6 +225,7 @@ public class SnmpV3Configuration implements ISnmpConfiguration {
 			.retryIntervals(retryIntervals)
 			.timeout(timeout)
 			.username(username)
+			.hostname(hostname)
 			.build();
 	}
 }

--- a/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfiguration.java
+++ b/metricshub-wbem-extension/src/main/java/org/sentrysoftware/metricshub/extension/wbem/WbemConfiguration.java
@@ -34,6 +34,7 @@ import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfiguratio
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
 import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 import org.sentrysoftware.metricshub.engine.configuration.TransportProtocols;
+import org.sentrysoftware.metricshub.engine.deserialization.MultiValueDeserializer;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 
 /**
@@ -64,6 +65,8 @@ public class WbemConfiguration implements IConfiguration {
 	char[] password;
 	String vCenter;
 
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = MultiValueDeserializer.class)
 	private String hostname;
 
 	@Override
@@ -145,6 +148,7 @@ public class WbemConfiguration implements IConfiguration {
 			.timeout(timeout)
 			.username(username)
 			.vCenter(vCenter)
+			.hostname(hostname)
 			.build();
 	}
 }

--- a/metricshub-windows/src/main/resources/jpackage/MetricsHub/config/metricshub-example.yaml
+++ b/metricshub-windows/src/main/resources/jpackage/MetricsHub/config/metricshub-example.yaml
@@ -295,7 +295,7 @@ resourceGroups:
 
       # group-1:
       #   attributes:
-      #     host.names: [server-14, server-15, server-16]
+      #     host.name: [server-14, server-15, server-16]
       #     host.type: linux
       #   protocols:
       #     snmp:

--- a/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
+++ b/metricshub-winrm-extension/src/main/java/org/sentrysoftware/metricshub/extension/winrm/WinRmConfiguration.java
@@ -36,6 +36,7 @@ import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfiguratio
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
 import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
 import org.sentrysoftware.metricshub.engine.configuration.TransportProtocols;
+import org.sentrysoftware.metricshub.engine.deserialization.MultiValueDeserializer;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 import org.sentrysoftware.metricshub.extension.win.IWinConfiguration;
 import org.sentrysoftware.winrm.service.client.auth.AuthenticationEnum;
@@ -50,12 +51,16 @@ import org.sentrysoftware.winrm.service.client.auth.AuthenticationEnum;
 @NoArgsConstructor
 public class WinRmConfiguration implements IWinConfiguration {
 
+	private static final String WINRM_DESCRIPTION = "WinRm";
+
 	private String username;
 
 	private char[] password;
 
 	private String namespace;
 
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = MultiValueDeserializer.class)
 	private String hostname;
 
 	@Default
@@ -83,7 +88,7 @@ public class WinRmConfiguration implements IWinConfiguration {
 					"Resource %s - Invalid port configured for protocol %s. Port value returned: %s." +
 					" This resource will not be monitored. Please verify the configured port value.",
 					resourceKey,
-					"WinRm",
+					WINRM_DESCRIPTION,
 					port
 				)
 		);
@@ -96,7 +101,7 @@ public class WinRmConfiguration implements IWinConfiguration {
 					"Resource %s - Timeout value is invalid for protocol %s." +
 					" Timeout value returned: %s. This resource will not be monitored. Please verify the configured timeout value.",
 					resourceKey,
-					"WinRm",
+					WINRM_DESCRIPTION,
 					timeout
 				)
 		);
@@ -109,14 +114,14 @@ public class WinRmConfiguration implements IWinConfiguration {
 					"Resource %s - No username configured for protocol %s." +
 					" This resource will not be monitored. Please verify the configured username.",
 					resourceKey,
-					"WinRm"
+					WINRM_DESCRIPTION
 				)
 		);
 	}
 
 	@Override
 	public String toString() {
-		String desc = "WinRm";
+		String desc = WINRM_DESCRIPTION;
 		if (username != null) {
 			desc = desc + " as " + username;
 		}
@@ -134,6 +139,7 @@ public class WinRmConfiguration implements IWinConfiguration {
 			.protocol(protocol)
 			.timeout(timeout)
 			.username(username)
+			.hostname(hostname)
 			.build();
 	}
 }

--- a/metricshub-wmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/wmi/WmiConfiguration.java
+++ b/metricshub-wmi-extension/src/main/java/org/sentrysoftware/metricshub/extension/wmi/WmiConfiguration.java
@@ -33,6 +33,7 @@ import lombok.NoArgsConstructor;
 import org.sentrysoftware.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.sentrysoftware.metricshub.engine.common.helpers.StringHelper;
 import org.sentrysoftware.metricshub.engine.configuration.IConfiguration;
+import org.sentrysoftware.metricshub.engine.deserialization.MultiValueDeserializer;
 import org.sentrysoftware.metricshub.engine.deserialization.TimeDeserializer;
 import org.sentrysoftware.metricshub.extension.win.IWinConfiguration;
 
@@ -50,6 +51,8 @@ public class WmiConfiguration implements IWinConfiguration {
 	private char[] password;
 	private String namespace;
 
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = MultiValueDeserializer.class)
 	private String hostname;
 
 	@Default
@@ -90,6 +93,7 @@ public class WmiConfiguration implements IWinConfiguration {
 			.password(password)
 			.timeout(timeout)
 			.username(username)
+			.hostname(hostname)
 			.build();
 	}
 }


### PR DESCRIPTION
This pull request includes several changes to the deserialization logic in the `metricshub-agent` project, focusing on handling multi-value attributes and updating resource configurations. The most important changes include modifications to the `AttributesDeserializer` and `PostConfigDeserializer` classes, as well as updates to the associated tests.

### Deserialization Logic Improvements:

* [`AttributesDeserializer.java`](diffhunk://#diff-e7331969375ae5dccd91666b58e72e951809dd8c1377c464f32f5b6abff31b45R24-R25): Added the `MULTI_VALUE_SEPARATOR` constant to handle multi-value attributes during deserialization. Updated the `deserialize` method to use this separator. [[1]](diffhunk://#diff-e7331969375ae5dccd91666b58e72e951809dd8c1377c464f32f5b6abff31b45R24-R25) [[2]](diffhunk://#diff-e7331969375ae5dccd91666b58e72e951809dd8c1377c464f32f5b6abff31b45L63-R65)
* [`PostConfigDeserializer.java`](diffhunk://#diff-347083d86da737255b9cc7affc2b4b0634e380c57ef753a1517367e968ab3cedL24-R59): Replaced the handling of multiple hosts with handling multiple resources, updated the logic to split multi-value attributes, and added methods to normalize protocol hostnames and determine attribute values. Deprecated the `MULTI_HOST_ATTRIBUTE_KEY`. [[1]](diffhunk://#diff-347083d86da737255b9cc7affc2b4b0634e380c57ef753a1517367e968ab3cedL24-R59) [[2]](diffhunk://#diff-347083d86da737255b9cc7affc2b4b0634e380c57ef753a1517367e968ab3cedL75-R87) [[3]](diffhunk://#diff-347083d86da737255b9cc7affc2b4b0634e380c57ef753a1517367e968ab3cedL89-R134) [[4]](diffhunk://#diff-347083d86da737255b9cc7affc2b4b0634e380c57ef753a1517367e968ab3cedL131-R265)

### Test Updates:

* [`AgentContextTest.java`](diffhunk://#diff-ba5af940832001d8cae2ea582f978150cf759cc7196ccebf197f3b64bfa68483L125-R128): Updated test cases to reflect the new resource key format for multi-resource configurations.
* [`AttributesDeserializerTest.java`](diffhunk://#diff-9e176c479c4aeec01eb394f3c38de031891c9577c427ee2d6052211b720a3222R17): Modified the test to use the `MULTI_VALUE_SEPARATOR` constant and adjusted the expected results for multi-value attributes. [[1]](diffhunk://#diff-9e176c479c4aeec01eb394f3c38de031891c9577c427ee2d6052211b720a3222R17) [[2]](diffhunk://#diff-9e176c479c4aeec01eb394f3c38de031891c9577c427ee2d6052211b720a3222L31-R35)
---------------------------------------------------------------------------
Testing

### Legacy `host.names`
![legacy-host names-non-reg](https://github.com/user-attachments/assets/82b1b6eb-678a-4926-8c36-ebecdcbdeed1)
### `host.name` as array
![test-host name-as-array](https://github.com/user-attachments/assets/ba043e32-4fb1-4012-aa19-1c98a21ba1f6)
### Multiple attributes as array
![test-multiple-attributes-as-array](https://github.com/user-attachments/assets/9ab6bd7f-5249-41e2-83ab-55392712af2f)
### `host.name` and protocol `hostname` as array
![test-multiple-host name-as-array-plus-protocol-hostname](https://github.com/user-attachments/assets/494c6a29-cd04-42c0-9e2f-8d831aa1e3d5)


