### PR TITLE
Issue #597: Rename host response time to `metricshub.host.response_time`

### DIFF
--- a/metricshub-agent/src/main/resources/metricshub-host-metrics.yaml
+++ b/metricshub-agent/src/main/resources/metricshub-host-metrics.yaml
@@ -36,7 +36,7 @@ metrics:
       - failed
       - ok
 
-  metricshub.host.up.response_time:
+  metricshub.host.response_time:
     description: Response time for protocol check.
     type: Gauge
     unit: s

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategy.java
@@ -48,12 +48,22 @@ public class ProtocolHealthCheckStrategy extends AbstractStrategy {
 	/**
 	 * Protocol up status value '1.0'
 	 */
-	public static final Double UP = 1.0;
+	static final Double UP = 1.0;
 
 	/**
 	 * Protocol down status value '0.0'
 	 */
-	public static final Double DOWN = 0.0;
+	static final Double DOWN = 0.0;
+
+	/**
+	 * Protocol up metric format
+	 */
+	static final String UP_METRIC_FORMAT = "metricshub.host.up{protocol=\"%s\"}";
+
+	/**
+	 * Protocol response time metric format
+	 */
+	static final String RESPONSE_TIME_METRIC_FORMAT = "metricshub.host.response_time{protocol=\"%s\"}";
 
 	/**
 	 * Constructs a new {@code HealthCheckStrategy} using the provided telemetry
@@ -96,14 +106,14 @@ public class ProtocolHealthCheckStrategy extends AbstractStrategy {
 					// Collect protocol check metric
 					metricFactory.collectNumberMetric(
 						endpointHostMonitor,
-						"metricshub.host.up{protocol=\"" + protocolExtension.getIdentifier() + "\"}",
+						UP_METRIC_FORMAT.formatted(protocolExtension.getIdentifier()),
 						Boolean.TRUE.equals(isUp) ? UP : DOWN,
 						strategyTime
 					);
 					// Collect protocol check response time metric
 					metricFactory.collectNumberMetric(
 						endpointHostMonitor,
-						"metricshub.host.up.response_time{protocol=\"" + protocolExtension.getIdentifier() + "\"}",
+						RESPONSE_TIME_METRIC_FORMAT.formatted(protocolExtension.getIdentifier()),
 						responseTime,
 						strategyTime
 					);

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategyTest.java
@@ -1,6 +1,9 @@
 package org.sentrysoftware.metricshub.engine.strategy.collect;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.sentrysoftware.metricshub.engine.common.helpers.KnownMonitorType.HOST;
 import static org.sentrysoftware.metricshub.engine.constants.Constants.HOSTNAME;
@@ -8,6 +11,7 @@ import static org.sentrysoftware.metricshub.engine.constants.Constants.HOSTNAME;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +24,7 @@ import org.sentrysoftware.metricshub.engine.extension.IProtocolExtension;
 import org.sentrysoftware.metricshub.engine.extension.TestConfiguration;
 import org.sentrysoftware.metricshub.engine.telemetry.Monitor;
 import org.sentrysoftware.metricshub.engine.telemetry.TelemetryManager;
+import org.sentrysoftware.metricshub.engine.telemetry.metric.NumberMetric;
 
 @ExtendWith(MockitoExtension.class)
 class ProtocolHealthCheckStrategyTest {
@@ -62,11 +67,12 @@ class ProtocolHealthCheckStrategyTest {
 					.configurations(Map.of(TestConfiguration.class, TestConfiguration.builder().build()))
 					.build()
 			)
+			.strategyTime(System.currentTimeMillis())
 			.build();
 	}
 
 	@Test
-	void testCheckHealth() throws Exception {
+	void testCheckHealth() {
 		// Create a telemetry manager using a test configuration.
 		final TelemetryManager telemetryManager = createTelemetryManagerWithTestConfig();
 
@@ -80,6 +86,12 @@ class ProtocolHealthCheckStrategyTest {
 			.when(protocolExtensionMock)
 			.isValidConfiguration(telemetryManager.getHostConfiguration().getConfigurations().get(TestConfiguration.class));
 
+		final String protocol = "snmp";
+
+		doReturn(protocol).when(protocolExtensionMock).getIdentifier();
+
+		doReturn(Optional.of(true)).when(protocolExtensionMock).checkProtocol(any(TelemetryManager.class));
+
 		// Create a new protocol health check strategy
 		final ProtocolHealthCheckStrategy healthCheckStrategy = new ProtocolHealthCheckStrategy(
 			telemetryManager,
@@ -88,5 +100,18 @@ class ProtocolHealthCheckStrategyTest {
 			extensionManager
 		);
 		assertDoesNotThrow(() -> healthCheckStrategy.run());
+
+		assertEquals(
+			ProtocolHealthCheckStrategy.UP,
+			telemetryManager
+				.getEndpointHostMonitor()
+				.getMetric(ProtocolHealthCheckStrategy.UP_METRIC_FORMAT.formatted(protocol), NumberMetric.class)
+				.getValue()
+		);
+		assertNotNull(
+			telemetryManager
+				.getEndpointHostMonitor()
+				.getMetric(ProtocolHealthCheckStrategy.RESPONSE_TIME_METRIC_FORMAT.formatted(protocol), NumberMetric.class)
+		);
 	}
 }


### PR DESCRIPTION
This pull request includes several changes to the `ProtocolHealthCheckStrategy` class and related test cases, as well as a modification to the metric names in the `metricshub-host-metrics.yaml` file. The most important changes include renaming metrics, updating the `ProtocolHealthCheckStrategy` class, and enhancing test coverage.

### Metric Renaming:
* `metricshub.host.up.response_time` was renamed to `metricshub.host.response_time` in the `metricshub-host-metrics.yaml` file.

### Updates to `ProtocolHealthCheckStrategy`:
* Changed the visibility of constants `UP` and `DOWN` from `public` to package-private and introduced new constants `UP_METRIC_FORMAT` and `RESPONSE_TIME_METRIC_FORMAT` for metric formatting in `ProtocolHealthCheckStrategy.java`.
* Refactored the `run` method to use the new metric format constants for collecting metrics.

### Enhancements to Test Coverage:
* Added new import statements for `assertEquals`, `assertNotNull`, and `Optional` in `ProtocolHealthCheckStrategyTest.java`.
* Included `NumberMetric` import and updated the `createTelemetryManagerWithTestConfig` method to set `strategyTime`. [[1]](diffhunk://#diff-eaba2e24640e1c387ed8a284f72e1ce1c6fdeb51abcb83fbab1ad33819697085R27) [[2]](diffhunk://#diff-eaba2e24640e1c387ed8a284f72e1ce1c6fdeb51abcb83fbab1ad33819697085R70-R75)
* Enhanced the `testCheckHealth` method to validate the metric values and ensure the metrics are not null. [[1]](diffhunk://#diff-eaba2e24640e1c387ed8a284f72e1ce1c6fdeb51abcb83fbab1ad33819697085R89-R94) [[2]](diffhunk://#diff-eaba2e24640e1c387ed8a284f72e1ce1c6fdeb51abcb83fbab1ad33819697085R103-R115)

----------------
![image](https://github.com/user-attachments/assets/74e347e7-b34e-449e-9493-467a61f103be)

