### PR TITLE
Issue #523: hw.network.up metric not reported for WARN or ALARM states

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/state/LinkStatus.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/state/LinkStatus.java
@@ -71,6 +71,10 @@ public enum LinkStatus implements IState {
 		"failed",
 		UNPLUGGED,
 		"unplugged",
+		UNPLUGGED,
+		"warn",
+		UNPLUGGED,
+		"alarm",
 		UNPLUGGED
 	);
 
@@ -78,7 +82,7 @@ public enum LinkStatus implements IState {
 	 * Interpret the specified state value:
 	 *  <ul>
 	 *  	<li>{0, ok, plugged} as Plugged</li>
-	 *  	<li>{1, degraded, failed, 2, unplugged} as Unplugged</li>
+	 *  	<li>{1, degraded, failed, 2, unplugged, warn, alarm} as Unplugged</li>
 	 *  </ul>
 	 * @param state String to be interpreted
 	 * @return {@link Optional} of {@link LinkStatus}

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/common/helpers/state/LinkStatusTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/common/helpers/state/LinkStatusTest.java
@@ -1,0 +1,45 @@
+package org.sentrysoftware.metricshub.engine.common.helpers.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class LinkStatusTest {
+
+	@Test
+	void testInterpret() {
+		// {0, ok, plugged} as Plugged
+		final String[] pluggedStates = new String[] { "PLUGGED", "OK", "plugged", "ok", "0" };
+		for (String state : pluggedStates) {
+			assertEquals(
+				LinkStatus.PLUGGED,
+				LinkStatus.interpret(state).get(),
+				"Unexpected plugged state: %s".formatted(state)
+			);
+		}
+
+		// {1, degraded, failed, 2, unplugged, warn, alarm} as Unplugged
+		final String[] unpluggedStates = new String[] {
+			"UNPLUGGED",
+			"DEGRADED",
+			"FAILED",
+			"WARN",
+			"ALARM",
+			"unplugged",
+			"degraded",
+			"failed",
+			"unplugged",
+			"warn",
+			"alarm",
+			"1",
+			"2"
+		};
+		for (String state : unpluggedStates) {
+			assertEquals(
+				LinkStatus.UNPLUGGED,
+				LinkStatus.interpret(state).get(),
+				"Unexpected unplugged state: %s".formatted(state)
+			);
+		}
+	}
+}


### PR DESCRIPTION
Fixed LinkStatus state mapping.

**Details**
This pull request includes changes to the `LinkStatus` enum and the addition of a new test class to ensure the correct interpretation of state values. The most important changes include updating the `LinkStatus` enum to handle new states and adding a comprehensive test to verify the interpretation logic.

Updates to `LinkStatus` enum:

* [`metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/common/helpers/state/LinkStatus.java`](diffhunk://#diff-41baa07ba58e537649d2b8366fef16e6d546df36a10cf1e7d463231c6262b4eeR74-R85): Added new states "warn" and "alarm" to the `LinkStatus` enum and updated the interpretation logic to classify these states as `UNPLUGGED`.

Addition of test class:

* [`metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/common/helpers/state/LinkStatusTest.java`](diffhunk://#diff-f966498b8fe57978751288f627d7a4c9ff124fd3346aa20738ff1628aa7f4da0R1-R45): Added a new test class `LinkStatusTest` to verify the correct interpretation of various state values, including the newly added "warn" and "alarm" states.
---
**Testing**
*Before* 
Reported power: **378W**
![{9C056755-AA1C-4EAC-A245-BDEB2ADDFB09}](https://github.com/user-attachments/assets/010a8488-4a1a-4b25-810b-b954555a3ffe)
*After*
Reported power: **278W**
![{CB86C0EC-D499-4C56-A6C5-88EE8158EA6E}](https://github.com/user-attachments/assets/08ffc0f9-c8e6-464e-9464-f6d331534774)

