### PR TITLE
Issue #574: When upgrading from previous version

### DIFF
--- a/metricshub-linux/pom.xml
+++ b/metricshub-linux/pom.xml
@@ -146,67 +146,67 @@
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-snmp-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-snmp-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-snmpv3-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-snmpv3-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-http-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-http-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-ipmi-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-ipmi-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-oscommand-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-oscommand-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-wmi-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-wmi-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-wbem-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-wbem-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-winrm-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-winrm-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-ping-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-ping-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-classloader-agent</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-classloader-agent.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-internaldb-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-internaldb-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-jdbc-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-jdbc-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-jawk-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-jawk-extension.jar</destFileName>
 								</artifactItem>
 							</artifactItems>
 						</configuration>

--- a/metricshub-windows/pom.xml
+++ b/metricshub-windows/pom.xml
@@ -152,67 +152,67 @@
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-snmp-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-snmp-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-snmpv3-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-snmpv3-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-oscommand-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-oscommand-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-ipmi-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-ipmi-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-http-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-http-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-wmi-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-wmi-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-wbem-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-wbem-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-winrm-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-winrm-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-ping-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-ping-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-classloader-agent</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-classloader-agent.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-internaldb-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-internaldb-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-jawk-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-jawk-extension.jar</destFileName>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
 									<artifactId>metricshub-jdbc-extension</artifactId>
-									<version>${project.version}</version>
+									<destFileName>metricshub-jdbc-extension.jar</destFileName>
 								</artifactItem>
 							</artifactItems>
 						</configuration>


### PR DESCRIPTION
* Removed versions on metricshub extensions to avoid problems when unzipping a new metricshub version on the same metricshub directory where an old version is.
* Tested on MetricsHub windows and linux.

# Tests
## Windows
![image](https://github.com/user-attachments/assets/8c0f4f4c-8fc0-41ef-8734-bfbb6a5767bf)

## Linux
![image](https://github.com/user-attachments/assets/9a9f40f3-7a88-4012-ae89-8d3ca8c579f5)
