### PR TITLE
Issue #577: IPMI Command processing fail with ArrayIndexOutOfBoundsException

### DIFF
--- a/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/ipmi/IpmiHelper.java
+++ b/metricshub-oscommand-extension/src/main/java/org/sentrysoftware/metricshub/extension/oscommand/ipmi/IpmiHelper.java
@@ -628,7 +628,7 @@ public class IpmiHelper {
 					// Retrieve the vendor/model/serial from the corresponding FRU
 					String elt = fruList.stream().filter(fru -> fru.startsWith(fruId + TABLE_SEP)).findFirst().orElse("");
 					if (!elt.isEmpty()) {
-						String[] fruSplit = elt.split(TABLE_SEP);
+						String[] fruSplit = elt.split(TABLE_SEP, -1);
 						vendor = fruSplit[1];
 						model = fruSplit[2];
 						serialNumber = fruSplit[3];


### PR DESCRIPTION

* Corrected the split responsible of the ArrayIndexOutOfBoundsException where the empty fields weren't retained, which resulted in that exception.
* Reproduced, tested and ensured that the fix resolved the bug.

# Tests
## Before the fix
![image](https://github.com/user-attachments/assets/f61668ad-df77-4c38-8ab2-4630af25d761)

## After the fix
![image](https://github.com/user-attachments/assets/fb296c95-b366-4ee8-a432-3dc7060f6fba)
