### PR TITLE
Refine ListHelper negative index handling

### DIFF
--- a/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/ListHelper.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/ListHelper.java
@@ -40,7 +40,13 @@ public class ListHelper {
 	 * @return The element at the specified position in the list, or the default value if the index is out of bounds.
 	 */
 	public static <T> T getValueAtIndex(List<T> list, int index, T defaultValue) {
-		if (list == null || list.size() <= index) {
+		if (index < 0) {
+			return defaultValue;
+		}
+		if (list == null) {
+			return defaultValue;
+		}
+		if (list.size() <= index) {
 			return defaultValue;
 		}
 		return list.get(index);

--- a/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/ListHelperTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/ListHelperTest.java
@@ -1,5 +1,6 @@
 package org.metricshub.engine.common.helpers;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
@@ -9,9 +10,19 @@ import org.junit.jupiter.api.Test;
 class ListHelperTest {
 
 	@Test
-	void getValueAtIndexTest() {
+	void getValueAtIndexReturnsValueWhenIndexIsValid() {
 		List<Integer> array = Arrays.asList(1, 2, 3, 4);
 		assertEquals(3, ListHelper.getValueAtIndex(array, 2, 6));
 		assertEquals(6, ListHelper.getValueAtIndex(array, 5, 6));
+	}
+
+	@Test
+	void getValueAtIndexReturnsDefaultForNegativeIndexWithoutThrowing() {
+		List<Integer> array = Arrays.asList(1, 2, 3, 4);
+		Integer defaultValue = 6;
+
+		Integer actualValue = assertDoesNotThrow(() -> ListHelper.getValueAtIndex(array, -1, defaultValue));
+
+		assertEquals(defaultValue, actualValue);
 	}
 }


### PR DESCRIPTION
## Summary
- return early from `ListHelper#getValueAtIndex` when the requested index is negative before performing list-bound checks
- expand `ListHelperTest` to cover negative indices explicitly and assert no exception is thrown

## Testing
- mvn -pl metricshub-engine verify

------
https://chatgpt.com/codex/tasks/task_b_68f6bf37bc8c83218bd77effa75f4985