### PR TITLE
Issue #865: Fixed frontend routes with file DOT

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/web/config/UiConfig.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/config/UiConfig.java
@@ -27,7 +27,6 @@ import org.metricshub.agent.helper.ConfigHelper;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.io.Resource;
-import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -70,12 +69,6 @@ public class UiConfig implements WebMvcConfigurer {
 						Resource requested = location.createRelative(resourcePath);
 						if (requested.exists() && requested.isReadable()) {
 							return requested;
-						}
-
-						// Path has a file extension? let's consider a static asset
-						if (StringUtils.getFilenameExtension(resourcePath) != null) {
-							// Return null to bypass SPA fallback so Spring returns a real 404 for missing files
-							return null;
 						}
 
 						// Fallback to the SPA entry point for client-side routes


### PR DESCRIPTION
This pull request simplifies the logic for serving static assets and client-side routes in the `UiConfig` class. The main change is the removal of a file extension check that previously bypassed the Single Page Application (SPA) fallback for missing static assets.

Static asset and SPA routing logic:

* Removed the check for file extensions in `getResource`, so all requests that do not resolve to an existing resource will now fall back to `index.html`, regardless of whether the path looks like a static asset. This means client-side routes and missing assets will both be handled by the SPA entry point.
* Removed the unused import of `StringUtils` since the file extension check is no longer needed.

<img width="894" height="316" alt="image" src="https://github.com/user-attachments/assets/adcbef9f-ca94-469f-9174-b7a5ba5429dc" />
