### PR TITLE
Issue #515: Fix indentation in monitoring use cases

### DIFF
--- a/metricshub-doc/src/site/markdown/usecases/network-interfaces.md
+++ b/metricshub-doc/src/site/markdown/usecases/network-interfaces.md
@@ -23,24 +23,26 @@ To monitor our switch:
    * host type: `network`
 
     ```yaml
-    alcatel-switch:
-        attributes: 
-          host.name: alcatel-switch-01
-          host.type: network
+        resources:
+          alcatel-switch:
+            attributes: 
+              host.name: alcatel-switch-01
+              host.type: network
     ```
 2.  We configure **MetricsHub** to connect to the network switch using the SNMP `v2c` protocol and the `public` community
 
     ```yaml
-        protocols:
-          snmp:
-            version: v2c 
-            community: public 
+            protocols:
+              snmp:
+                version: v2c
+                community: public
     ```
 
 Here is the complete YAML configuration to be added to `config/metricshub.yaml` to monitor the switch:
 
-   ```yaml
-    alcatel-switch:
+```yaml
+    resources:
+      alcatel-switch:
         attributes: 
           host.name: alcatel-switch-01
           host.type: network
@@ -48,4 +50,4 @@ Here is the complete YAML configuration to be added to `config/metricshub.yaml` 
           snmp:
             version: v2c 
             community: public 
-  ```
+```

--- a/metricshub-doc/src/site/markdown/usecases/ping.md
+++ b/metricshub-doc/src/site/markdown/usecases/ping.md
@@ -38,17 +38,17 @@ To configure the **Ping Check** feature:
     ```yaml
             protocols:
               ping:
-                timeout: 3  
+                timeout: 3s
     ```
 
 Here is the complete YAML configuration to be added to `config/metricshub.yaml` to ping resources:
 
-   ```yaml
-        resources:
-          host-ping:
-            attributes:
-              host.name: [ euclide, ibm-v7k, carnap, dev-nvidia-01, babbage, morgan, toland, ibm-fs900, hmc-ds-1, hmc-ds-2, sup-fuji-01 ]
-            protocols:
-              ping:
-                timeout:  3  
-  ```
+```yaml
+    resources:
+      host-ping:
+        attributes:
+          host.name: [ euclide, ibm-v7k, carnap, dev-nvidia-01, babbage, morgan, toland, ibm-fs900, hmc-ds-1, hmc-ds-2, sup-fuji-01 ]
+        protocols:
+          ping:
+            timeout: 3s  
+```

--- a/metricshub-doc/src/site/markdown/usecases/process-windows.md
+++ b/metricshub-doc/src/site/markdown/usecases/process-windows.md
@@ -16,6 +16,34 @@ To monitor the Microsoft SQL Server process:
 1. In the `config/metricshub.yaml` file, we configure the monitoring on a local Windows machine through `WMI`:
 
     ```yaml
+        resources:
+          localhost:
+            attributes:
+              host.name: localhost
+              host.type: windows
+            protocols:
+              wmi:
+                timeout: 120
+    ```
+
+2. We specify the `mssqlProcess` dedicated instance of the [Windows - Processes (WMI)](../connectors/windowsprocess.html) connector:
+
+    ```yaml
+            additionalConnectors:
+              mssqlProcess:
+                uses: WindowsProcess # Connector used
+    ```
+
+3.  We specify the regular expression that will match with the command line of Microsoft SQL Server processes (note how we escape the dot in `sqlservr.exe`):
+
+    ```yaml
+                variables:
+                  matchCommand: "sqlservr\\.exe"
+    ```
+
+Here is the complete YAML configuration to be added to `config/metricshub.yaml` to monitor the `metricshub` process on a Windows machine:
+
+```yaml
     resources:
       localhost:
         attributes:
@@ -24,37 +52,9 @@ To monitor the Microsoft SQL Server process:
         protocols:
           wmi:
             timeout: 120
-    ```
-
-2. We specify the `mssqlProcess` dedicated instance of the [Windows - Processes (WMI)](../connectors/windowsprocess.html) connector:
-
-    ```yaml
         additionalConnectors:
-          mssqlProcess:
-            uses: WindowsProcess # Connector used
-    ```
-
-3.  We specify the regular expression that will match with the command line of Microsoft SQL Server processes (note how we escape the dot in `sqlservr.exe`):
-
-    ```yaml
+          mssqlProcess: 
+            uses: WindowsProcess 
             variables:
               matchCommand: "sqlservr\\.exe"
-    ```
-
-Here is the complete YAML configuration to be added to `config/metricshub.yaml` to monitor the `metricshub` process on a Windows machine:
-
-```yaml
-resources:
-  localhost:
-    attributes:
-      host.name: localhost
-      host.type: windows
-    protocols:
-      wmi:
-        timeout: 120
-    additionalConnectors:
-      mssqlProcess: 
-        uses: WindowsProcess 
-        variables:
-          matchCommand: "sqlservr\\.exe"
 ```

