### PR TITLE
Issue #500: Mono-Instance collect processes only one monitor

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java
@@ -266,25 +266,12 @@ public class CollectStrategy extends AbstractStrategy {
 				final Map<String, Monitor> sameTypeMonitors = telemetryManager.findMonitorsByType(monitorType);
 
 				if (sameTypeMonitors != null && !sameTypeMonitors.isEmpty()) {
-					final Map<String, Monitor> sameTypeSameConnectorMonitors = sameTypeMonitors
+					sameTypeMonitors
 						.values()
 						.stream()
 						.filter(monitor ->
 							currentConnector.getCompiledFilename().equals(monitor.getAttribute(MONITOR_ATTRIBUTE_CONNECTOR_ID))
 						)
-						.collect(
-							Collectors.toMap(
-								monitorEntry -> monitorEntry.getAttribute(MONITOR_ATTRIBUTE_CONNECTOR_ID),
-								monitorEntry -> monitorEntry,
-								(oldValue, newValue) -> oldValue,
-								LinkedHashMap::new
-							)
-						);
-
-					// Loop on each monitor
-					sameTypeSameConnectorMonitors
-						.values()
-						.stream()
 						.forEach(monitor -> {
 							processSourcesAndComputes(orderedSources.getSources(), monitor.getAttributes(), jobInfo);
 							processMonitors(monitorType, collect.getMapping(), currentConnector, hostname, monitor);


### PR DESCRIPTION
* Resolved an issue in the `CollectStrategy` where mono-instance collect was limited to processing only one connector due to incorrect indexation logic.
* Updated the logic to iterate over all relevant monitors, ensuring that metrics are collected for each connector during mono-instance collect.

This pull request includes a change to the `processMonitorJob` method in the `CollectStrategy` class to simplify the processing of monitors by removing unnecessary intermediate collections and directly iterating over the filtered stream.

Fix monitor processing:

* [`metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java`](diffhunk://#diff-df056a21da0447fb587fcc752797b20168ca4e31e3bb80af1b591c07c5061fdbL269-L287): Removed the creation of the `sameTypeSameConnectorMonitors` map and directly iterated over the filtered stream of monitors.
-------
Testing

## CLI Output 

### Before 

Predicted failure is collected on the last disk only

```shel-session
    physical_disk monitors:
    - physical_disk: /dev/sde ()

      Attributes:
      connector_id: SmartMonLinux
      hw.parent.type: enclosure
      id: /dev/sde
      name: /dev/sde ()
      serial_number: 3HW1PQW2

      Metrics:
      hw.power{hw.type="physical_disk"}                       11 W
      hw.status{hw.type="physical_disk", state="present"}     1

    - physical_disk: /dev/sdf ()

      Attributes:
      connector_id: SmartMonLinux
      hw.parent.type: enclosure
      id: /dev/sdf
      name: /dev/sdf ()
      serial_number: 3HW1PDWB

      Metrics:
      hw.power{hw.type="physical_disk"}                       11 W
      hw.status{hw.type="physical_disk", state="present"}     1

    - physical_disk: /dev/sdh ()

      Attributes:
      connector_id: SmartMonLinux
      hw.parent.type: enclosure
      id: /dev/sdh
      name: /dev/sdh ()
      serial_number: 021730018781

      Metrics:
      hw.power{hw.type="physical_disk"}                       11 W
      hw.status{hw.type="physical_disk", state="present"}     1

    - physical_disk: /dev/sdi ()

      Attributes:
      connector_id: SmartMonLinux
      hw.parent.type: enclosure
      id: /dev/sdi
      name: /dev/sdi ()
      serial_number: 021730018781

      Metrics:
      hw.power{hw.type="physical_disk"}                       11 W
      hw.status{hw.type="physical_disk", state="present"}     1

    - physical_disk: /dev/sdj ()

      Attributes:
      connector_id: SmartMonLinux
      hw.parent.type: enclosure
      id: /dev/sdj
      name: /dev/sdj ()
      serial_number: 021730018781

      Metrics:
      hw.power{hw.type="physical_disk"}                                 11 W
      hw.status{hw.type="physical_disk", state="predicted_failure"}     0
      hw.status{hw.type="physical_disk", state="present"}               1
      hw.status{hw.type="physical_disk"}                                OK

      Text parameters:
        StatusInformation:
        Working
```

### Now

Each disk is collected

```shell-session
    physical_disk monitors:
    - physical_disk: /dev/sde ()

      Attributes:
      connector_id: SmartMonLinux
      hw.parent.type: enclosure
      id: /dev/sde
      name: /dev/sde ()
      serial_number: 3HW1PQW2

      Metrics:
      hw.power{hw.type="physical_disk"}                                 11 W
      hw.status{hw.type="physical_disk", state="predicted_failure"}     0
      hw.status{hw.type="physical_disk", state="present"}               1
      hw.status{hw.type="physical_disk"}                                OK

      Text parameters:
        StatusInformation:
        Working


    - physical_disk: /dev/sdf ()

      Attributes:
      connector_id: SmartMonLinux
      hw.parent.type: enclosure
      id: /dev/sdf
      name: /dev/sdf ()
      serial_number: 3HW1PDWB

      Metrics:
      hw.power{hw.type="physical_disk"}                                 11 W
      hw.status{hw.type="physical_disk", state="predicted_failure"}     0
      hw.status{hw.type="physical_disk", state="present"}               1
      hw.status{hw.type="physical_disk"}                                OK

      Text parameters:
        StatusInformation:
        Working


    - physical_disk: /dev/sdh ()

      Attributes:
      connector_id: SmartMonLinux
      hw.parent.type: enclosure
      id: /dev/sdh
      name: /dev/sdh ()
      serial_number: 021730018781

      Metrics:
      hw.power{hw.type="physical_disk"}                                 11 W
      hw.status{hw.type="physical_disk", state="predicted_failure"}     0
      hw.status{hw.type="physical_disk", state="present"}               1
      hw.status{hw.type="physical_disk"}                                OK

      Text parameters:
        StatusInformation:
        Working


    - physical_disk: /dev/sdi ()

      Attributes:
      connector_id: SmartMonLinux
      hw.parent.type: enclosure
      id: /dev/sdi
      name: /dev/sdi ()
      serial_number: 021730018781

      Metrics:
      hw.power{hw.type="physical_disk"}                                 11 W
      hw.status{hw.type="physical_disk", state="predicted_failure"}     0
      hw.status{hw.type="physical_disk", state="present"}               1
      hw.status{hw.type="physical_disk"}                                OK

      Text parameters:
        StatusInformation:
        Working


    - physical_disk: /dev/sdj ()

      Attributes:
      connector_id: SmartMonLinux
      hw.parent.type: enclosure
      id: /dev/sdj
      name: /dev/sdj ()
      serial_number: 021730018781

      Metrics:
      hw.power{hw.type="physical_disk"}                                 11 W
      hw.status{hw.type="physical_disk", state="predicted_failure"}     0
      hw.status{hw.type="physical_disk", state="present"}               1
      hw.status{hw.type="physical_disk"}                                OK

      Text parameters:
        StatusInformation:
        Working
```