### PR TITLE
Silence SLF4J logging in programmable configuration tests

### DIFF
--- a/metricshub-programmable-configuration-extension/src/test/resources/simplelogger.properties
+++ b/metricshub-programmable-configuration-extension/src/test/resources/simplelogger.properties
@@ -1,0 +1,7 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("off", "trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=off


### PR DESCRIPTION
## Summary
- disable SLF4J SimpleLogger output during tests by adding a simplelogger.properties file to the programmable configuration extension

## Testing
- mvn prettier:write
- mvn license:check-file-header
- mvn checkstyle:check
- mvn verify

------
https://chatgpt.com/codex/tasks/task_b_6901e328e18c8332bad03ef1ca2ececf