### PR TITLE
Issue #608: Fix SNMP CLI retry-intervals option names and update SNMPv3 retry intervals example in documentation

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/SnmpCli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/SnmpCli.java
@@ -72,19 +72,19 @@ public class SnmpCli implements IQuery, Callable<Integer> {
 
 		@|green # SNMP Get request|@
 		snmpcli <HOSTNAME> --get <OID> --community <COMMUNITY> --version <VERSION> --port <PORT> --timeout <TIMEOUT> --retry <INTERVAL1>,<INTERVAL2>,...
-		snmpcli <HOSTNAME> --get 1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.1.1 --community public --version v2c --port 161 --timeout 1m --retry 500,1000
+		snmpcli <HOSTNAME> --get 1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.1.1 --community public --version v2c --port 161 --timeout 1m --retry 5000,10000
 
 		@|green # SNMP Get Next request|@
 		snmpcli <HOSTNAME> --getNext <OID> --community <COMMUNITY> --version <VERSION> --port <PORT> --timeout <TIMEOUT> --retry <INTERVAL1>,<INTERVAL2>,...
-		snmpcli <HOSTNAME> --getNext 1.3.6.1.4.1.674.10892.5.5.1.20.130.4 --community public --version v2c --port 161 --timeout 1m --retry 500,1000
+		snmpcli <HOSTNAME> --getNext 1.3.6.1.4.1.674.10892.5.5.1.20.130.4 --community public --version v2c --port 161 --timeout 1m
 
 		@|green # SNMP Walk request|@
 		snmpcli <HOSTNAME> --walk <OID> --community <COMMUNITY> --version <VERSION> --port <PORT> --timeout <TIMEOUT> --retry <INTERVAL1>,<INTERVAL2>,...
-		snmpcli <HOSTNAME> --walk 1.3.6.1 --community public --version v1 --port 161 --timeout 1m --retry 500,1000
+		snmpcli <HOSTNAME> --walk 1.3.6.1 --community public --version v1 --port 161 --timeout 1m
 
 		@|green # SNMP Table request|@
 		snmpcli <HOSTNAME> --table <OID> --columns <COLUMN, COLUMN, ...> --community <COMMUNITY> --version <VERSION> --port <PORT> --timeout <TIMEOUT> --retry <INTERVAL1>,<INTERVAL2>,...
-		snmpcli <HOSTNAME> --table 1.3.6.1.4.1.674.10892.5.4.300.10.1 --columns 1,3,8,9,11 --community public --version v1 --port 161 --timeout 1m --retry 500,1000
+		snmpcli <HOSTNAME> --table 1.3.6.1.4.1.674.10892.5.4.300.10.1 --columns 1,3,8,9,11 --community public --version v1 --port 161 --timeout 1m
 		""";
 
 	@Parameters(index = "0", paramLabel = "HOSTNAME", description = "Hostname or IP address of the host to monitor")
@@ -134,7 +134,7 @@ public class SnmpCli implements IQuery, Callable<Integer> {
 		order = 5,
 		paramLabel = "RETRYINTERVALS",
 		split = ",",
-		description = "Timeout in milliseconds after which the elementary operations will be retried"
+		description = "Comma-separated retry intervals in milliseconds for SNMP operations."
 	)
 	int[] retryIntervals;
 

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/SnmpCli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/SnmpCli.java
@@ -134,7 +134,7 @@ public class SnmpCli implements IQuery, Callable<Integer> {
 		order = 5,
 		paramLabel = "RETRYINTERVALS",
 		split = ",",
-		description = "Comma-separated retry intervals in milliseconds for SNMP operations."
+		description = "Comma-separated retry intervals in milliseconds for SNMP operations"
 	)
 	int[] retryIntervals;
 

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/SnmpV3Cli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/SnmpV3Cli.java
@@ -197,7 +197,7 @@ public class SnmpV3Cli implements IQuery, Callable<Integer> {
 		order = 9,
 		paramLabel = "RETRYINTERVALS",
 		split = ",",
-		description = "Comma-separated retry intervals in milliseconds for SNMPv3 operations."
+		description = "Comma-separated retry intervals in milliseconds for SNMPv3 operations"
 	)
 	private int[] retryIntervals;
 

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/SnmpV3Cli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/SnmpV3Cli.java
@@ -81,10 +81,10 @@ public class SnmpV3Cli implements IQuery, Callable<Integer> {
 		--retry <INTERVAL1>,<INTERVAL2>,...
 
 		snmpv3cli dev-01 --get 1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.1.1 --privacy AES --privacy-password privacyPassword \
-		--auth MD5 --username username --password password --context-name context --timeout 2m --retry 500,1000
+		--auth MD5 --username username --password password --context-name context --timeout 2m --retry 5000,10000
 
 		snmpv3cli dev-01 --get 1.3.6.1.4.1.674.10892.5.5.1.20.130.4.1.1.1 --privacy AES --privacy-password privacyPassword \
-		--auth SHA256 --username username --password password --context-name context --timeout 2m --retry 500,1000
+		--auth SHA256 --username username --password password --context-name context --timeout 2m
 
 		@|green # SNMPv3 Get Next request:|@
 		snmpv3cli <HOSTNAME> --getNext <OID> --privacy <DES|AES> --privacy-password <PRIVACY-PASSWORD> \
@@ -92,30 +92,30 @@ public class SnmpV3Cli implements IQuery, Callable<Integer> {
 		--retry <INTERVAL1>,<INTERVAL2>,...
 
 		snmpv3cli dev-01 --getNext 1.3.6.1.4.1.674.10892.5.5.1.20.130.4 --privacy AES --privacy-password privacyPassword \
-		--auth MD5 --username username --password password --context-name context --timeout 2m --retry 500,1000
+		--auth MD5 --username username --password password --context-name context --timeout 2m
 
 		snmpv3cli dev-01 --getNext 1.3.6.1.4.1.674.10892.5.5.1.20.130.4 --privacy AES --privacy-password privacyPassword \
-		--auth SHA256 --username username --password password --context-name context --timeout 2m --retry 500,1000
+		--auth SHA256 --username username --password password --context-name context --timeout 2m
 
 		@|green # SNMPv3 Walk request:|@
 		snmpv3cli <HOSTNAME> --walk <OID> --privacy <DES|AES> --privacy-password <PRIVACY-PASSWORD> --auth <SHA|MD5> \
 		--username username --password password --context-name <CONTEXT> --timeout <TIMEOUT> --retry <INTERVAL1>,<INTERVAL2>,...
 
 		snmpv3cli dev-01 --walk 1.3.6.1 --privacy AES --privacy-password privacyPassword --auth MD5 --username username \
-		--password password --context-name context --timeout 2m --retry 500,1000
+		--password password --context-name context --timeout 2m
 
 		snmpv3cli dev-01 --walk 1.3.6.1 --privacy AES --privacy-password privacyPassword --auth SHA256 \
-		--username username --password password --context-name context --timeout 2m --retry 500,1000
+		--username username --password password --context-name context --timeout 2m
 
 		@|green # SNMPv3 Table request:|@
 		snmpv3cli <HOSTNAME> --table <OID> --columns <COLUMN1>,<COLUMN2>,... --privacy <DES|AES> --privacy-password <PRIVACY-PASSWORD> \
 		--auth <SHA|MD5> --username username --password password --context-name <CONTEXT> --timeout <TIMEOUT> --retry <INTERVAL1>,<INTERVAL2>,...
 
 		snmpv3cli dev-01 --table 1.3.6.1.4.1.674.10892.5.4.300.10.1 --columns 1,3,8,9,11 --privacy AES --privacy-password privacyPassword \
-		--auth MD5 --username username --password password --context-name context --timeout 2m --retry 500,1000
+		--auth MD5 --username username --password password --context-name context --timeout 2m
 
 		snmpv3cli dev-01 --table 1.3.6.1.4.1.674.10892.5.4.300.10.1 --columns 1,3,8,9,11 --privacy AES --privacy-password privacyPassword \
-		--auth SHA256 --username username --password password --context-name context --timeout 2m --retry 500,1000
+		--auth SHA256 --username username --password password --context-name context --timeout 2m
 
 		Note: If --password is not provided, you will be prompted interactively.
 		""";
@@ -195,9 +195,9 @@ public class SnmpV3Cli implements IQuery, Callable<Integer> {
 	@Option(
 		names = { "--retry-intervals", "--retry" },
 		order = 9,
-		paramLabel = "RETRY INTERVALS",
+		paramLabel = "RETRYINTERVALS",
 		split = ",",
-		description = "Comma-separated retry intervals in milliseconds for SNMP version 3 operations"
+		description = "Comma-separated retry intervals in milliseconds for SNMPv3 operations."
 	)
 	private int[] retryIntervals;
 

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpConfigCli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpConfigCli.java
@@ -86,7 +86,7 @@ public class SnmpConfigCli implements IProtocolConfigCli {
 		order = 5,
 		paramLabel = "RETRYINTERVALS",
 		split = ",",
-		description = "Comma-separated retry intervals in milliseconds for SNMP operations."
+		description = "Comma-separated retry intervals in milliseconds for SNMP operations"
 	)
 	int[] retryIntervals;
 

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpConfigCli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpConfigCli.java
@@ -82,10 +82,11 @@ public class SnmpConfigCli implements IProtocolConfigCli {
 	String timeout;
 
 	@Option(
-		names = { "--snmp-retry-intervals", "--retry" },
+		names = { "--snmp-retry-intervals", "--snmp-retry" },
 		order = 5,
 		paramLabel = "RETRYINTERVALS",
-		description = "Timeout in milliseconds after which the elementary operations will be retried"
+		split = ",",
+		description = "Comma-separated retry intervals in milliseconds for SNMP operations."
 	)
 	int[] retryIntervals;
 

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpV3ConfigCli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpV3ConfigCli.java
@@ -120,7 +120,7 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 		order = 10,
 		paramLabel = "RETRYINTERVALS",
 		split = ",",
-		description = "Comma-separated retry intervals in milliseconds for SNMPv3 operations."
+		description = "Comma-separated retry intervals in milliseconds for SNMPv3 operations"
 	)
 	private int[] retryIntervals;
 

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpV3ConfigCli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/SnmpV3ConfigCli.java
@@ -116,11 +116,11 @@ public class SnmpV3ConfigCli implements IProtocolConfigCli {
 	private int port;
 
 	@Option(
-		names = "--snmpv3-retryIntervals",
+		names = { "--snmpv3-retry-intervals", "--snmpv3-retry" },
 		order = 10,
-		paramLabel = "RETRY INTERVALS",
+		paramLabel = "RETRYINTERVALS",
 		split = ",",
-		description = "Comma-separated retry intervals in milliseconds for SNMP version 3 operations"
+		description = "Comma-separated retry intervals in milliseconds for SNMPv3 operations."
 	)
 	private int[] retryIntervals;
 

--- a/metricshub-doc/src/site/markdown/appendix/cli.md
+++ b/metricshub-doc/src/site/markdown/appendix/cli.md
@@ -128,7 +128,7 @@ This command will connect to the `CISC03` SAN switch (`sto`rage) using `SNMP` ve
 ### Storage System, SNMP v3
 
 ```batch
-$ metricshub STOR02 -t storage --snmpv3 --snmpv3-auth SHA --snmpv3-username USERA --snmpv3-password MySECRET --snmpv3-privacy DES --snmpv3-retryIntervals 5,10,15 --snmpv3-privacy-password MyPrivacySECRET
+$ metricshub STOR02 -t storage --snmpv3 --snmpv3-auth SHA --snmpv3-username USERA --snmpv3-password MySECRET --snmpv3-privacy DES --snmpv3-retry-intervals 5000,10000,15000 --snmpv3-privacy-password MyPrivacySECRET
 ```
 
 This command will connect to the `STOR02` storage system (`storage`) using `SNMP` version `3`.
@@ -302,7 +302,7 @@ Use the `--monitors` option to filter the monitor types according to the specifi
 To display only specific monitor types, use the `--monitors` option with a `+` sign before each monitor type you want to include. For example, to display only memory and file system monitors:
 
 ```batch
-$ metricshub STOR02 -t storage --snmpv3 --snmpv3-auth SHA --snmpv3-username USERA --snmpv3-password MySECRET --snmpv3-privacy DES --snmpv3-retryIntervals 5,10,15 --snmpv3-privacy-password MyPrivacySECRET --monitors +memory,+file_system
+$ metricshub STOR02 -t storage --snmpv3 --snmpv3-auth SHA --snmpv3-username USERA --snmpv3-password MySECRET --snmpv3-privacy DES --snmpv3-retry-intervals 5000,10000,15000 --snmpv3-privacy-password MyPrivacySECRET --monitors +memory,+file_system
 ```
 
 ### Example 2: Exclude a Set of Monitor Types
@@ -310,6 +310,6 @@ $ metricshub STOR02 -t storage --snmpv3 --snmpv3-auth SHA --snmpv3-username USER
 To exclude specific monitor types, use the `--monitors` option with a `!` sign before each monitor type you want to exclude. For example, to exclude CPU and disk monitors:
 
 ```batch
-$ metricshub STOR02 -t storage --snmpv3 --snmpv3-auth SHA --snmpv3-username USERA --snmpv3-password MySECRET --snmpv3-privacy DES --snmpv3-retryIntervals 5,10,15 --snmpv3-privacy-password MyPrivacySECRET --monitors !cpu,!disk
+$ metricshub STOR02 -t storage --snmpv3 --snmpv3-auth SHA --snmpv3-username USERA --snmpv3-password MySECRET --snmpv3-privacy DES --snmpv3-retry-intervals 5000,10000,15000 --snmpv3-privacy-password MyPrivacySECRET --monitors !cpu,!disk
 ```
 


### PR DESCRIPTION

* Updated CLI Option Definitions.
* Updated Documentation Examples.
* Tested all the Changes

# Tests
## MetricsHub -h result
![image](https://github.com/user-attachments/assets/007cf35b-7fc9-49cc-8e74-165db6537741)
## SNMP requests
NB: With a short retry intervals time (5,10 milliseconds), the request does not have the time to get executed, which caused the detection to stop.
![image](https://github.com/user-attachments/assets/c37056b9-53b2-41a4-8ce5-414c82ef2ca2)

## SNMPv3 requests
![image](https://github.com/user-attachments/assets/8b4b3307-b34f-4825-9849-913ddd5357b7)