--- a/metricshub-doc/src/site/markdown/usecases/remote-linux.md
+++ b/metricshub-doc/src/site/markdown/usecases/remote-linux.md
@@ -21,15 +21,17 @@ To monitor a remote machine running on Linux:
 1. In the `config/metricshub.yaml` file, we configure the monitoring on a Linux machine through `SSH`: 
 
     ```yaml
+        resources:
           dev-nvidia-01:
             attributes:
               host.name: dev-nvidia-01
               host.type: linux
     ```
+
 2. Then, we configure the SSH protocol
 
     ```yaml
-          protocols:
+            protocols:
               ssh:
                 username: myusername
                 password: mypassword
@@ -39,6 +41,7 @@ Here is the complete YAML configuration to be added to `config/metricshub.yaml`
 to monitor a remote machine running on Linux:
 
 ```yaml
+    resources:
       dev-nvidia-01:
         attributes:
           host.name: dev-nvidia-01

--- a/metricshub-doc/src/site/markdown/usecases/service-health.md
+++ b/metricshub-doc/src/site/markdown/usecases/service-health.md
@@ -22,6 +22,68 @@ To collect data from the Grafana health API:
 1. In the `config/metricshub.yaml` file, we first declare the `m8b-demo-service` resource, specify its `service.name` and `host.name` attributes, following [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/resource/), and HTTP as the protocol to connect to this resource:
 
     ```yaml
+        resources:
+          m8b-demo-grafana:
+            attributes:
+              service.name: Grafana
+              host.name: m8b-demo.metricshub.com
+            protocols:
+              http:
+                https: true
+                port: 443
+    ```
+
+2. We then specify the entity we monitor: `grafana-health` with a `simple` job:  
+
+    ```yaml
+            monitors:
+              grafana-health:
+                simple: 
+    ```
+
+3. We specify the Grafana health API as a data source as follows:
+
+    ```yaml
+                  sources:
+                    # HTTP GET /api/health which returns a JSON
+                    grafanaHealthApi:
+                      type: http
+                      path: /api/health
+                      method: get
+                      header: "Accept: application/json"
+                      computes:
+                      # Convert the JSON document into a simple CSV
+                      - type: json2Csv
+                        entryKey: /
+                        properties: commit;database;version
+                        separator: ;
+                      # Translate the value of "database" in the 2nd column:
+                      # - "ok" --> 1
+                      # - anything else --> 0
+                      - type: translate
+                        column: 3
+                        translationTable:
+                          ok: 1
+                          default: 0
+    ```
+
+4. Finally, we specify how the collected metrics are mapped to **MetricsHub**'s monitoring model:
+
+    ```yaml
+                  mapping:
+                    source: ${esc.d}{source::grafanaHealthApi}
+                    attributes:
+                      id: $2
+                      service.instance.id: $2
+                      service.version: $4
+                    metrics:
+                      grafana.db.status{state="ok"}: $3
+    ```
+
+Here is the complete YAML configuration to be added to `config/metricshub.yaml` to monitor the health of our Grafana service:
+
+```yaml
+    resources:
       m8b-demo-grafana:
         attributes:
           service.name: Grafana
@@ -30,43 +92,25 @@ To collect data from the Grafana health API:
           http:
             https: true
             port: 443
-    ```
-
-2. We then specify the entity we monitor: `grafana-health` with a `simple` job:  
-
-    ```yaml
-      monitors:
-        grafana-health:
-          simple: 
-    ```
-3. We specify the Grafana health API as a data source as follows:
-
-    ```yaml
+        monitors:
+          grafana-health:
+            simple: 
               sources:
-                # HTTP GET /api/health which returns a JSON
                 grafanaHealthApi:
                   type: http
                   path: /api/health
                   method: get
                   header: "Accept: application/json"
                   computes:
-                  # Convert the JSON document into a simple CSV
                   - type: json2Csv
                     entryKey: /
                     properties: commit;database;version
                     separator: ;
-                  # Translate the value of "database" in the 2nd column:
-                  # - "ok" --> 1
-                  # - anything else --> 0
                   - type: translate
                     column: 3
                     translationTable:
                       ok: 1
                       default: 0
-    ```
-4. Finally, we specify how the collected metrics are mapped to **MetricsHub**'s monitoring model:
-
-    ```yaml
               mapping:
                 source: ${esc.d}{source::grafanaHealthApi}
                 attributes:
@@ -75,44 +119,4 @@ To collect data from the Grafana health API:
                   service.version: $4
                 metrics:
                   grafana.db.status{state="ok"}: $3
-    ```
-
-Here is the complete YAML configuration to be added to `config/metricshub.yaml` to monitor the health of our Grafana service:
-
-```yaml
-  m8b-demo-grafana:
-    attributes:
-      service.name: Grafana
-      host.name: m8b-demo.metricshub.com
-    protocols:
-      http:
-        https: true
-        port: 443
-    monitors:
-      grafana-health:
-        simple: 
-          sources:
-            grafanaHealthApi:
-              type: http
-              path: /api/health
-              method: get
-              header: "Accept: application/json"
-              computes:
-              - type: json2Csv
-                entryKey: /
-                properties: commit;database;version
-                separator: ;
-              - type: translate
-                column: 3
-                translationTable:
-                  ok: 1
-                  default: 0
-          mapping:
-            source: ${esc.d}{source::grafanaHealthApi}
-            attributes:
-              id: $2
-              service.instance.id: $2
-              service.version: $4
-            metrics:
-              grafana.db.status{state="ok"}: $3
 ```

