### PR TITLE
Issue #626: Remove mandatory attribute id requirement

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/PrettyPrinterService.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/PrettyPrinterService.java
@@ -22,7 +22,6 @@ package org.sentrysoftware.metricshub.cli.service;
  */
 
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_CONNECTOR_ID;
-import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_ID;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_NAME;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_PARENT_ID;
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.WHITE_SPACE;
@@ -362,7 +361,7 @@ public class PrettyPrinterService {
 	 */
 	private String getMonitorDisplayName(final Monitor monitor) {
 		String displayName = monitor.getAttribute(MONITOR_ATTRIBUTE_NAME);
-		displayName = displayName != null ? displayName : monitor.getAttribute(MONITOR_ATTRIBUTE_ID);
+		displayName = displayName != null ? displayName : monitor.formatIdentifyingAttributes();
 		return displayName != null ? displayName : monitor.getId();
 	}
 
@@ -512,7 +511,7 @@ public class PrettyPrinterService {
 			// Create MonitorChildren for each Monitor and put them in the map
 			for (final Monitor monitorInstance : monitors) {
 				final MonitorChildren monitorChildren = new MonitorChildren(monitorInstance);
-				final String attributeId = monitorInstance.getAttribute(MONITOR_ATTRIBUTE_ID);
+				final String attributeId = monitorInstance.formatIdentifyingAttributes();
 				final String monitorType = monitorInstance.getType();
 				monitorMap.put(String.format(MONITOR_ID_FORMAT, monitorType, attributeId), monitorChildren);
 			}

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/telemetry/Monitor.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/telemetry/Monitor.java
@@ -23,8 +23,12 @@ package org.sentrysoftware.metricshub.engine.telemetry;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Builder.Default;
@@ -67,6 +71,9 @@ public class Monitor {
 
 	@JsonProperty("is_endpoint")
 	private boolean isEndpoint;
+
+	@Default
+	private Set<String> identifyingAttributeKeys = new HashSet<>(MetricsHubConstants.DEFAULT_KEYS);
 
 	/**
 	 * Gets a metric of the specified type by name.
@@ -177,5 +184,18 @@ public class Monitor {
 	 */
 	public void setAsEndpoint() {
 		setIsEndpoint(true);
+	}
+
+	/**
+	 * Format the identifying attributes
+	 *
+	 * @return formatted identifying attributes separated by "_"
+	 */
+	public String formatIdentifyingAttributes() {
+		return identifyingAttributeKeys
+			.stream()
+			.sorted()
+			.map(key -> Optional.ofNullable(attributes.get(key)).orElse(""))
+			.collect(Collectors.joining("_"));
 	}
 }

--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/telemetry/MonitorFactory.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/telemetry/MonitorFactory.java
@@ -31,6 +31,7 @@ import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubCons
 import static org.sentrysoftware.metricshub.engine.common.helpers.MetricsHubConstants.UNDERSCORE;
 
 import java.net.InetAddress;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,6 +39,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -80,7 +82,8 @@ public class MonitorFactory {
 	private Long discoveryTime;
 
 	// Monitor job keys
-	private Set<String> keys;
+	@Default
+	private Set<String> keys = new HashSet<>(MetricsHubConstants.DEFAULT_KEYS);
 
 	/**
 	 * This method creates or updates the monitor
@@ -102,6 +105,7 @@ public class MonitorFactory {
 		// monitor section in the connector file
 		final String keysString = keys
 			.stream()
+			.sorted()
 			.map(key -> Optional.ofNullable(attributes.get(key)).orElse(""))
 			.collect(Collectors.joining("_"));
 
@@ -164,6 +168,7 @@ public class MonitorFactory {
 				.attributes(attributes)
 				.type(monitorType)
 				.id(id)
+				.identifyingAttributeKeys(keys)
 				.discoveryTime(discoveryTime)
 				.build();
 

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/discovery/DiscoveryStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/discovery/DiscoveryStrategyTest.java
@@ -1,8 +1,10 @@
 package org.sentrysoftware.metricshub.engine.strategy.discovery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -537,5 +539,23 @@ class DiscoveryStrategyTest {
 				)
 				.getValue()
 		);
+	}
+
+	@Test
+	void testHasAllIdentifyingAttributes() {
+		final ExtensionManager extensionManager = ExtensionManager
+			.builder()
+			.withProtocolExtensions(List.of(protocolExtensionMock))
+			.build();
+		discoveryStrategy =
+			DiscoveryStrategy
+				.builder()
+				.clientsExecutor(clientsExecutorMock)
+				.strategyTime(strategyTime)
+				.telemetryManager(new TelemetryManager())
+				.extensionManager(extensionManager)
+				.build();
+		assertTrue(discoveryStrategy.hasAllIdentifyingAttributes(Set.of("id1", "id2"), Map.of("id1", "1", "id2", "2")));
+		assertFalse(discoveryStrategy.hasAllIdentifyingAttributes(Set.of("id1", "id2"), Map.of("id1", "1")));
 	}
 }

--- a/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/telemetry/MonitorTest.java
+++ b/metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/telemetry/MonitorTest.java
@@ -1,0 +1,36 @@
+package org.sentrysoftware.metricshub.engine.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class MonitorTest {
+
+	@Test
+	void testFormatIdentifyingAttributes() {
+		{
+			final Monitor monitor = Monitor.builder().attributes(Map.of("id", "1", "name", "test")).build();
+			assertEquals("1", monitor.formatIdentifyingAttributes());
+		}
+
+		{
+			final Monitor monitor = Monitor
+				.builder()
+				.identifyingAttributeKeys(Set.of("id", "name"))
+				.attributes(Map.of("id", "1", "name", "test"))
+				.build();
+			assertEquals("1_test", monitor.formatIdentifyingAttributes());
+		}
+
+		{
+			final Monitor monitor = Monitor
+				.builder()
+				.identifyingAttributeKeys(Set.of("id", "name"))
+				.attributes(Map.of("id", "1"))
+				.build();
+			assertEquals("1_", monitor.formatIdentifyingAttributes());
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces several changes to the `metricshub-agent` and `metricshub-engine` projects to enhance the handling of identifying attributes for monitors. The most significant changes include the addition of methods to format and validate identifying attributes, updates to the `Monitor` and `MonitorFactory` classes, and new test cases to ensure the correctness of these changes.

Enhancements to identifying attributes:

* [`metricshub-agent/src/main/java/org/sentrysoftware/metricshub/cli/service/PrettyPrinterService.java`](diffhunk://#diff-6b07bf98078c57605f45aeb09f5ecb4b709b16f7433c8c92d921880fa9b3fdf9L365-R364): Modified the `getMonitorDisplayName` and `build` methods to use `formatIdentifyingAttributes` instead of `MONITOR_ATTRIBUTE_ID`. [[1]](diffhunk://#diff-6b07bf98078c57605f45aeb09f5ecb4b709b16f7433c8c92d921880fa9b3fdf9L365-R364) [[2]](diffhunk://#diff-6b07bf98078c57605f45aeb09f5ecb4b709b16f7433c8c92d921880fa9b3fdf9L515-R514)

Updates to `Monitor` and `MonitorFactory` classes:

* [`metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/telemetry/Monitor.java`](diffhunk://#diff-e593f870e4c4c2ce67389b88afa796f483c78610f1880ec77d73c131075cb2f2R75-R77): Added `identifyingAttributeKeys` field and `formatIdentifyingAttributes` method to format the identifying attributes. [[1]](diffhunk://#diff-e593f870e4c4c2ce67389b88afa796f483c78610f1880ec77d73c131075cb2f2R75-R77) [[2]](diffhunk://#diff-e593f870e4c4c2ce67389b88afa796f483c78610f1880ec77d73c131075cb2f2R188-R200)
* [`metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/telemetry/MonitorFactory.java`](diffhunk://#diff-b89c59381ea5ae2c90a080d31a69ff1028fa7dd1ec249d5bf2fcce23a483ba00L83-R86): Initialized `keys` with default identifying attribute keys and updated the `createOrUpdateMonitor` method to use sorted keys for formatting. [[1]](diffhunk://#diff-b89c59381ea5ae2c90a080d31a69ff1028fa7dd1ec249d5bf2fcce23a483ba00L83-R86) [[2]](diffhunk://#diff-b89c59381ea5ae2c90a080d31a69ff1028fa7dd1ec249d5bf2fcce23a483ba00R108) [[3]](diffhunk://#diff-b89c59381ea5ae2c90a080d31a69ff1028fa7dd1ec249d5bf2fcce23a483ba00R171)

Validation of identifying attributes:

* [`metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/AbstractAllAtOnceStrategy.java`](diffhunk://#diff-7a3bbaec04b5d6975f86195ccb5af8866d39ede1653a99f0fd062f1d95c02c6aR429-R443): Added `hasAllIdentifyingAttributes` method to check the availability of identifying attributes.

New test cases:

* [`metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/strategy/discovery/DiscoveryStrategyTest.java`](diffhunk://#diff-d15ec3400026a96e8c81cc57e96a3a210857202773aa9647b9657282146f50a3R543-R560): Added `testHasAllIdentifyingAttributes` to validate the new method for checking identifying attributes.
* [`metricshub-engine/src/test/java/org/sentrysoftware/metricshub/engine/telemetry/MonitorTest.java`](diffhunk://#diff-2f40e07aa601983f3603e53176574307f0a067c561286cc17b6f8326b9f2c609R1-R36): Added tests for the `formatIdentifyingAttributes` method.
-------------
### CLI output (without `id` attribute)

![image](https://github.com/user-attachments/assets/03a0933f-4863-4b2b-b19d-50d9efe61600)
