### PR TITLE
Issue #843: Fixed Connector parsing error for multi-file references

### DIFF
--- a/metricshub-engine/src/main/java/org/metricshub/engine/connector/parser/EmbeddedFilesResolver.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/connector/parser/EmbeddedFilesResolver.java
@@ -36,6 +36,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -126,7 +127,7 @@ public class EmbeddedFilesResolver {
 			return;
 		}
 
-		final List<EmbeddedFile> embeddedFilesWithEmbeddedFiles = new ArrayList<>();
+		final Set<EmbeddedFile> embeddedFilesWithEmbeddedFiles = new HashSet<>();
 
 		// Parse the embedded files to find eventual new embedded files within them.
 		Collection<EmbeddedFile> temporaryEmbeddedFilesList = new ArrayList<>(processedEmbeddedFiles.values());


### PR DESCRIPTION
This pull request makes a minor change to the `EmbeddedFilesResolver` class by updating the data structure used to track embedded files that contain other embedded files. The change replaces a `List` with a `Set` to avoid duplicate entries, which improves correctness and efficiency when processing embedded files but also fixes the parsing error when embedded files are referenced multiple times in another embedded file.

Data structure improvement:

* Changed the type of `embeddedFilesWithEmbeddedFiles` from `List` to `Set` in `EmbeddedFilesResolver` to prevent duplicates when collecting embedded files that contain other embedded files. [[1]](diffhunk://#diff-ebc519997cec3a11221227455041b73f667fbc8146841bf8877161aa09080e98R39) [[2]](diffhunk://#diff-ebc519997cec3a11221227455041b73f667fbc8146841bf8877161aa09080e98L129-R130)

#### Testing

Before 
<img width="2531" height="184" alt="image" src="https://github.com/user-attachments/assets/91c47647-cb96-42a7-ad04-339e3438b235" />
After 
<img width="2378" height="134" alt="image" src="https://github.com/user-attachments/assets/39bb3fca-7352-44c8-8214-a9aef2b4925e" />
