### PR TITLE
Issue #614: metricshub.host.response_time is reported when metricshubhost.up is down

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategy.java
@@ -110,13 +110,16 @@ public class ProtocolHealthCheckStrategy extends AbstractStrategy {
 						Boolean.TRUE.equals(isUp) ? UP : DOWN,
 						strategyTime
 					);
-					// Collect protocol check response time metric
-					metricFactory.collectNumberMetric(
-						endpointHostMonitor,
-						RESPONSE_TIME_METRIC_FORMAT.formatted(protocolExtension.getIdentifier()),
-						responseTime,
-						strategyTime
-					);
+
+					// Collect protocol check response time metric if response up is true
+					if (Boolean.TRUE.equals(isUp)) {
+						metricFactory.collectNumberMetric(
+							endpointHostMonitor,
+							RESPONSE_TIME_METRIC_FORMAT.formatted(protocolExtension.getIdentifier()),
+							responseTime,
+							strategyTime
+						);
+					}
 				});
 		});
 		// CHECKSTYLE:ON

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategy.java
@@ -102,17 +102,11 @@ public class ProtocolHealthCheckStrategy extends AbstractStrategy {
 					final Double responseTime = (System.currentTimeMillis() - startTime) / 1000.0;
 					final Monitor endpointHostMonitor = telemetryManager.getEndpointHostMonitor();
 					final Long strategyTime = telemetryManager.getStrategyTime();
-					MetricFactory metricFactory = new MetricFactory();
-					// Collect protocol check metric
-					metricFactory.collectNumberMetric(
-						endpointHostMonitor,
-						UP_METRIC_FORMAT.formatted(protocolExtension.getIdentifier()),
-						Boolean.TRUE.equals(isUp) ? UP : DOWN,
-						strategyTime
-					);
-
-					// Collect protocol check response time metric if response up is true
+					final MetricFactory metricFactory = new MetricFactory();
+					Double up = DOWN;
 					if (Boolean.TRUE.equals(isUp)) {
+						up = UP;
+						// Collect protocol check response time metric if response up is true
 						metricFactory.collectNumberMetric(
 							endpointHostMonitor,
 							RESPONSE_TIME_METRIC_FORMAT.formatted(protocolExtension.getIdentifier()),
@@ -120,6 +114,13 @@ public class ProtocolHealthCheckStrategy extends AbstractStrategy {
 							strategyTime
 						);
 					}
+					// Collect protocol check metric
+					metricFactory.collectNumberMetric(
+						endpointHostMonitor,
+						UP_METRIC_FORMAT.formatted(protocolExtension.getIdentifier()),
+						up,
+						strategyTime
+					);
 				});
 		});
 		// CHECKSTYLE:ON


### PR DESCRIPTION

* Added a condition to collect `metricshub_response_time_seconds` only if the `metricshub_host_up` is collected as TRUE/1.0.
* Tested successfully on MetricsHub.

# Tests
## Before (`metricshub_host_response_time_seconds` is collected even if the `metricshub_host_up` is down)
![image](https://github.com/user-attachments/assets/08736556-e6d1-44da-947d-882c5d534b75)

## After (`metricshub_host_response_time_seconds` is collected only when the `metricshub_host_up` is up)
![image](https://github.com/user-attachments/assets/0bce298d-1082-4acb-b5e4-d62afe0e567f)
