### PR TITLE
Issue #569: gRPC message size limit issue

### DIFF
--- a/metricshub-doc/src/site/markdown/troubleshooting/grpc-message-size-limit.md
+++ b/metricshub-doc/src/site/markdown/troubleshooting/grpc-message-size-limit.md
@@ -1,0 +1,71 @@
+keywords: grpc, message size, export, troubleshooting
+description: How to resolve gRPC message size limit issues in MetricsHub when exporting large metric sets
+
+# gRPC message size limit issues
+
+<!-- MACRO{toc|fromDepth=1|toDepth=2|id=toc} -->
+
+When **exporting a large number of metrics**, **MetricsHub** may encounter gRPC message size limit errors due to the default `4MB` gRPC payload size limit.
+
+## Common errors
+
+**MetricsHub log**
+
+```
+Failed to export metrics. The request could not be executed. Full error message: stream was reset: NO_ERROR
+```
+
+**OpenTelemetry Collector log**
+
+```
+grpc-message: grpc: received message larger than max (6117815 vs. 4194304)
+```
+
+## Possible causes
+
+- **Large metric payloads exceeding the default 4MB limit**
+- **High-cardinality data causing oversized requests**
+
+## Solutions
+
+### 1. Enable gzip compression
+
+Add the following setting in your `metricshub.yaml` file to **reduce message size** using gzip.
+
+```yaml
+otel:
+  otel.exporter.otlp.metrics.compression: gzip
+```
+
+### 2. Increase the maximum gRPC message size
+
+In the `otel/otel-config.yaml` file, increase `max_recv_msg_size_mib` to `16`.
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        max_recv_msg_size_mib: 16 # Increase to 16MB (adjust if needed)
+```
+
+### 3. Reduce the number of exported metrics
+
+To **avoid exceeding gRPC limits**, consider excluding non-essential metrics.
+
+For example, if **SAN storage volumes** are generating too many metrics, you can exclude them using the [`monitorFilters`](../configuration/configure-monitoring.md#example-6-excluding-monitors-for-a-specific-resource) setting in `metricshub.yaml`.
+
+```yaml
+resourceGroups:
+  <resource-group-name>:
+    resources:
+    <resource-id>:
+        monitorFilters: ["!volume"] # Exclude volume metrics if not needed
+```
+
+## Logs to check for troubleshooting
+
+If issues persist, refer to:
+
+- [OpenTelemetry Collector Logs](./otel-logs.md)
+- [MetricsHub Logs](./metricshub-logs.md)

--- a/metricshub-doc/src/site/site.xml
+++ b/metricshub-doc/src/site/site.xml
@@ -117,7 +117,7 @@
 			<item name="Degraded Performance" href="troubleshooting/degraded-performance.html"/>
 			<item name="No Data for a Specific Resource" href="troubleshooting/no-data-resources.html"/>
 			<item name="No Data in Observability Platforms" href="troubleshooting/no-data-observability-platforms.html"/>
-			<item name="gRPC message size limit issues" href="troubleshooting/grpc-message-size-limit.html"/>
+			<item name="gRPC Message Size Limit Issues" href="troubleshooting/grpc-message-size-limit.html"/>
 			<item name="MetricsHub Logs" href="troubleshooting/metricshub-logs.html"/>
 			<item name="OTel Logs" href="troubleshooting/otel-logs.html"/>
 			<item name="Protocol CLIs" href="troubleshooting/cli/index.html">

--- a/metricshub-doc/src/site/site.xml
+++ b/metricshub-doc/src/site/site.xml
@@ -117,6 +117,7 @@
 			<item name="Degraded Performance" href="troubleshooting/degraded-performance.html"/>
 			<item name="No Data for a Specific Resource" href="troubleshooting/no-data-resources.html"/>
 			<item name="No Data in Observability Platforms" href="troubleshooting/no-data-observability-platforms.html"/>
+			<item name="gRPC message size limit issues" href="troubleshooting/grpc-message-size-limit.html"/>
 			<item name="MetricsHub Logs" href="troubleshooting/metricshub-logs.html"/>
 			<item name="OTel Logs" href="troubleshooting/otel-logs.html"/>
 			<item name="Protocol CLIs" href="troubleshooting/cli/index.html">


### PR DESCRIPTION
This pull request includes documentation updates to address gRPC message size limit issues in MetricsHub. The changes provide detailed troubleshooting steps and solutions for users encountering these errors.

Documentation updates:

* [`metricshub-doc/src/site/markdown/troubleshooting/grpc-message-size-limit.md`](diffhunk://#diff-388426639b3f28f8a4d6bb182f906c21bdb59b62d8245339753e43f02d8abfd1R1-R71): Added a new troubleshooting guide for resolving gRPC message size limit issues when exporting large metric sets. The guide includes common errors, possible causes, and solutions such as enabling gzip compression, increasing the maximum gRPC message size, and reducing the number of exported metrics.
* [`metricshub-doc/src/site/site.xml`](diffhunk://#diff-fa620bd5f1ffa03945a1c05fa7e7181113465798b7e311a175ffa5722cfe26fdR120): Added a new item link for the gRPC message size limit issues troubleshooting guide to the site navigation.

----

![image](https://github.com/user-attachments/assets/063fd2f6-f6d7-4a9f-a417-ed0db9681bd1)
![image](https://github.com/user-attachments/assets/95edf93a-871c-4310-961a-e32b7c7d2936)
