### PR TITLE
Issue #590: `hw_voltage_limit_volts` is incorrectly collected

### DIFF
--- a/metricshub-agent/src/main/dist/config/metricshub-alertmanager-rules-example.yaml
+++ b/metricshub-agent/src/main/dist/config/metricshub-alertmanager-rules-example.yaml
@@ -148,6 +148,14 @@ groups:
     expr:  hw_voltage_volts >= ignoring(limit_type) hw_voltage_limit_volts{limit_type="high.critical"}
     labels:
       severity: 'critical'
+  - alert: Voltage-Low-warn
+    expr:  hw_voltage_volts <= ignoring(limit_type) hw_voltage_limit_volts{limit_type="low.degraded"}
+    labels:
+      severity: 'warn'
+  - alert: Voltage-High-warn
+    expr:  hw_voltage_volts >= ignoring(limit_type) hw_voltage_limit_volts{limit_type="high.degraded"}
+    labels:
+      severity: 'warn'
 
 - name: Protocol-Status
   rules:

--- a/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/VoltageMetricNormalizer.java
+++ b/metricshub-hardware/src/main/java/org/sentrysoftware/metricshub/hardware/threshold/VoltageMetricNormalizer.java
@@ -79,43 +79,32 @@ public class VoltageMetricNormalizer extends AbstractMetricNormalizer {
 			// Adjust values if both metrics are present
 			swapIfFirstLessThanSecond(maybeHighCriticaldMetric.get(), maybeLowCriticalMetric.get());
 		} else if (maybeHighCriticaldMetric.isPresent()) {
-			// Create low critical metric if only high critical is present
+			// Create high degraded metric if only high critical is present
 			final NumberMetric highCriticalMetric = maybeHighCriticaldMetric.get();
-			final Double maybeLowCriticalMetricValue = highCriticalMetric.getValue();
-			final String lowCriticalMetricName = replaceLimitType(
+
+			final String highDegradedMetricName = replaceLimitType(
 				highCriticalMetric.getName(),
-				"limit_type=\"low.critical\""
+				"limit_type=\"high.degraded\""
 			);
-			Double lowCriticalMetricValue = maybeLowCriticalMetricValue;
-			final Double maybeHighCriticalMetricValue = maybeLowCriticalMetricValue * 1.1;
-			Double highCriticalMetricValue = maybeHighCriticalMetricValue;
 
-			if (lowCriticalMetricValue <= 0) {
-				highCriticalMetricValue = maybeLowCriticalMetricValue;
-				lowCriticalMetricValue = maybeHighCriticalMetricValue;
-			}
-
-			highCriticalMetric.setValue(highCriticalMetricValue);
-			collectMetric(monitor, lowCriticalMetricName, lowCriticalMetricValue);
+			final Double highCriticalValue = highCriticalMetric.getValue();
+			collectMetric(
+				monitor,
+				highDegradedMetricName,
+				highCriticalValue > 0 ? highCriticalValue * 0.9 : highCriticalValue * 1.1
+			);
 		} else if (maybeLowCriticalMetric.isPresent()) {
-			// Create high critical metric if only low critical is present
+			// Create low degraded metric if only low critical is present
 			final NumberMetric lowCriticalMetric = maybeLowCriticalMetric.get();
-			final Double maybeHighCriticalMetricValue = lowCriticalMetric.getValue();
-			final String highCriticalMetricName = replaceLimitType(
-				lowCriticalMetric.getName(),
-				"limit_type=\"high.critical\""
+
+			final String lowDegradedMetricName = replaceLimitType(lowCriticalMetric.getName(), "limit_type=\"low.degraded\"");
+
+			final Double lowCriticalValue = lowCriticalMetric.getValue();
+			collectMetric(
+				monitor,
+				lowDegradedMetricName,
+				lowCriticalValue > 0 ? lowCriticalValue * 1.1 : lowCriticalValue * 0.9
 			);
-			Double highCriticalMetricValue = maybeHighCriticalMetricValue;
-			final Double maybeLowCriticalMetricValue = maybeHighCriticalMetricValue * 0.9;
-			Double lowCriticalMetricValue = maybeLowCriticalMetricValue;
-
-			if (highCriticalMetricValue <= 0) {
-				highCriticalMetricValue = maybeLowCriticalMetricValue;
-				lowCriticalMetricValue = maybeHighCriticalMetricValue;
-			}
-
-			lowCriticalMetric.setValue(lowCriticalMetricValue);
-			collectMetric(monitor, highCriticalMetricName, highCriticalMetricValue);
 		}
 	}
 }

