### PR TITLE
Add concurrent multi-host ping support to MCP ping tool

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/MultiHostToolResponse.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/MultiHostToolResponse.java
@@ -1,0 +1,40 @@
+package org.metricshub.web.mcp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents the response of executing a tool against a specific host.
+ *
+ * @param <T> the type of the tool response payload
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MultiHostToolResponse<T> {
+
+	private String hostname;
+	private T response;
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/PingToolServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/PingToolServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.metricshub.agent.context.AgentContext;
@@ -45,5 +47,31 @@ class PingToolServiceTest {
 		assertTrue(response.isReachable(), "Host should be reachable");
 		assertNull(response.getErrorMessage(), "Error message should be null for successful ping");
 		assertTrue(response.getResponseTime() >= 0, "Duration should be non-negative");
+	}
+
+	@Test
+	void testShouldReturnSuccessfulPingResponsesForMultipleHosts() {
+		final List<String> hostnames = List.of("localhost", "127.0.0.1");
+
+		final List<MultiHostToolResponse<ProtocolCheckResponse>> responses = pingToolService.pingHosts(hostnames, 3L);
+
+		assertEquals(hostnames.size(), responses.size(), "Responses should be returned for each hostname");
+
+		final Map<String, ProtocolCheckResponse> responseByHost = responses
+			.stream()
+			.collect(
+				Collectors.toMap(
+					MultiHostToolResponse::getHostname,
+					MultiHostToolResponse::getResponse,
+					(existing, replacement) -> existing
+				)
+			);
+
+		hostnames.forEach(hostname -> {
+			final ProtocolCheckResponse response = responseByHost.get(hostname);
+			assertNotNull(response, () -> "Response should be present for host " + hostname);
+			assertTrue(response.isReachable(), () -> "Host should be reachable: " + hostname);
+			assertNull(response.getErrorMessage(), "Error message should be null for successful ping");
+		});
 	}
 }


### PR DESCRIPTION
## Summary
- add a reusable `MultiHostToolResponse` wrapper for returning per-host payloads
- extend `PingToolService` with a concurrent `PingHosts` tool that pings multiple hosts in parallel
- update unit tests to cover the new multi-host behavior

## Testing
- mvn -pl metricshub-agent test

------
https://chatgpt.com/codex/tasks/task_b_68f64d8f1e9083328afd89648a3f709b