### PR TITLE
feat(navbar): add documentation link button to NavBar

### DIFF
--- a/metricshub-web/react/src/components/navbar/navbar.jsx
+++ b/metricshub-web/react/src/components/navbar/navbar.jsx
@@ -7,7 +7,17 @@ import { useAuth } from "../../hooks/use-auth";
 import { paths } from "../../paths";
 
 import { useNavigate, NavLink } from "react-router-dom";
-import { AppBar, Box, CssBaseline, Toolbar, Typography, Button } from "@mui/material";
+import {
+	AppBar,
+	Box,
+	CssBaseline,
+	Toolbar,
+	Typography,
+	Button,
+	IconButton,
+	Tooltip,
+} from "@mui/material";
+import MenuBookOutlinedIcon from "@mui/icons-material/MenuBookOutlined";
 
 import { useAppDispatch, useAppSelector } from "../../hooks/store";
 import { fetchApplicationStatus } from "../../store/thunks/applicationStatusThunks";
@@ -142,6 +152,18 @@ const NavBar = ({ toggleTheme }) => {
 							</Typography>
 						)}
 						<StatusDetailsMenu />
+						{/* Docs link button */}
+						<Tooltip title="Documentation" arrow enterDelay={200}>
+							<IconButton
+								component="a"
+								href="https://metricshub.com/docs/latest/"
+								target="_blank"
+								rel="noopener noreferrer"
+								aria-label="Open MetricsHub documentation in a new tab"
+							>
+								<MenuBookOutlinedIcon />
+							</IconButton>
+						</Tooltip>
 						<Logout onClick={handleSignOut} />
 						<ToggleTheme onClick={toggleTheme} />
 					</Box>


### PR DESCRIPTION
This pull request enhances the navigation bar by adding a new button that links directly to the MetricsHub documentation. The button uses a book icon and is accompanied by a tooltip for improved accessibility and user experience.

<img width="421" height="111" alt="image" src="https://github.com/user-attachments/assets/6a1bfd03-8abf-4eda-b648-86074b94e1f3" />
<img width="153" height="80" alt="image" src="https://github.com/user-attachments/assets/a2b24a7f-91fd-46cc-b16e-6890c8b52590" />
