### PR TITLE
Issue #580: Incorrect snmpv3cli flag (--retryIntervals instead of --retry)

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/SnmpV3Cli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/SnmpV3Cli.java
@@ -181,7 +181,7 @@ public class SnmpV3Cli implements IQuery, Callable<Integer> {
 	private int port;
 
 	@Option(
-		names = "--retryIntervals",
+		names = { "--retry-intervals", "--retry" },
 		order = 9,
 		paramLabel = "RETRY INTERVALS",
 		split = ",",


### PR DESCRIPTION

* Replaced `--retryIntervals` option by `--retry` (or possibly --retry-intervals) as stated for SnmpCLI.
* Tested the fix on MetricsHub.

# Tests
![image](https://github.com/user-attachments/assets/36e50976-028a-4246-92fb-9603e3e38029)
