### PR TITLE
Handle primitive arrays in StringHelper stringify

### DIFF
--- a/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/StringHelper.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/StringHelper.java
@@ -25,6 +25,7 @@ import static org.metricshub.engine.common.helpers.MetricsHubConstants.COMMA;
 import static org.metricshub.engine.common.helpers.MetricsHubConstants.EMPTY;
 import static org.springframework.util.Assert.isTrue;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -220,10 +221,21 @@ public class StringHelper {
 				.map(item -> item != null ? item.toString() : EMPTY)
 				.collect(Collectors.joining(separator));
 		} else if (value.getClass().isArray()) {
-			// If the input is an array, convert it to a CSV string
-			Object[] array = (Object[]) value;
+			// If the input is an array, convert it to a delimited string
+			if (value.getClass().getComponentType().isPrimitive()) {
+				final int length = Array.getLength(value);
+				final StringBuilder builder = new StringBuilder();
+				for (int index = 0; index < length; index++) {
+					if (index > 0) {
+						builder.append(separator);
+					}
+					final Object element = Array.get(value, index);
+					builder.append(element != null ? element.toString() : EMPTY);
+				}
+				return builder.toString();
+			}
 			return Arrays
-				.stream(array)
+				.stream((Object[]) value)
 				.map(item -> item != null ? item.toString() : EMPTY)
 				.collect(Collectors.joining(separator));
 		} else {

--- a/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/StringHelperTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/StringHelperTest.java
@@ -87,6 +87,13 @@ class StringHelperTest {
 		assertEquals("a", StringHelper.stringify("a"));
 		assertEquals("a,b", StringHelper.stringify(List.of("a", "b")));
 		assertEquals("a,b", StringHelper.stringify(new String[] { "a", "b" }));
+		assertEquals("1,2", StringHelper.stringify(new int[] { 1, 2 }));
+	}
+
+	@Test
+	void testStringifyWithCustomSeparator() {
+		assertEquals("a|b", StringHelper.stringify(new String[] { "a", "b" }, "|"));
+		assertEquals("1|2|3", StringHelper.stringify(new int[] { 1, 2, 3 }, "|"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- update `StringHelper.stringify` to iterate over primitive array values without casting to `Object[]`
- add unit tests covering object and primitive arrays, including custom separators

## Testing
- mvn -pl metricshub-engine test

------
https://chatgpt.com/codex/tasks/task_b_68f6bf3a9a84832196642fea38a0f5e3