### PR TITLE
Issue #525: Add job duration metrics to connectors

### DIFF
--- a/metricshub-doc/src/site/markdown/configuration/configure-monitoring.md
+++ b/metricshub-doc/src/site/markdown/configuration/configure-monitoring.md
@@ -1209,6 +1209,81 @@ hw.status{state="degraded"} 1
 
 In this case, only the `degraded` state is reported, and the zero values for `ok` and `failed` are suppressed after the initial state transition.
 
+## Self-Monitoring
+
+**MetricsHub** includes **self-monitoring capabilities** to track its own performance. This feature can monitor key aspects such **job duration metrics**.
+
+### Configuration: `enableSelfMonitoring`
+
+This configuration controls whether **MetricsHub** reports internal signals such as job duration metrics.
+
+#### Supported Values
+
+- `true` (default): Enables self-monitoring capabilities.
+- `false`: Disables self-monitoring capabilities.
+
+#### Configuration Scopes
+
+You can configure `enableSelfMonitoring` at the following levels:
+
+1. **Global Configuration**
+   Applies to all monitored resources.
+
+   ```yaml
+   enableSelfMonitoring: true # Set to "false" to disable
+   resourceGroups: ...
+   ```
+
+2. **Per Resource Group**
+   Applies to all resources within a specific group.
+
+   ```yaml
+   resourceGroups:
+     <resource-group-name>:
+       enableSelfMonitoring: true # Set to "false" to disable
+       resources: ...
+   ```
+
+3. **Per Resource**
+   Applies to an individual resource.
+
+   ```yaml
+   resourceGroups:
+     <resource-group-name>:
+       resources:
+         <resource-id>:
+           enableSelfMonitoring: true # Set to "false" to disable
+   ```
+
+### Examples of Self-Monitoring Metrics
+
+When enabled, **MetricsHub** reports the `metricshub.job.duration` metrics, for example:
+
+```
+metricshub.job.duration{job.type="discovery", monitor.type="enclosure", connector_id="HPEGen10IloREST"} 0.020
+metricshub.job.duration{job.type="discovery", monitor.type="cpu", connector_id="HPEGen10IloREST"} 0.030
+metricshub.job.duration{job.type="discovery", monitor.type="temperature", connector_id="HPEGen10IloREST"} 0.025
+metricshub.job.duration{job.type="discovery", monitor.type="connector", connector_id="HPEGen10IloREST"} 0.015
+metricshub.job.duration{job.type="collect", monitor.type="cpu", connector_id="HPEGen10IloREST"} 0.015
+```
+
+Where:
+- **`job.type`**: Specifies the type of operation performed by MetricsHub.
+    - Possible values:
+        - `discovery`: Identifies and registers components.
+        - `collect`: Gathers telemetry data from the monitored components.
+        - `simple`: Executes a single straightforward task.
+        - `beforeAll` or `afterAll`: Runs preparatory or cleanup operations.
+- **`monitor.type`**: Indicates the specific category of component being monitored.
+    - Examples:
+        - Hardware components like `cpu`, `memory`, `physical_disk`, or `disk_controller`.
+        - Environmental metrics like `temperature` or `battery`.
+        - Logical entities like `connector`.
+- **`connector_id`**: The unique identifier of the connector defining the method and protocol to collect metrics for the specified component.
+    - Example: `"HPEGen10IloREST"` denotes the HPE Gen10 iLO REST connector.
+
+These metrics provide granular insights into task execution times, enabling the identification of bottlenecks or inefficiencies and helping optimize monitoring performance.
+
 #### Timeout, duration and period format
 
 Timeouts, durations and periods are specified with the below format:

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/Connector.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/connector/model/Connector.java
@@ -115,7 +115,7 @@ public class Connector implements Serializable {
 	private Map<String, Source> afterAll = new HashMap<>();
 
 	/**
-	 * Map of monitor jobs, where each key is the name of the monitor job and the value is its definition.
+	 * Map of monitor jobs, where each key is the name of the monitor type and the value is the monitor job instance.
 	 */
 	@Default
 	private Map<String, MonitorJob> monitors = new LinkedHashMap<>();

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractAllAtOnceStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractAllAtOnceStrategy.java
@@ -263,13 +263,7 @@ public abstract class AbstractAllAtOnceStrategy extends AbstractStrategy {
 		processSameTypeMonitors(currentConnector, mapping, monitorType, hostname, monitorJob);
 		final long jobEndTime = System.currentTimeMillis();
 		// Set the job duration metric in the host monitor
-		setJobDurationMetricInHostMonitorWithMonitorType(
-			getJobName(),
-			monitorType,
-			currentConnector.getCompiledFilename(),
-			jobStartTime,
-			jobEndTime
-		);
+		setJobDurationMetric(getJobName(), monitorType, currentConnector.getCompiledFilename(), jobStartTime, jobEndTime);
 	}
 
 	/**

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractAllAtOnceStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractAllAtOnceStrategy.java
@@ -94,11 +94,18 @@ public abstract class AbstractAllAtOnceStrategy extends AbstractStrategy {
 	/**
 	 * This method processes each connector
 	 *
-	 * @param currentConnector
-	 * @param hostname
+	 * @param currentConnector The current connector
+	 * @param hostname		   The host name
 	 */
 	private void process(final Connector currentConnector, final String hostname) {
-		if (!validateConnectorDetectionCriteria(currentConnector, hostname)) {
+		// Check whether the strategy job name matches at least one of the monitor jobs names of the current connector
+		final boolean connectorHasExpectedJobTypes = hasExpectedJobTypes(currentConnector, getJobName());
+		// If the connector doesn't define any monitor job that matches the given strategy job name, log a message then exit the current discovery or simple operation
+		if (!connectorHasExpectedJobTypes) {
+			log.debug("Connector doesn't define any monitor job of type {}.", getJobName());
+			return;
+		}
+		if (!validateConnectorDetectionCriteria(currentConnector, hostname, getJobName())) {
 			log.error(
 				"Hostname {} - The connector {} no longer matches the host. Stopping the connector's {} job.",
 				hostname,
@@ -255,7 +262,8 @@ public abstract class AbstractAllAtOnceStrategy extends AbstractStrategy {
 
 		processSameTypeMonitors(currentConnector, mapping, monitorType, hostname, monitorJob);
 		final long jobEndTime = System.currentTimeMillis();
-		setJobDurationMetricInHostMonitor(
+		// Set the job duration metric in the host monitor
+		setJobDurationMetricInHostMonitorWithMonitorType(
 			getJobName(),
 			monitorType,
 			currentConnector.getCompiledFilename(),

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java
@@ -84,6 +84,8 @@ import org.sentrysoftware.metricshub.engine.telemetry.TelemetryManager;
 @EqualsAndHashCode(callSuper = true)
 public class CollectStrategy extends AbstractStrategy {
 
+	private static final String JOB_NAME = "collect";
+
 	/**
 	 * Constructs a new {@code CollectStrategy} using the provided telemetry manager, strategy time, and
 	 * clients executor.
@@ -106,10 +108,17 @@ public class CollectStrategy extends AbstractStrategy {
 	/**
 	 * This method collects the monitors and their metrics
 	 * @param currentConnector Connector instance
-	 * @param hostname the host name
+	 * @param hostname The host name
 	 */
 	private void collect(final Connector currentConnector, final String hostname) {
-		if (!validateConnectorDetectionCriteria(currentConnector, hostname)) {
+		// Check whether the strategy job name matches at least one of the monitor jobs names of the current connector
+		final boolean connectorHasExpectedJobTypes = hasExpectedJobTypes(currentConnector, JOB_NAME);
+		// If the connector doesn't define any monitor job of type collect, log a message then exit the current collect operation
+		if (!connectorHasExpectedJobTypes) {
+			log.debug("Connector doesn't define any monitor job of type collect.");
+			return;
+		}
+		if (!validateConnectorDetectionCriteria(currentConnector, hostname, JOB_NAME)) {
 			log.error(
 				"Hostname {} - The connector {} no longer matches the host. Stopping the connector's collect job.",
 				hostname,
@@ -280,8 +289,9 @@ public class CollectStrategy extends AbstractStrategy {
 				}
 			}
 			final long jobEndTime = System.currentTimeMillis();
-			setJobDurationMetricInHostMonitor(
-				"collect",
+			// Set the job duration metric in the host monitor
+			setJobDurationMetricInHostMonitorWithMonitorType(
+				JOB_NAME,
 				monitorType,
 				currentConnector.getCompiledFilename(),
 				jobStartTime,
@@ -414,7 +424,7 @@ public class CollectStrategy extends AbstractStrategy {
 						.connectorId(connectorId)
 						.hostname(hostname)
 						.monitorType(monitorType)
-						.jobName("collect")
+						.jobName(JOB_NAME)
 						.build()
 				)
 				.collectTime(strategyTime)

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java
@@ -290,13 +290,7 @@ public class CollectStrategy extends AbstractStrategy {
 			}
 			final long jobEndTime = System.currentTimeMillis();
 			// Set the job duration metric in the host monitor
-			setJobDurationMetricInHostMonitorWithMonitorType(
-				JOB_NAME,
-				monitorType,
-				currentConnector.getCompiledFilename(),
-				jobStartTime,
-				jobEndTime
-			);
+			setJobDurationMetric(JOB_NAME, monitorType, currentConnector.getCompiledFilename(), jobStartTime, jobEndTime);
 		}
 	}
 

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/surrounding/SurroundingStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/surrounding/SurroundingStrategy.java
@@ -123,7 +123,7 @@ public abstract class SurroundingStrategy extends AbstractStrategy {
 
 		final long jobEndTime = System.currentTimeMillis();
 		// Set the job duration metric in the host monitor
-		setJobDurationMetricInHostMonitorWithoutMonitorType(jobName, connectorId, jobStartTime, jobEndTime);
+		setJobDurationMetric(jobName, connectorId, jobStartTime, jobEndTime);
 	}
 
 	/**

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/surrounding/SurroundingStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/surrounding/SurroundingStrategy.java
@@ -122,7 +122,8 @@ public abstract class SurroundingStrategy extends AbstractStrategy {
 		processSourcesAndComputes(orderedSources.getSources(), jobInfo);
 
 		final long jobEndTime = System.currentTimeMillis();
-		setJobDurationMetricInHostMonitor(jobName, "none", connectorId, jobStartTime, jobEndTime);
+		// Set the job duration metric in the host monitor
+		setJobDurationMetricInHostMonitorWithoutMonitorType(jobName, connectorId, jobStartTime, jobEndTime);
 	}
 
 	/**

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategyTest.java
@@ -252,6 +252,16 @@ class CollectStrategyTest {
 				)
 				.getValue()
 		);
+		assertNotNull(
+			telemetryManager
+				.getMonitors()
+				.get("host")
+				.get("anyMonitorId")
+				.getMetric(
+					"metricshub.job.duration{job.type=\"collect\", monitor.type=\"connector\", connector_id=\"TestConnector\"}"
+				)
+				.getValue()
+		);
 
 		// Mock detection criteria result to switch to a failing criterion processing case
 		doReturn(CriterionTestResult.failure(snmpGetNextCriterion, "1.3.6.1.4.1.795.10.1.1.3.1.1.0	ASN_OCTET_STR	Test"))

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/discovery/DiscoveryStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/discovery/DiscoveryStrategyTest.java
@@ -294,6 +294,16 @@ class DiscoveryStrategyTest {
 				)
 				.getValue()
 		);
+		assertNotNull(
+			telemetryManager
+				.getMonitors()
+				.get("host")
+				.get("anyMonitorId")
+				.getMetric(
+					"metricshub.job.duration{job.type=\"discovery\"," + " monitor.type=\"connector\", connector_id=\"AAC\"}"
+				)
+				.getValue()
+		);
 	}
 
 	@Test

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/simple/SimpleStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/simple/SimpleStrategyTest.java
@@ -221,6 +221,16 @@ class SimpleStrategyTest {
 				)
 				.getValue()
 		);
+		assertNotNull(
+			telemetryManager
+				.getMonitors()
+				.get("host")
+				.get("monitor1")
+				.getMetric(
+					"metricshub.job.duration{job.type=\"simple\", monitor.type=\"connector\", connector_id=\"TestConnectorWithSimple\"}"
+				)
+				.getValue()
+		);
 
 		// Mock detection criteria result to switch to a failing criterion processing case
 		doReturn(CriterionTestResult.failure(snmpGetNextCriterion, "1.3.6.1.4.1.795.10.1.1.3.1.1.0	ASN_OCTET_STR	Test"))

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/surrounding/AfterAllStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/surrounding/AfterAllStrategyTest.java
@@ -281,9 +281,7 @@ class AfterAllStrategyTest {
 				.getMonitors()
 				.get("host")
 				.get("anyMonitorId")
-				.getMetric(
-					"metricshub.job.duration{job.type=\"afterAll\", monitor.type=\"none\", connector_id=\"afterAllSource\"}"
-				)
+				.getMetric("metricshub.job.duration{job.type=\"afterAll\", connector_id=\"afterAllSource\"}")
 				.getValue()
 		);
 		assertNotNull(

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/surrounding/BeforeAllStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/surrounding/BeforeAllStrategyTest.java
@@ -281,9 +281,7 @@ class BeforeAllStrategyTest {
 				.getMonitors()
 				.get("host")
 				.get("anyMonitorId")
-				.getMetric(
-					"metricshub.job.duration{job.type=\"beforeAll\", monitor.type=\"none\", connector_id=\"beforeAllSource\"}"
-				)
+				.getMetric("metricshub.job.duration{job.type=\"beforeAll\", connector_id=\"beforeAllSource\"}")
 				.getValue()
 		);
 		assertNotNull(


### PR DESCRIPTION
    * Compute job duration in validateConnectorDetectionCriteria
    * Remove monitorType('none') from surrounding strategy job duration metric
    * Add documentation for enableSelfMonitoring in configure-monitoring.md
    * Add unit tests