### PR TITLE
Issue #895: Update deprecated Apache Velocity configuration keys

### DIFF
--- a/metricshub-programmable-configuration-extension/src/main/java/org/metricshub/programmable/configuration/VelocityConfigurationLoader.java
+++ b/metricshub-programmable-configuration-extension/src/main/java/org/metricshub/programmable/configuration/VelocityConfigurationLoader.java
@@ -53,10 +53,10 @@ public class VelocityConfigurationLoader {
 			// Initialize VelocityEngine
 			final var velocityEngine = new VelocityEngine();
 			var props = new Properties();
-			props.setProperty("resource.loader", "file");
-			props.setProperty("file.resource.loader.class", "org.apache.velocity.runtime.resource.loader.FileResourceLoader");
-			props.setProperty("file.resource.loader.path", vmPath.getParent().toString());
-			props.setProperty("file.resource.loader.cache", "false");
+			props.setProperty("resource.loaders", "file");
+			props.setProperty("resource.loader.file.class", "org.apache.velocity.runtime.resource.loader.FileResourceLoader");
+			props.setProperty("resource.loader.file.path", vmPath.getParent().toString());
+			props.setProperty("resource.loader.file.cache", "false");
 			velocityEngine.init(props);
 
 			// Load template


### PR DESCRIPTION
This pull request updates the Velocity configuration loading logic to use the newer Velocity property names, improving compatibility and maintainability.

Velocity configuration modernization:

* Changed Velocity property keys from the deprecated `file.resource.loader.*` format to the recommended `resource.loader.file.*` format in `VelocityConfigurationLoader.java`.

**Tests**

Unit tests (ProgrammableConfigurationProviderTest) run cleanly without warnings. [run1](https://github.com/MetricsHub/metricshub-community/actions/runs/18886835790/job/53904203791)

No regression:
<img width="987" height="479" alt="image" src="https://github.com/user-attachments/assets/3b097582-e2ad-4c82-943a-55630523a435" />

<img width="2124" height="863" alt="image" src="https://github.com/user-attachments/assets/4bc0cb7a-6005-4f17-8079-7790f1dd4091" />

<img width="1523" height="870" alt="image" src="https://github.com/user-attachments/assets/b120efdc-96c3-4a30-80f3-251e08117f16" />
