### PR TITLE
Issue #619: Incorrect text table display in SNMP logs when adding columns using computes

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractStrategy.java
@@ -380,7 +380,7 @@ public abstract class AbstractStrategy implements IStrategy {
 				executionClassName,
 				executionKey,
 				connectorId,
-				TextTableHelper.generateTextTable(sourceTable.getHeaders(), sourceTable.getTable())
+				TextTableHelper.generateTextTable(sourceTable.getTable())
 			);
 			return;
 		}
@@ -393,7 +393,7 @@ public abstract class AbstractStrategy implements IStrategy {
 			executionKey,
 			connectorId,
 			sourceTable.getRawData(),
-			TextTableHelper.generateTextTable(sourceTable.getHeaders(), sourceTable.getTable())
+			TextTableHelper.generateTextTable(sourceTable.getTable())
 		);
 	}
 

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/SourceProcessor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/source/SourceProcessor.java
@@ -538,7 +538,7 @@ public class SourceProcessor implements ISourceProcessor {
 				parentSourceKey,
 				childSourceKey,
 				connectorId,
-				TextTableHelper.generateTextTable(sourceTable.getHeaders(), sourceTable.getTable())
+				TextTableHelper.generateTextTable(sourceTable.getTable())
 			);
 			return;
 		}
@@ -550,7 +550,7 @@ public class SourceProcessor implements ISourceProcessor {
 			childSourceKey,
 			connectorId,
 			sourceTable.getRawData(),
-			TextTableHelper.generateTextTable(sourceTable.getHeaders(), sourceTable.getTable())
+			TextTableHelper.generateTextTable(sourceTable.getTable())
 		);
 	}
 


### PR DESCRIPTION

* Used generateTextTable(List<List<String>> rows) instead of generateTextTable(String[] columns, List<List<String>> rows) to avoid columns display, which corrects the bug.
* Tested the resulted version on MetricsHub.

# Tests
![image](https://github.com/user-attachments/assets/f5dc7252-6711-4804-a161-68bbd7a67120)
