### PR TITLE
Issue #643: Added logging for monitor job execution mode (parallel vs sequential)

### DIFF
--- a/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java
+++ b/metricshub-engine/src/main/java/org/sentrysoftware/metricshub/engine/strategy/collect/CollectStrategy.java
@@ -175,17 +175,22 @@ public class CollectStrategy extends AbstractStrategy {
 		// Run monitor jobs defined in monitor jobs priority map (host, enclosure, blade, disk_controller and cpu)  in sequential mode
 		sequentialMonitorJobs.entrySet().forEach(entry -> processMonitorJob(currentConnector, hostname, entry));
 
+		final boolean isSequential = telemetryManager.getHostConfiguration().isSequential();
+		final String mode = isSequential ? "sequential" : "parallel";
+
+		log.info(
+			"Hostname {} - Running collect in {} mode. Connector: {}.",
+			hostname,
+			mode,
+			currentConnector.getConnectorIdentity().getCompiledFilename()
+		);
+
 		// If monitor jobs execution is set to "sequential", execute monitor jobs one by one
-		if (telemetryManager.getHostConfiguration().isSequential()) {
+		if (isSequential) {
 			otherMonitorJobs.entrySet().forEach(entry -> processMonitorJob(currentConnector, hostname, entry));
 		} else {
 			// Execute monitor jobs in parallel
-			log.info(
-				"Hostname {} - Running collect in parallel mode. Connector: {}.",
-				hostname,
-				currentConnector.getConnectorIdentity().getCompiledFilename()
-			);
-
+			// Create a thread pool with a fixed number of threads
 			final ExecutorService threadsPool = Executors.newFixedThreadPool(MAX_THREADS_COUNT);
 
 			otherMonitorJobs


### PR DESCRIPTION

- Add `isSequential` and `mode` variables for execution mode
- Log execution mode before running monitor jobs
- Remove redundant logging in parallel execution block
- Use `isSequential` variable in conditional checks
- Ensure consistent logging format across strategies
- Maintain existing functionality for sequential and parallel execution

Parallel
![image](https://github.com/user-attachments/assets/fb92397f-0069-41d8-b7b3-24e20f01d123)
Sequential
![image](https://github.com/user-attachments/assets/17db8e68-5b63-4f0a-8e91-95c4fcf2185a)
