### PR TITLE
Issue #582: Simplify the options required in httpcli

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/HttpCli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/HttpCli.java
@@ -126,7 +126,7 @@ public class HttpCli implements IQuery, Callable<Integer> {
 	@Spec
 	CommandSpec spec;
 
-	@Parameters(index = "0", paramLabel = "POSITIONALMETHOD", description = "HTTP request Method.", arity = "0..1")
+	@Parameters(index = "0", paramLabel = "METHOD", description = "HTTP request Method.", arity = "0..1")
 	private String positionalMethod;
 
 	@Parameters(index = "1", paramLabel = "URL", description = "Url for HTTP request.", arity = "0..1")
@@ -288,11 +288,10 @@ public class HttpCli implements IQuery, Callable<Integer> {
 	 */
 	public void resolveMethod() {
 		if (method == null) {
-			method =
-				(positionalMethod != null && VALID_HTTP_METHODS.contains(positionalMethod.toUpperCase()))
-					? positionalMethod
-					: HTTP_GET;
-		} else if (!VALID_HTTP_METHODS.contains(method.toUpperCase())) {
+			method = positionalMethod != null ? positionalMethod : HTTP_GET;
+		}
+
+		if (!VALID_HTTP_METHODS.contains(method.toUpperCase())) {
 			method = HTTP_GET;
 		}
 	}

--- a/metricshub-doc/src/site/markdown/troubleshooting/cli/http.md
+++ b/metricshub-doc/src/site/markdown/troubleshooting/cli/http.md
@@ -12,6 +12,10 @@ Before using the CLI, ensure your platform supports HTTP monitoring by checking 
 ## Syntax
 
 ```bash
+httpcli <GET|POST|PUT|DELETE> <URL> --username <USERNAME> --password <PASSWORD> [--body <BODY> | --body-file <FILE PATH>] [--header <HEADER> | --header-file <FILE PATH>] --timeout <TIMEOUT>
+```
+or
+```
 httpcli --method <GET|POST|PUT|DELETE> --url <URL> --username <USERNAME> --password <PASSWORD> [--body <BODY> | --body-file <FILE PATH>] [--header <HEADER> | --header-file <FILE PATH>] --timeout <TIMEOUT>
 ```
 
@@ -36,13 +40,13 @@ httpcli --method <GET|POST|PUT|DELETE> --url <URL> --username <USERNAME> --passw
 ### Example 1: HTTP GET Request with Headers and Body
 
 ```bash
-httpcli --method get --url https://dev-01:443/users --username username --password password --header="Content-Type:application/xml" --header="Accept:application/json" --body="<aaaLogin inName='username' inPassword='password' />" --timeout 120
+httpcli get https://dev-01:443/users --username username --password password --header="Content-Type:application/xml" --header="Accept:application/json" --body="<aaaLogin inName='username' inPassword='password' />" --timeout 120
 ```
 
 ### Example 2: HTTP POST Request with Header and Body Files
 
 ```bash
-httpcli --method post --url https://dev-01:443/users --username admin --password pass --header-file="/opt/metricshub/header.txt" --body-file="/opt/metricshub/body.txt" --timeout 120
+httpcli post https://dev-01:443/users --username admin --password pass --header-file="/opt/metricshub/header.txt" --body-file="/opt/metricshub/body.txt" --timeout 120
 ```
 
 ### Example 3: HTTP Get Request with Interactive Password Input


### PR DESCRIPTION
* Simplified httpcli options by adding two parameters `positionalMethod` and `positionalUrl` which allow to create CLI requests without using `--method` and `--url`.
* Handled all the possible cases when the user specifies both positional parameters and options.
* Tested on MetricsHub.

# Tests
## Use cases
![image](https://github.com/user-attachments/assets/d7ee52ae-9cd2-430b-918a-2650304e86f7)
### 1
![image](https://github.com/user-attachments/assets/22d8d92d-801a-48a1-a85d-66cf96f12dbf)

### 2
![image](https://github.com/user-attachments/assets/74039343-7c4f-405b-9f5d-f08417d38f79)

### 3
![image](https://github.com/user-attachments/assets/2d7cb770-be3b-42a5-9de3-5c3a434ec830)

### 4
![image](https://github.com/user-attachments/assets/66fd4a2e-0ff3-40a0-b52c-7635e8ba604d)

### 5
![image](https://github.com/user-attachments/assets/28ac400b-ba52-4d8f-b786-baf0a4dc3b78)

### 6
![image](https://github.com/user-attachments/assets/bd3d5e7b-e000-4cd9-80d4-fc3a4f049d6c)

### 7
![image](https://github.com/user-attachments/assets/5e3ef02c-3af6-4bfc-94db-383f4e2cdf6f)

### 8
![image](https://github.com/user-attachments/assets/62763148-798a-4685-8a9d-cc4a269a4631)

### 9
![image](https://github.com/user-attachments/assets/c64840c2-7505-42d2-8700-ce5658055c47)

### 10
![image](https://github.com/user-attachments/assets/700e6b26-db24-4e2e-aca8-cdfcfce1426d)

### 11
![image](https://github.com/user-attachments/assets/e500b016-6e44-48d9-8438-58bc9816e100)
