### PR TITLE
Issue #567: Added unit tests to metricshub-internaldb-extension

### DIFF
--- a/metricshub-internaldb-extension/pom.xml
+++ b/metricshub-internaldb-extension/pom.xml
@@ -55,11 +55,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.snmp4j</groupId>
-			<artifactId>snmp4j-agent</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 		</dependency>
@@ -118,7 +113,7 @@
 										<limit>
 											<counter>COMPLEXITY</counter>
 											<value>COVEREDRATIO</value>
-											<minimum>0.5</minimum>
+											<minimum>0.66</minimum>
 										</limit>
 									</limits>
 								</rule>

--- a/metricshub-internaldb-extension/src/main/java/org/sentrysoftware/metricshub/extension/internaldb/DatabaseHelper.java
+++ b/metricshub-internaldb-extension/src/main/java/org/sentrysoftware/metricshub/extension/internaldb/DatabaseHelper.java
@@ -115,29 +115,32 @@ public class DatabaseHelper {
 				return true;
 			}
 
+			// Trim only for non-String types to avoid parsing errors
+			final String trimmedValue = trimValue(value, javaType);
+
 			// Map Java types to PreparedStatement setters
 			if (Integer.class.equals(javaType)) {
-				preparedStatement.setInt(position, Integer.parseInt(value));
+				preparedStatement.setInt(position, Integer.parseInt(trimmedValue));
 			} else if (Long.class.equals(javaType)) {
-				preparedStatement.setLong(position, Long.parseLong(value));
+				preparedStatement.setLong(position, Long.parseLong(trimmedValue));
 			} else if (BigDecimal.class.equals(javaType)) {
-				preparedStatement.setBigDecimal(position, new BigDecimal(value));
+				preparedStatement.setBigDecimal(position, new BigDecimal(trimmedValue));
 			} else if (Boolean.class.equals(javaType)) {
-				preparedStatement.setBoolean(position, Boolean.parseBoolean(value));
+				preparedStatement.setBoolean(position, Boolean.parseBoolean(trimmedValue));
 			} else if (Double.class.equals(javaType)) {
-				preparedStatement.setDouble(position, Double.parseDouble(value));
+				preparedStatement.setDouble(position, Double.parseDouble(trimmedValue));
 			} else if (Float.class.equals(javaType)) {
-				preparedStatement.setFloat(position, Float.parseFloat(value));
+				preparedStatement.setFloat(position, Float.parseFloat(trimmedValue));
 			} else if (java.sql.Date.class.equals(javaType)) {
-				preparedStatement.setDate(position, java.sql.Date.valueOf(value));
+				preparedStatement.setDate(position, java.sql.Date.valueOf(trimmedValue));
 			} else if (java.sql.Time.class.equals(javaType)) {
-				preparedStatement.setTime(position, java.sql.Time.valueOf(value));
+				preparedStatement.setTime(position, java.sql.Time.valueOf(trimmedValue));
 			} else if (java.sql.Timestamp.class.equals(javaType)) {
-				preparedStatement.setTimestamp(position, java.sql.Timestamp.valueOf(value));
+				preparedStatement.setTimestamp(position, java.sql.Timestamp.valueOf(trimmedValue));
 			} else if (Byte.class.equals(javaType)) {
-				preparedStatement.setByte(position, Byte.parseByte(value));
+				preparedStatement.setByte(position, Byte.parseByte(trimmedValue));
 			} else if (Short.class.equals(javaType)) {
-				preparedStatement.setShort(position, Short.parseShort(value));
+				preparedStatement.setShort(position, Short.parseShort(trimmedValue));
 			} else {
 				// Default to String
 				preparedStatement.setString(position, value);
@@ -148,5 +151,16 @@ public class DatabaseHelper {
 			log.error("Error setting value '{}' at position {}: {}", value, position, ex.getMessage());
 			return false;
 		}
+	}
+
+	/**
+	 * Trim the value if it is not a String.
+	 *
+	 * @param value    The value to trim.
+	 * @param javaType The Java type of the value.
+	 * @return The trimmed value.
+	 */
+	private static String trimValue(final String value, final Class<?> javaType) {
+		return String.class.equals(javaType) ? value : value.trim();
 	}
 }