--- a/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/threshold/VoltageMetricNormalizerTest.java
+++ b/metricshub-hardware/src/test/java/org/sentrysoftware/metricshub/hardware/threshold/VoltageMetricNormalizerTest.java
@@ -17,6 +17,10 @@ class VoltageMetricNormalizerTest {
 		HW_VOLTAGE_LIMIT + "{limit_type=\"high.critical\"}";
 	public static final String HW_VOLTAGE_LIMIT_LIMIT_TYPE_LOW_CRITICAL =
 		HW_VOLTAGE_LIMIT + "{limit_type=\"low.critical\"}";
+	public static final String HW_VOLTAGE_LIMIT_LIMIT_TYPE_HIGH_DEGRADED =
+		HW_VOLTAGE_LIMIT + "{limit_type=\"high.degraded\"}";
+	public static final String HW_VOLTAGE_LIMIT_LIMIT_TYPE_LOW_DEGRADED =
+		HW_VOLTAGE_LIMIT + "{limit_type=\"low.degraded\"}";
 
 	@Test
 	void testNormalize() {
@@ -159,15 +163,15 @@ class VoltageMetricNormalizerTest {
 
 			new VoltageMetricNormalizer(STRATEGY_TIME, HOSTNAME).normalize(monitorWithHwVoltageLimitMetric);
 			assertEquals(
-				11.0,
+				10.0,
 				monitorWithHwVoltageLimitMetric
 					.getMetric(HW_VOLTAGE_LIMIT_LIMIT_TYPE_HIGH_CRITICAL, NumberMetric.class)
 					.getValue()
 			);
 			assertEquals(
-				10.0,
+				9.0,
 				monitorWithHwVoltageLimitMetric
-					.getMetric(HW_VOLTAGE_LIMIT_LIMIT_TYPE_LOW_CRITICAL, NumberMetric.class)
+					.getMetric(HW_VOLTAGE_LIMIT_LIMIT_TYPE_HIGH_DEGRADED, NumberMetric.class)
 					.getValue()
 			);
 		}
@@ -211,7 +215,7 @@ class VoltageMetricNormalizerTest {
 			assertEquals(
 				-11.0,
 				monitorWithHwVoltageLimitMetric
-					.getMetric(HW_VOLTAGE_LIMIT_LIMIT_TYPE_LOW_CRITICAL, NumberMetric.class)
+					.getMetric(HW_VOLTAGE_LIMIT_LIMIT_TYPE_HIGH_DEGRADED, NumberMetric.class)
 					.getValue()
 			);
 		}
@@ -247,13 +251,13 @@ class VoltageMetricNormalizerTest {
 
 			new VoltageMetricNormalizer(STRATEGY_TIME, HOSTNAME).normalize(monitorWithHwVoltageLimitMetric);
 			assertEquals(
-				10.0,
+				11.0,
 				monitorWithHwVoltageLimitMetric
-					.getMetric(HW_VOLTAGE_LIMIT_LIMIT_TYPE_HIGH_CRITICAL, NumberMetric.class)
+					.getMetric(HW_VOLTAGE_LIMIT_LIMIT_TYPE_LOW_DEGRADED, NumberMetric.class)
 					.getValue()
 			);
 			assertEquals(
-				9.0,
+				10.0,
 				monitorWithHwVoltageLimitMetric
 					.getMetric(HW_VOLTAGE_LIMIT_LIMIT_TYPE_LOW_CRITICAL, NumberMetric.class)
 					.getValue()
@@ -293,7 +297,7 @@ class VoltageMetricNormalizerTest {
 			assertEquals(
 				-9.0,
 				monitorWithHwVoltageLimitMetric
-					.getMetric(HW_VOLTAGE_LIMIT_LIMIT_TYPE_HIGH_CRITICAL, NumberMetric.class)
+					.getMetric(HW_VOLTAGE_LIMIT_LIMIT_TYPE_LOW_DEGRADED, NumberMetric.class)
 					.getValue()
 			);
 			assertEquals(


### PR DESCRIPTION
This pull request includes changes to the `VoltageMetricNormalizer` class and its corresponding test class to update the handling of voltage metrics. The main focus is on replacing the creation of high/low critical metrics with high/low degraded metrics.

Changes to `VoltageMetricNormalizer`:

* Modified the logic to create high degraded metrics instead of high critical metrics when only high critical metrics are present.
* Modified the logic to create low degraded metrics instead of low critical metrics when only low critical metrics are present.

Changes to `VoltageMetricNormalizerTest`:

* Added constants for high degraded and low degraded metric types.
* Updated test cases to verify the creation of high degraded metrics instead of low critical metrics. [[1]](diffhunk://#diff-3fafe99f7ce17df5910726a17950f845d4afd3dab41d1c9ecfcf53ccd279da1aL162-R174) [[2]](diffhunk://#diff-3fafe99f7ce17df5910726a17950f845d4afd3dab41d1c9ecfcf53ccd279da1aL214-R218)
* Updated test cases to verify the creation of low degraded metrics instead of high critical metrics. [[1]](diffhunk://#diff-3fafe99f7ce17df5910726a17950f845d4afd3dab41d1c9ecfcf53ccd279da1aL250-R260) [[2]](diffhunk://#diff-3fafe99f7ce17df5910726a17950f845d4afd3dab41d1c9ecfcf53ccd279da1aL296-R300)

------

Battery thresholds
![image](https://github.com/user-attachments/assets/e2dfeda5-7857-4e11-b466-37ed57d0390c)

Other thresholds already correct 
![image](https://github.com/user-attachments/assets/78f0c268-51c8-4278-a366-47ea6b2c1d9d)
