### PR TITLE
Issue #641: Add LogContextSetter for async logging

### DIFF
--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/opentelemetry/LogContextSetter.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/opentelemetry/LogContextSetter.java
@@ -1,4 +1,4 @@
-package org.sentrysoftware.metricshub.agent.opentelemetry.client;
+package org.sentrysoftware.metricshub.agent.opentelemetry;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -21,32 +21,21 @@ package org.sentrysoftware.metricshub.agent.opentelemetry.client;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
-import lombok.NoArgsConstructor;
-import org.sentrysoftware.metricshub.agent.opentelemetry.LogContextSetter;
-
 /**
- * Noop client that does nothing.
+ * Functional interface used to explicitly set the logging context for asynchronous operations.
+ * <p>
+ * This interface should be implemented to manage the {@link org.apache.logging.log4j.ThreadContext}
+ * within callbacks running on different threads, ensuring consistent context propagation in log entries.
+ * </p>
  */
-@NoArgsConstructor
-public class NoopClient implements IOtelClient {
-
+@FunctionalInterface
+public interface LogContextSetter {
 	/**
-	 * Does nothing.
-	 * @param request          The request containing the metrics to send.
-	 * @param logContextSetter The log context setter to use for logging.
-	 * This method is a no-op and does not send any metrics.
+	 * Sets the logging context using {@code ThreadContext.put()} before executing log statements.
+	 * <p>
+	 * Implementations of this method should explicitly set all necessary context entries required
+	 * for log correlation.
+	 * </p>
 	 */
-	@Override
-	public void send(ExportMetricsServiceRequest request, LogContextSetter logContextSetter) {
-		// NO-OP
-	}
-
-	/**
-	 * Does nothing.
-	 */
-	@Override
-	public void shutdown() {
-		// NO-OP
-	}
+	void setContext();
 }

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/opentelemetry/MetricsExporter.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/opentelemetry/MetricsExporter.java
@@ -53,12 +53,16 @@ public class MetricsExporter {
 	/**
 	 * Exports the metrics to the OptenTelemetry Collector.
 	 *
-	 * @param resourceMetrics A list of the ScopeMetrics collection from a Resource.
+	 * @param resourceMetrics  A list of the ScopeMetrics collection from a Resource.
+	 * @param logContextSetter The log context setter to use for asynchronous logging.
 	 */
-	public void export(final List<ResourceMetrics> resourceMetrics) {
+	public void export(final List<ResourceMetrics> resourceMetrics, final LogContextSetter logContextSetter) {
 		try {
 			// Simply send the metrics using the client
-			client.send(ExportMetricsServiceRequest.newBuilder().addAllResourceMetrics(resourceMetrics).build());
+			client.send(
+				ExportMetricsServiceRequest.newBuilder().addAllResourceMetrics(resourceMetrics).build(),
+				logContextSetter
+			);
 		} catch (Exception e) {
 			log.error("Failed to export metrics. Message: {}", e.getMessage());
 			log.debug("Failed to export metrics", e);

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/opentelemetry/ResourceMeterProvider.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/opentelemetry/ResourceMeterProvider.java
@@ -48,9 +48,11 @@ public class ResourceMeterProvider {
 
 	/**
 	 * Records the metrics for all resource meters and exports them.
+	 *
+	 * @param logContextSetter The log context setter to use for asynchronous logging.
 	 */
-	public void exportMetrics() {
-		metricsExporter.export(meters.stream().map(ResourceMeter::recordSafe).toList());
+	public void exportMetrics(final LogContextSetter logContextSetter) {
+		metricsExporter.export(meters.stream().map(ResourceMeter::recordSafe).toList(), logContextSetter);
 	}
 
 	/**

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/opentelemetry/client/IOtelClient.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/opentelemetry/client/IOtelClient.java
@@ -22,6 +22,7 @@ package org.sentrysoftware.metricshub.agent.opentelemetry.client;
  */
 
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import org.sentrysoftware.metricshub.agent.opentelemetry.LogContextSetter;
 
 /**
  * Interface defining the methods for OpenTelemetry clients.
@@ -29,9 +30,10 @@ import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 public interface IOtelClient {
 	/**
 	 * Sends the given metrics to the OpenTelemetry receiver.
-	 * @param request the request containing the metrics to send.
+	 * @param request          The request containing the metrics to send.
+	 * @param logContextSetter The log context setter to use for logging.
 	 */
-	void send(ExportMetricsServiceRequest request);
+	void send(ExportMetricsServiceRequest request, LogContextSetter logContextSetter);
 
 	/**
 	 * Shuts down the client.

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/scheduling/ResourceGroupScheduling.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/scheduling/ResourceGroupScheduling.java
@@ -181,6 +181,8 @@ public class ResourceGroupScheduling extends AbstractScheduling {
 				);
 			});
 
-		meterProvider.exportMetrics();
+		meterProvider.exportMetrics(() ->
+			ConfigHelper.configureGlobalLogger(agentConfig.getLoggerLevel(), agentConfig.getOutputDirectory())
+		);
 	}
 }

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/scheduling/SelfScheduling.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/scheduling/SelfScheduling.java
@@ -134,6 +134,8 @@ public class SelfScheduling extends AbstractScheduling {
 		);
 
 		// Export the metric
-		meterProvider.exportMetrics();
+		meterProvider.exportMetrics(() ->
+			ConfigHelper.configureGlobalLogger(agentConfig.getLoggerLevel(), agentConfig.getOutputDirectory())
+		);
 	}
 }

--- a/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/task/MonitoringTask.java
+++ b/metricshub-agent/src/main/java/org/sentrysoftware/metricshub/agent/service/task/MonitoringTask.java
@@ -114,7 +114,7 @@ public class MonitoringTask implements Runnable {
 			initHostAttributes(telemetryManager, resourceConfig);
 
 			// Record metrics and export them all
-			registerTelemetryManagerRecorders(telemetryManager).exportMetrics();
+			registerTelemetryManagerRecorders(telemetryManager).exportMetrics(() -> configureLoggerContext(hostId));
 		}
 
 		log.info("Calling the engine to collect resource: {}.", hostId);
@@ -134,7 +134,7 @@ public class MonitoringTask implements Runnable {
 		telemetryManager.run(new HardwareStrategy(telemetryManager, collectTime));
 
 		// Record metrics and export them all
-		registerTelemetryManagerRecorders(telemetryManager).exportMetrics();
+		registerTelemetryManagerRecorders(telemetryManager).exportMetrics(() -> configureLoggerContext(hostId));
 
 		// Increment the number of collects
 		numberOfCollects++;

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/opentelemetry/MetricsExporterTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/opentelemetry/MetricsExporterTest.java
@@ -40,17 +40,17 @@ class MetricsExporterTest {
 	void export_shouldCallClientSend() {
 		final List<ResourceMetrics> metrics = List.of(ResourceMetrics.getDefaultInstance());
 
-		exporter.export(metrics);
+		exporter.export(metrics, () -> {});
 
-		verify(mockClient, times(1)).send(any(ExportMetricsServiceRequest.class));
+		verify(mockClient, times(1)).send(any(ExportMetricsServiceRequest.class), any());
 	}
 
 	@Test
 	void export_shouldHandleExceptionGracefully() {
-		doThrow(new RuntimeException("Test exception")).when(mockClient).send(any());
+		doThrow(new RuntimeException("Test exception")).when(mockClient).send(any(), any());
 
 		assertDoesNotThrow(
-			() -> exporter.export(List.of(ResourceMetrics.getDefaultInstance())),
+			() -> exporter.export(List.of(ResourceMetrics.getDefaultInstance()), () -> {}),
 			"Exporter should handle exceptions gracefully"
 		);
 	}

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/opentelemetry/ResourceMeterProviderTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/opentelemetry/ResourceMeterProviderTest.java
@@ -33,7 +33,7 @@ class ResourceMeterProviderTest {
 		provider.newResourceMeter("test.instrumentation1", Map.of("key1", "value1"));
 		provider.newResourceMeter("test.instrumentation2", Map.of("key2", "value2"));
 
-		provider.exportMetrics();
+		provider.exportMetrics(() -> {});
 
 		assertEquals(2, client.getRequest().getResourceMetricsList().size(), "All registered meters should be exported");
 	}
@@ -47,7 +47,7 @@ class ResourceMeterProviderTest {
 		provider.newResourceMeter("test.instrumentation1", Map.of("key1", "value1"));
 		provider.newResourceMeter("test.instrumentation2", Map.of("key2", "value2"));
 
-		provider.exportMetrics();
+		provider.exportMetrics(() -> {});
 
 		assertEquals(2, client.getRequest().getResourceMetricsList().size(), "All registered meters should be exported");
 	}

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/TestHelper.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/TestHelper.java
@@ -4,6 +4,7 @@ import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import lombok.Getter;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.ThreadContext;
+import org.sentrysoftware.metricshub.agent.opentelemetry.LogContextSetter;
 import org.sentrysoftware.metricshub.agent.opentelemetry.client.IOtelClient;
 
 /**
@@ -20,7 +21,7 @@ public class TestHelper {
 		private ExportMetricsServiceRequest request;
 
 		@Override
-		public void send(ExportMetricsServiceRequest request) {
+		public void send(ExportMetricsServiceRequest request, LogContextSetter logContextSetter) {
 			this.request = request;
 		}
 

--- a/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/task/MonitoringTaskTest.java
+++ b/metricshub-agent/src/test/java/org/sentrysoftware/metricshub/agent/service/task/MonitoringTaskTest.java
@@ -237,7 +237,7 @@ class MonitoringTaskTest {
 		final ResourceConfig resourceConfig = ResourceConfig.builder().attributes(hostAttributes).build();
 		monitoringTask.initHostAttributes(telemetryManager, resourceConfig);
 
-		monitoringTask.registerTelemetryManagerRecorders(telemetryManager).exportMetrics();
+		monitoringTask.registerTelemetryManagerRecorders(telemetryManager).exportMetrics(() -> {});
 
 		final ExportMetricsServiceRequest request = otelClient.getRequest();
 		assertNotNull(request);


### PR DESCRIPTION
- Introduce LogContextSetter interface
- Update MetricsExporter to use LogContextSetter
- Modify ResourceMeterProvider to accept LogContextSetter
- Update GrpcClient and HttpProtobufClient to use LogContextSetter
- Adjust test cases to include LogContextSetter
- Update scheduling and task classes to configure logger context
- Modify MonitoringTaskTest to use LogContextSetter in exportMetrics
- Ensure consistent context propagation in tests
- Validate ExportMetricsServiceRequest is not null in tests


--- 
#### Tests
Successful push

![image](https://github.com/user-attachments/assets/df8049b9-087f-4d24-a9e8-030f626a3c0a)

Receiver unavailable
![image](https://github.com/user-attachments/assets/d5782c21-9ddf-4c0c-88d0-3a929a03a528)