--- a/metricshub-internaldb-extension/src/test/java/org/sentrysoftware/metricshub/extension/internaldb/DatabaseHelperTest.java
+++ b/metricshub-internaldb-extension/src/test/java/org/sentrysoftware/metricshub/extension/internaldb/DatabaseHelperTest.java
@@ -1,0 +1,231 @@
+package org.sentrysoftware.metricshub.extension.internaldb;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DatabaseHelperTest {
+
+	private PreparedStatement preparedStatement;
+
+	@BeforeEach
+	void setUp() {
+		preparedStatement = mock(PreparedStatement.class);
+	}
+
+	@Test
+	void testSetInteger() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(1, Integer.class, Types.INTEGER);
+		boolean result = DatabaseHelper.set("123", metadata, preparedStatement);
+
+		verify(preparedStatement).setInt(1, 123);
+		assertTrue(result);
+
+		result = DatabaseHelper.set(" 123 ", metadata, preparedStatement);
+
+		verify(preparedStatement, times(2)).setInt(1, 123);
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetLong() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(2, Long.class, Types.BIGINT);
+		boolean result = DatabaseHelper.set("456789", metadata, preparedStatement);
+
+		verify(preparedStatement).setLong(2, 456789L);
+		assertTrue(result);
+
+		result = DatabaseHelper.set(" 456789 ", metadata, preparedStatement);
+
+		verify(preparedStatement, times(2)).setLong(2, 456789L);
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetBigDecimal() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(3, BigDecimal.class, Types.DECIMAL);
+		boolean result = DatabaseHelper.set("123.45", metadata, preparedStatement);
+
+		verify(preparedStatement).setBigDecimal(3, new BigDecimal("123.45"));
+		assertTrue(result);
+
+		result = DatabaseHelper.set(" 123.45 ", metadata, preparedStatement);
+
+		verify(preparedStatement, times(2)).setBigDecimal(3, new BigDecimal("123.45"));
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetBoolean() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(4, Boolean.class, Types.BOOLEAN);
+		boolean result = DatabaseHelper.set("true", metadata, preparedStatement);
+
+		verify(preparedStatement).setBoolean(4, true);
+		assertTrue(result);
+
+		result = DatabaseHelper.set(" TRUE ", metadata, preparedStatement);
+
+		verify(preparedStatement, times(2)).setBoolean(4, true);
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetDouble() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(5, Double.class, Types.DOUBLE);
+		boolean result = DatabaseHelper.set("12.34", metadata, preparedStatement);
+
+		verify(preparedStatement).setDouble(5, 12.34);
+		assertTrue(result);
+
+		result = DatabaseHelper.set(" 12.34 ", metadata, preparedStatement);
+
+		verify(preparedStatement, times(2)).setDouble(5, 12.34);
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetFloat() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(6, Float.class, Types.FLOAT);
+		boolean result = DatabaseHelper.set("5.67", metadata, preparedStatement);
+
+		verify(preparedStatement).setFloat(6, 5.67f);
+		assertTrue(result);
+
+		result = DatabaseHelper.set(" 5.67 ", metadata, preparedStatement);
+
+		verify(preparedStatement, times(2)).setFloat(6, 5.67f);
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetString() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(7, String.class, Types.VARCHAR);
+		boolean result = DatabaseHelper.set("Hello", metadata, preparedStatement);
+
+		verify(preparedStatement).setString(7, "Hello");
+		assertTrue(result);
+
+		result = DatabaseHelper.set(" Hello ", metadata, preparedStatement);
+
+		verify(preparedStatement).setString(7, " Hello ");
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetDate() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(8, Date.class, Types.DATE);
+		boolean result = DatabaseHelper.set("2024-01-30", metadata, preparedStatement);
+
+		verify(preparedStatement).setDate(8, Date.valueOf("2024-01-30"));
+		assertTrue(result);
+
+		result = DatabaseHelper.set("  2024-01-30  ", metadata, preparedStatement);
+
+		verify(preparedStatement, times(2)).setDate(8, Date.valueOf("2024-01-30"));
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetTime() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(9, Time.class, Types.TIME);
+		boolean result = DatabaseHelper.set("12:34:56", metadata, preparedStatement);
+
+		verify(preparedStatement).setTime(9, Time.valueOf("12:34:56"));
+		assertTrue(result);
+
+		result = DatabaseHelper.set(" 12:34:56 ", metadata, preparedStatement);
+
+		verify(preparedStatement, times(2)).setTime(9, Time.valueOf("12:34:56"));
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetTimestamp() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(10, Timestamp.class, Types.TIMESTAMP);
+		boolean result = DatabaseHelper.set("2024-01-30 15:45:00", metadata, preparedStatement);
+
+		verify(preparedStatement).setTimestamp(10, Timestamp.valueOf("2024-01-30 15:45:00"));
+		assertTrue(result);
+
+		result = DatabaseHelper.set(" 2024-01-30 15:45:00 ", metadata, preparedStatement);
+
+		verify(preparedStatement, times(2)).setTimestamp(10, Timestamp.valueOf("2024-01-30 15:45:00"));
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetByte() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(11, Byte.class, Types.TINYINT);
+		boolean result = DatabaseHelper.set("127", metadata, preparedStatement);
+
+		verify(preparedStatement).setByte(11, (byte) 127);
+		assertTrue(result);
+
+		result = DatabaseHelper.set("  127  ", metadata, preparedStatement);
+		assertTrue(result);
+		verify(preparedStatement, times(2)).setByte(11, (byte) 127);
+	}
+
+	@Test
+	void testSetShort() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(12, Short.class, Types.SMALLINT);
+		boolean result = DatabaseHelper.set("32767", metadata, preparedStatement);
+
+		verify(preparedStatement).setShort(12, (short) 32767);
+		assertTrue(result);
+
+		result = DatabaseHelper.set("  32767   ", metadata, preparedStatement);
+
+		verify(preparedStatement, times(2)).setShort(12, (short) 32767);
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetNullValue() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(13, Integer.class, Types.INTEGER);
+		boolean result = DatabaseHelper.set(null, metadata, preparedStatement);
+
+		verify(preparedStatement).setNull(13, Types.INTEGER);
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetEmptyValue() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(14, String.class, Types.VARCHAR);
+		boolean result = DatabaseHelper.set("", metadata, preparedStatement);
+
+		verify(preparedStatement).setNull(14, Types.VARCHAR);
+		assertTrue(result);
+	}
+
+	@Test
+	void testSetInvalidInteger() {
+		final ColumnMetadata metadata = new ColumnMetadata(15, Integer.class, Types.INTEGER);
+		boolean result = DatabaseHelper.set("invalid", metadata, preparedStatement);
+
+		// Exception should be caught and return false
+		assertFalse(result);
+	}
+
+	@Test
+	void testSetInvalidBoolean() throws SQLException {
+		final ColumnMetadata metadata = new ColumnMetadata(16, Boolean.class, Types.BOOLEAN);
+		boolean result = DatabaseHelper.set("notBoolean", metadata, preparedStatement);
+
+		// Invalid boolean should not throw an exception but will store "false"
+		verify(preparedStatement).setBoolean(16, false);
+		assertTrue(result);
+	}
+}


### PR DESCRIPTION
This pull request includes several changes to the `metricshub-internaldb-extension` project, focusing on dependency updates, code enhancements, and the addition of unit tests. The key changes are summarized below:

### Dependency Updates:
* Removed the `snmp4j-agent` dependency from the `pom.xml` file.
* Increased the minimum complexity coverage ratio from 0.5 to 0.66 in the `pom.xml` file.

### Code Enhancements:
* Modified the `set` method in `DatabaseHelper.java` to trim values for non-String types before parsing to avoid errors.
* Added a private `trimValue` method in `DatabaseHelper.java` to handle the trimming logic.

### Unit Tests:
* Added comprehensive unit tests for the `DatabaseHelper` class in `DatabaseHelperTest.java` to verify the correct behavior of the `set` method for various data types and edge cases.

----
![image](https://github.com/user-attachments/assets/71f0a58a-1779-4c9d-80fe-c8b1841f6297)
