### PR TITLE
style: reformat CLI exception handler formatting

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/cli/MetricsHubCliApplication.java
+++ b/metricshub-agent/src/main/java/org/metricshub/cli/MetricsHubCliApplication.java
@@ -58,9 +58,9 @@ public class MetricsHubCliApplication {
 		// As this is poorly documented, we keep this for future improvement.
 		// cli.setOut(new PrintWriter(AnsiConsole.out(), true, StandardCharsets.UTF_8)); // NOSONAR on commented code
 
-                // Set the exception handlers
-                cli.setExecutionExceptionHandler(new PrintExceptionMessageHandlerService());
-                cli.setParameterExceptionHandler(new PrintParameterExceptionHandlerService());
+		// Set the exception handlers
+		cli.setExecutionExceptionHandler(new PrintExceptionMessageHandlerService());
+		cli.setParameterExceptionHandler(new PrintParameterExceptionHandlerService());
 
 		// Allow case insensitive enum values
 		cli.setCaseInsensitiveEnumValuesAllowed(true);

--- a/metricshub-agent/src/main/java/org/metricshub/cli/service/PrintParameterExceptionHandlerService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/cli/service/PrintParameterExceptionHandlerService.java
@@ -32,18 +32,18 @@ import picocli.CommandLine.IParameterExceptionHandler;
  */
 public class PrintParameterExceptionHandlerService implements IParameterExceptionHandler {
 
-        static final String HELP_HINT = "Run metricshub --help to display usage.";
+	static final String HELP_HINT = "Run metricshub --help to display usage.";
 
-        @Override
-        public int handleParseException(CommandLine.ParameterException exception, String[] args) {
-                final CommandLine commandLine = exception.getCommandLine();
-                commandLine.getErr().println(commandLine.getColorScheme().errorText(exception.getMessage()));
-                commandLine.getErr().println(commandLine.getColorScheme().errorText(HELP_HINT));
+	@Override
+	public int handleParseException(CommandLine.ParameterException exception, String[] args) {
+		final CommandLine commandLine = exception.getCommandLine();
+		commandLine.getErr().println(commandLine.getColorScheme().errorText(exception.getMessage()));
+		commandLine.getErr().println(commandLine.getColorScheme().errorText(HELP_HINT));
 
-                if (commandLine.getExitCodeExceptionMapper() != null) {
-                        return commandLine.getExitCodeExceptionMapper().getExitCode(exception);
-                }
+		if (commandLine.getExitCodeExceptionMapper() != null) {
+			return commandLine.getExitCodeExceptionMapper().getExitCode(exception);
+		}
 
-                return CommandLine.ExitCode.USAGE;
-        }
+		return CommandLine.ExitCode.USAGE;
+	}
 }

--- a/metricshub-agent/src/test/java/org/metricshub/cli/service/PrintParameterExceptionHandlerServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/cli/service/PrintParameterExceptionHandlerServiceTest.java
@@ -32,22 +32,22 @@ import picocli.CommandLine;
 
 class PrintParameterExceptionHandlerServiceTest {
 
-        @Test
-        void shouldPrintErrorMessageAndHelpHintWithoutUsage() {
-                final CommandLine cli = new CommandLine(new MetricsHubCliService());
-                cli.setColorScheme(CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.OFF));
-                cli.setParameterExceptionHandler(new PrintParameterExceptionHandlerService());
+	@Test
+	void shouldPrintErrorMessageAndHelpHintWithoutUsage() {
+		final CommandLine cli = new CommandLine(new MetricsHubCliService());
+		cli.setColorScheme(CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.OFF));
+		cli.setParameterExceptionHandler(new PrintParameterExceptionHandlerService());
 
-                final StringWriter errWriter = new StringWriter();
-                cli.setErr(new PrintWriter(errWriter, true));
+		final StringWriter errWriter = new StringWriter();
+		cli.setErr(new PrintWriter(errWriter, true));
 
-                final int exitCode = cli.execute("example-host");
+		final int exitCode = cli.execute("example-host");
 
-                assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+		assertEquals(CommandLine.ExitCode.USAGE, exitCode);
 
-                final String errorOutput = errWriter.toString();
-                assertTrue(errorOutput.contains("Missing required option: '--type=TYPE'"));
-                assertTrue(errorOutput.contains(PrintParameterExceptionHandlerService.HELP_HINT));
-                assertFalse(errorOutput.contains("Usage"));
-        }
+		final String errorOutput = errWriter.toString();
+		assertTrue(errorOutput.contains("Missing required option: '--type=TYPE'"));
+		assertTrue(errorOutput.contains(PrintParameterExceptionHandlerService.HELP_HINT));
+		assertFalse(errorOutput.contains("Usage"));
+	}
 }


### PR DESCRIPTION
## Summary
- reformat the MetricsHub CLI application to match the formatter's spacing around exception handler setup
- apply the formatter to the PrintParameterExceptionHandlerService and its unit test

## Testing
- mvn prettier:write
- mvn license:check-file-header
- mvn checkstyle:check
- mvn verify

------
https://chatgpt.com/codex/tasks/task_b_68f8bbc164f88332be99799dcbdfe944