### PR TITLE
Issue #565: Prepare MetricsHub Release 1.0.01

### DIFF
--- a/metricshub-doc/src/site/markdown/release-notes.md
+++ b/metricshub-doc/src/site/markdown/release-notes.md
@@ -49,6 +49,14 @@ description: Learn more about the new features, changes and improvements, and bu
 | EC-97 | **Pure Storage FA Series (SSH)**: `hw.temperature` metrics are not collected                                                   |
 | EC-98 | **Dell iDRAC9 (REST)**: Incorrect JSON response handling leads to HTTP 404 error on network devices                            |
 
+### MetricsHub Enterprise Connectors v104
+
+#### Changes and Improvements
+
+| ID     | Description                                                                                             |
+|--------|---------------------------------------------------------------------------------------------------------|
+| EC-112 | Reduced high CPU usage caused by internal DB queries in `NetAppRESTv2` and `PureStorageREST` connectors |
+
 ### MetricsHub Community Edition v1.0.00
 
 #### What's New
@@ -79,6 +87,14 @@ description: Learn more about the new features, changes and improvements, and bu
 | [**\#541**](https://github.com/sentrysoftware/metricshub/issues/541) | Moved use cases from the documentation to [MetricsHub Use Cases](https://metricshub.com/usecases) |
 | [**\#533**](https://github.com/sentrysoftware/metricshub/issues/533) | Documented the self-monitoring feature                                                            |
 | [**\#529**](https://github.com/sentrysoftware/metricshub/issues/529) | Created a Troubleshooting section in the user documentation                                       |
+
+### MetricsHub Community Edition v1.0.01
+
+#### Changes and Improvements
+
+| ID                                                                   | Description                                                                        |
+|----------------------------------------------------------------------|------------------------------------------------------------------------------------|
+| [**\#563**](https://github.com/sentrysoftware/metricshub/issues/563) | MetricsHub Engine Internal DB: Improved memory usage and data types identification |
 
 ### MetricsHub Community Connectors v1.0.08
 


### PR DESCRIPTION
This pull request includes updates to the release notes in the `metricshub-doc/src/site/markdown/release-notes.md` file. The changes introduce new sections for MetricsHub Enterprise Connectors v104 and MetricsHub Community Edition v1.0.01, detailing changes and improvements.

Updates to release notes:

* Added a section for MetricsHub Enterprise Connectors v104, including a change to reduce high CPU usage caused by internal DB queries in `NetAppRESTv2` and `PureStorageREST` connectors.
* Added a section for MetricsHub Community Edition v1.0.01, detailing an improvement in memory usage and data types identification for the MetricsHub Engine Internal DB.
---------
![image](https://github.com/user-attachments/assets/21811d75-a33e-4400-a55f-03f6791a6da5)
![image](https://github.com/user-attachments/assets/169c50ed-7b87-4506-800e-5c1798e8d329)