--- a/metricshub-doc/src/site/markdown/usecases/service-linux.md
+++ b/metricshub-doc/src/site/markdown/usecases/service-linux.md
@@ -16,6 +16,35 @@ To monitor the `metricshub` service running on Linux:
 1. In the `config/metricshub.yaml` file, we configure the monitoring on a Linux machine through `SSH`: 
 
     ```yaml
+        resources:
+          prod-web:
+            attributes:
+              host.name: [prod-web-01, prod-web-02]
+              host.type: linux
+            protocols:
+              ssh:
+                username: monagent
+                password: REDACTED
+                timeout: 30s
+    ```
+2. We specify the `httpd` dedicated instance of the [Linux - Service (systemctl)](../connectors/linuxservice.html) connector:
+
+    ```yaml
+            additionalConnectors:
+              httpd: 
+                uses: LinuxService # Connector used
+    ```
+
+3. We specify the service to be monitored:
+
+    ```yaml
+                variables:
+                  serviceNames: httpd
+    ```
+
+Here is the complete YAML configuration to be added to `config/metricshub.yaml` to monitor the `metricshub` service running on Linux:
+
+```yaml
     resources:
       prod-web:
         attributes:
@@ -26,38 +55,9 @@ To monitor the `metricshub` service running on Linux:
             username: monagent
             password: REDACTED
             timeout: 30
-    ```
-2. We specify the `httpd` dedicated instance of the [Linux - Service (systemctl)](../connectors/linuxservice.html) connector:
-
-    ```yaml
         additionalConnectors:
-          httpd: 
-            uses: LinuxService # Connector used
-    ```
-
-3. We specify the service to be monitored:
-
-    ```yaml
+          httpd:
+            uses: LinuxService
             variables:
               serviceNames: httpd
-    ```
-
-Here is the complete YAML configuration to be added to `config/metricshub.yaml` to monitor the `metricshub` service running on Linux:
-
-```yaml
-resources:
-      prod-web:
-        attributes:
-          host.name: [prod-web-01, prod-web-02]
-          host.type: linux
-        protocols:
-          ssh:
-            username: monagent
-            password: REDACTED
-            timeout: 30
-    additionalConnectors:
-      httpd:
-        uses: LinuxService
-        variables:
-          serviceNames: httpd
 ```


