### PR TITLE
Issue #623: JDBC URL is not generated when the database type is set to `mssql` in the resource protocol configuration

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/MetricsHubCliService.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/MetricsHubCliService.java
@@ -293,8 +293,6 @@ public class MetricsHubCliService implements Callable<Integer> {
 
 		// Set the configurations
 		final Map<Class<? extends IConfiguration>, IConfiguration> configurations = buildConfigurations();
-		// Duplicate the main hostname on each configuration. By design, the extensions retrieve the hostname from the configuration.
-		configurations.values().forEach(configuration -> configuration.setHostname(hostname));
 		hostConfiguration.setConfigurations(configurations);
 
 		// Create the TelemetryManager using the connector store and the host configuration created above.
@@ -488,6 +486,7 @@ public class MetricsHubCliService implements Callable<Integer> {
 			.map(protocolConfig -> {
 				try {
 					final IConfiguration protocol = protocolConfig.toConfiguration(username, password);
+					protocol.setHostname(hostname);
 					protocol.validateConfiguration(hostname);
 					return protocol;
 				} catch (InvalidConfigurationException e) {

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/JdbcConfigCli.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/protocol/JdbcConfigCli.java
@@ -75,7 +75,7 @@ public class JdbcConfigCli implements IProtocolConfigCli {
 	private String timeout;
 
 	@Option(names = "--jdbc-port", order = 6, paramLabel = "PORT", description = "Port for JDBC connection")
-	private int port;
+	private Integer port;
 
 	@Option(names = "--jdbc-database", order = 7, paramLabel = "DATABASE", description = "Name of the database")
 	private String database;
@@ -113,7 +113,9 @@ public class JdbcConfigCli implements IProtocolConfigCli {
 			configuration.set("url", new TextNode(String.valueOf(url)));
 		}
 		configuration.set("timeout", new TextNode(timeout));
-		configuration.set("port", new IntNode(port));
+		if (port != null) {
+			configuration.set("port", new IntNode(port));
+		}
 		configuration.set("database", new TextNode(database));
 		configuration.set("type", new TextNode(type));
 

--- a/metricshub-doc/src/site/markdown/appendix/cli.md
+++ b/metricshub-doc/src/site/markdown/appendix/cli.md
@@ -136,7 +136,7 @@ This command will connect to the `STOR02` storage system (`storage`) using `SNMP
 ### Windows, JDBC (MySQL)
 
 ```batch
-$ metricshub WIN06 -t win --jdbc --jdbc-username USERA --jdbc-password MYSECRET --jdbc-port 3306 --jdbc-database MyDB --jdbc-type mysql -c +MySql
+$ metricshub WIN06 -t win --jdbc --jdbc-username USERA --jdbc-password MYSECRET --jdbc-port 3306 --jdbc-type mysql -c +MySql
 ```
 
 This command will connect to the `WIN06` `Win`dows system using the `JDBC` configuration to access the database and execute SQL queries as `USERA`.

--- a/metricshub-doc/src/site/markdown/configuration/configure-monitoring.md
+++ b/metricshub-doc/src/site/markdown/configuration/configure-monitoring.md
@@ -291,11 +291,10 @@ resourceGroups:
             hostname: my-host-02
             username: dbuser
             password: dbpassword
-            url: jdbc:mysql://my-host-02:3306/mydatabase
+            url: jdbc:mysql://my-host-02:3306
             timeout: 120s
             type: mysql
             port: 3306
-            database: mydatabase
 ```
 
 #### OS commands

--- a/metricshub-jdbc-extension/src/main/java/org/sentrysoftware/metricshub/extension/jdbc/JdbcConfiguration.java
+++ b/metricshub-jdbc-extension/src/main/java/org/sentrysoftware/metricshub/extension/jdbc/JdbcConfiguration.java
@@ -99,17 +99,6 @@ public class JdbcConfiguration implements IConfiguration {
 
 		if (url == null || url.length == 0) {
 			StringHelper.validateConfigurationAttribute(
-				database,
-				attr -> attr == null || attr.isBlank(),
-				() ->
-					"""
-					Resource %s - No database name configured for JDBC. \
-					Database value returned: %s. This resource will not be monitored. \
-					Please verify the configured database value.\
-					""".formatted(resourceKey, database)
-			);
-
-			StringHelper.validateConfigurationAttribute(
 				type,
 				attr -> attr == null || attr.isBlank(),
 				() ->
@@ -188,9 +177,9 @@ public class JdbcConfiguration implements IConfiguration {
 	char[] generateUrl() {
 		return switch (type.toLowerCase()) {
 			case "postgresql" -> String.format("jdbc:postgresql://%s:%d/%s", hostname, port, database).toCharArray();
-			case "mysql" -> String.format("jdbc:mysql://%s:%d/%s", hostname, port, database).toCharArray();
-			case "sqlserver" -> String
-				.format("jdbc:sqlserver://%s:%d;databaseName=%s", hostname, port, database)
+			case "mysql" -> String.format("jdbc:mysql://%s:%d", hostname, port).toCharArray();
+			case "mssql" -> String
+				.format("jdbc:sqlserver://%s:%d;decrypt=true;trustServerCertificate=true", hostname, port)
 				.toCharArray();
 			default -> new char[0];
 		};

--- a/metricshub-jdbc-extension/src/main/java/org/sentrysoftware/metricshub/extension/jdbc/JdbcConfiguration.java
+++ b/metricshub-jdbc-extension/src/main/java/org/sentrysoftware/metricshub/extension/jdbc/JdbcConfiguration.java
@@ -177,7 +177,9 @@ public class JdbcConfiguration implements IConfiguration {
 	char[] generateUrl() {
 		return switch (type.toLowerCase()) {
 			case "postgresql" -> String.format("jdbc:postgresql://%s:%d/%s", hostname, port, database).toCharArray();
-			case "mysql" -> String.format("jdbc:mysql://%s:%d", hostname, port).toCharArray();
+			case "mysql" -> String
+				.format("jdbc:mysql://%s:%d/%s", hostname, port, database != null ? database : "")
+				.toCharArray();
 			case "mssql" -> String
 				.format("jdbc:sqlserver://%s:%d;decrypt=true;trustServerCertificate=true", hostname, port)
 				.toCharArray();

--- a/metricshub-jdbc-extension/src/test/java/org/sentrysoftware/metricshub/extension/jdbc/JdbcConfigurationTest.java
+++ b/metricshub-jdbc-extension/src/test/java/org/sentrysoftware/metricshub/extension/jdbc/JdbcConfigurationTest.java
@@ -14,20 +14,20 @@ class JdbcConfigurationTest {
 
 	@Test
 	void testGenerateUrl() {
-		JdbcConfiguration jdbcConfiguration = JdbcConfiguration
+		final JdbcConfiguration jdbcConfiguration = JdbcConfiguration
 			.builder()
 			.type("mysql")
 			.hostname("localhost")
 			.port(3306)
 			.build();
 
-		char[] expectedUrl = "jdbc:mysql://localhost:3306".toCharArray();
+		final char[] expectedUrl = "jdbc:mysql://localhost:3306/".toCharArray();
 		assertArrayEquals(expectedUrl, jdbcConfiguration.generateUrl());
 	}
 
 	@Test
 	void testValidateConfigurationMissingUsername() {
-		JdbcConfiguration jdbcConfiguration = JdbcConfiguration
+		final JdbcConfiguration jdbcConfiguration = JdbcConfiguration
 			.builder()
 			.type("mysql")
 			.database("testdb")
@@ -35,7 +35,7 @@ class JdbcConfigurationTest {
 			.username("")
 			.build();
 
-		Exception exception = assertThrows(
+		final Exception exception = assertThrows(
 			InvalidConfigurationException.class,
 			() -> jdbcConfiguration.validateConfiguration("resourceKey")
 		);
@@ -49,7 +49,7 @@ class JdbcConfigurationTest {
 
 	@Test
 	void testValidateConfigurationInvalidTimeout() {
-		JdbcConfiguration jdbcConfiguration = JdbcConfiguration
+		final JdbcConfiguration jdbcConfiguration = JdbcConfiguration
 			.builder()
 			.username("testUser")
 			.type("mysql")
@@ -58,7 +58,7 @@ class JdbcConfigurationTest {
 			.timeout(-10L)
 			.build();
 
-		Exception exception = assertThrows(
+		final Exception exception = assertThrows(
 			InvalidConfigurationException.class,
 			() -> jdbcConfiguration.validateConfiguration("resourceKey")
 		);
@@ -73,7 +73,7 @@ class JdbcConfigurationTest {
 
 	@Test
 	void testValidateConfigurationInvalidPort() {
-		JdbcConfiguration jdbcConfiguration = JdbcConfiguration
+		final JdbcConfiguration jdbcConfiguration = JdbcConfiguration
 			.builder()
 			.username("testUser")
 			.type("mysql")
@@ -82,7 +82,7 @@ class JdbcConfigurationTest {
 			.port(-1)
 			.build();
 
-		Exception exception = assertThrows(
+		final Exception exception = assertThrows(
 			InvalidConfigurationException.class,
 			() -> jdbcConfiguration.validateConfiguration("resourceKey")
 		);
@@ -97,7 +97,7 @@ class JdbcConfigurationTest {
 
 	@Test
 	void testValidateConfigurationGeneratesUrlWhenNull() {
-		JdbcConfiguration jdbcConfiguration = JdbcConfiguration
+		final JdbcConfiguration jdbcConfiguration = JdbcConfiguration
 			.builder()
 			.username("testUser")
 			.type("mysql")
@@ -109,12 +109,12 @@ class JdbcConfigurationTest {
 
 		assertDoesNotThrow(() -> jdbcConfiguration.validateConfiguration("resourceKey"));
 		assertNotNull(jdbcConfiguration.getUrl());
-		assertEquals("jdbc:mysql://localhost:3306", new String(jdbcConfiguration.getUrl()));
+		assertEquals("jdbc:mysql://localhost:3306/testdb", new String(jdbcConfiguration.getUrl()));
 	}
 
 	@Test
 	void testValidateConfigurationWithEmptyUrl() {
-		JdbcConfiguration jdbcConfiguration = JdbcConfiguration
+		final JdbcConfiguration jdbcConfiguration = JdbcConfiguration
 			.builder()
 			.username("testUser")
 			.type("unsupported_db")
@@ -123,7 +123,7 @@ class JdbcConfigurationTest {
 			.port(3306)
 			.build();
 
-		Exception exception = assertThrows(
+		final Exception exception = assertThrows(
 			InvalidConfigurationException.class,
 			() -> jdbcConfiguration.validateConfiguration("resourceKey")
 		);
@@ -138,7 +138,7 @@ class JdbcConfigurationTest {
 
 	@Test
 	void testValidateConfigurationWithPredefinedUrl() {
-		JdbcConfiguration jdbcConfiguration = JdbcConfiguration
+		final JdbcConfiguration jdbcConfiguration = JdbcConfiguration
 			.builder()
 			.username("testUser")
 			.type("mysql")
@@ -154,11 +154,10 @@ class JdbcConfigurationTest {
 
 	@Test
 	void testValidateConfigurationGeneratesUrlWhenEmpty() {
-		JdbcConfiguration jdbcConfiguration = JdbcConfiguration
+		final JdbcConfiguration jdbcConfiguration = JdbcConfiguration
 			.builder()
 			.username("testUser")
 			.type("mysql")
-			.database("testdb")
 			.hostname("localhost")
 			.port(3306)
 			.url(new char[0]) // URL is empty
@@ -166,12 +165,12 @@ class JdbcConfigurationTest {
 
 		assertDoesNotThrow(() -> jdbcConfiguration.validateConfiguration("resourceKey"));
 		assertNotNull(jdbcConfiguration.getUrl());
-		assertEquals("jdbc:mysql://localhost:3306", new String(jdbcConfiguration.getUrl()));
+		assertEquals("jdbc:mysql://localhost:3306/", new String(jdbcConfiguration.getUrl()));
 	}
 
 	@Test
 	void testValidateConfigurationAssignsDefaultPort() {
-		JdbcConfiguration jdbcConfiguration = JdbcConfiguration
+		final JdbcConfiguration jdbcConfiguration = JdbcConfiguration
 			.builder()
 			.username("testUser")
 			.type("mysql")
@@ -186,7 +185,7 @@ class JdbcConfigurationTest {
 
 	@Test
 	void testCopyConfigurationWithAllFields() {
-		JdbcConfiguration jdbcConfiguration = JdbcConfiguration
+		final JdbcConfiguration jdbcConfiguration = JdbcConfiguration
 			.builder()
 			.username("testUser")
 			.password("password".toCharArray())

--- a/metricshub-jdbc-extension/src/test/java/org/sentrysoftware/metricshub/extension/jdbc/JdbcConfigurationTest.java
+++ b/metricshub-jdbc-extension/src/test/java/org/sentrysoftware/metricshub/extension/jdbc/JdbcConfigurationTest.java
@@ -18,11 +18,10 @@ class JdbcConfigurationTest {
 			.builder()
 			.type("mysql")
 			.hostname("localhost")
-			.database("testdb")
 			.port(3306)
 			.build();
 
-		char[] expectedUrl = "jdbc:mysql://localhost:3306/testdb".toCharArray();
+		char[] expectedUrl = "jdbc:mysql://localhost:3306".toCharArray();
 		assertArrayEquals(expectedUrl, jdbcConfiguration.generateUrl());
 	}
 
@@ -110,7 +109,7 @@ class JdbcConfigurationTest {
 
 		assertDoesNotThrow(() -> jdbcConfiguration.validateConfiguration("resourceKey"));
 		assertNotNull(jdbcConfiguration.getUrl());
-		assertEquals("jdbc:mysql://localhost:3306/testdb", new String(jdbcConfiguration.getUrl()));
+		assertEquals("jdbc:mysql://localhost:3306", new String(jdbcConfiguration.getUrl()));
 	}
 
 	@Test
@@ -167,7 +166,7 @@ class JdbcConfigurationTest {
 
 		assertDoesNotThrow(() -> jdbcConfiguration.validateConfiguration("resourceKey"));
 		assertNotNull(jdbcConfiguration.getUrl());
-		assertEquals("jdbc:mysql://localhost:3306/testdb", new String(jdbcConfiguration.getUrl()));
+		assertEquals("jdbc:mysql://localhost:3306", new String(jdbcConfiguration.getUrl()));
 	}
 
 	@Test


### PR DESCRIPTION
* Rename sqlserver to mssql in generateUrl
* Update unit tests