### PR DESCRIPTION
* Fixed YAML examples.

This pull request includes several documentation updates to the `metricshub-doc` repository. The most important changes involve adding the `resources` key to YAML configuration examples and updating timeout values to include units.

YAML configuration updates:

* [`metricshub-doc/src/site/markdown/usecases/network-interfaces.md`](diffhunk://#diff-178092bf70f6ba7891bda965a9699c0665dca90cdd1fdda15c0ae96f694694f5R26): Added the `resources` key to the YAML configuration examples to monitor the switch. [[1]](diffhunk://#diff-178092bf70f6ba7891bda965a9699c0665dca90cdd1fdda15c0ae96f694694f5R26) [[2]](diffhunk://#diff-178092bf70f6ba7891bda965a9699c0665dca90cdd1fdda15c0ae96f694694f5R44)
* [`metricshub-doc/src/site/markdown/usecases/remote-linux.md`](diffhunk://#diff-8891638b6fd7e2c225edcb0444b7d81a42d7290f39b580bf9ac5763193d7c4a6R24-R30): Added the `resources` key to the YAML configuration examples to monitor a remote Linux machine. [[1]](diffhunk://#diff-8891638b6fd7e2c225edcb0444b7d81a42d7290f39b580bf9ac5763193d7c4a6R24-R30) [[2]](diffhunk://#diff-8891638b6fd7e2c225edcb0444b7d81a42d7290f39b580bf9ac5763193d7c4a6R44)
* [`metricshub-doc/src/site/markdown/usecases/service-health.md`](diffhunk://#diff-50fe9a366f0f4712efeb6cb07a6e7ad1d63ef382387dc9f20a84f62dda288102R25): Added the `resources` key to the YAML configuration examples to collect data from the Grafana health API. [[1]](diffhunk://#diff-50fe9a366f0f4712efeb6cb07a6e7ad1d63ef382387dc9f20a84f62dda288102R25) [[2]](diffhunk://#diff-50fe9a366f0f4712efeb6cb07a6e7ad1d63ef382387dc9f20a84f62dda288102R43) [[3]](diffhunk://#diff-50fe9a366f0f4712efeb6cb07a6e7ad1d63ef382387dc9f20a84f62dda288102R69) [[4]](diffhunk://#diff-50fe9a366f0f4712efeb6cb07a6e7ad1d63ef382387dc9f20a84f62dda288102R86)

Timeout value updates:

* [`metricshub-doc/src/site/markdown/usecases/ping.md`](diffhunk://#diff-7935bdf17b2d2891d98f4728e448b956f64f4af28accc9e2b2cb882bff0dbc40L41-R41): Updated the timeout values to include units (`3s`). [[1]](diffhunk://#diff-7935bdf17b2d2891d98f4728e448b956f64f4af28accc9e2b2cb882bff0dbc40L41-R41) [[2]](diffhunk://#diff-7935bdf17b2d2891d98f4728e448b956f64f4af28accc9e2b2cb882bff0dbc40L53-R53)
* [`metricshub-doc/src/site/markdown/usecases/service-linux.md`](diffhunk://#diff-62aa32ffe1565bb0bbdbfc1ef2a6ef27e3bf20d32ed1f0402cf70fc06597fc54L28-R28): Updated the timeout value to include units (`30s`).