### PR TITLE
Issue #909: write release notes for MetricsHub EE 3.0.02

### DIFF
--- a/metricshub-doc/src/site/markdown/release-notes.md
+++ b/metricshub-doc/src/site/markdown/release-notes.md
@@ -11,14 +11,14 @@ description: Learn more about the new features, changes and improvements, and bu
 
 #### What's New
 
-| ID                                                                       | Description                                                     |
-| ------------------------------------------------------------------------ | --------------------------------------------------------------- |
-| [**#89**](https://github.com/MetricsHub/metricshub-enterprise/issues/89) | Red Hat and Debian ARM64 installable packages are now available |
+| ID                                                                       | Description                                                         |
+|--------------------------------------------------------------------------|---------------------------------------------------------------------|
+| [**#89**](https://github.com/MetricsHub/metricshub-enterprise/issues/89) | Installable packages are now available for Red Hat and Debian ARM64 |
 
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                                            |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|----------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**#116**](https://github.com/MetricsHub/metricshub-enterprise/issues/116) | Upgraded OpenTelemetry Collector Contrib to version [0.138.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.138.0) |
 
 ### MetricsHub Enterprise Connectors v110
@@ -26,7 +26,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                       | Description                                                                                                                   |
-| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
 | [**#92**](https://github.com/MetricsHub/enterprise-connectors/issues/92) | Added support for **[Cisco UCS C885A](./connectors/ciscoucsc885a.html)** rack servers via Redfish API                         |
 | [**#96**](https://github.com/MetricsHub/enterprise-connectors/issues/96) | Added support for **[Dell PowerFlex 3](./connectors/dellpowerflexrestv3.html)** storage systems via REST API                  |
 | [**#96**](https://github.com/MetricsHub/enterprise-connectors/issues/96) | Added support for **[Dell PowerFlex 4](./connectors/dellpowerflexrestv4.html)** storage systems via REST API                  |
@@ -35,14 +35,14 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                                     |
-| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**#111**](https://github.com/MetricsHub/enterprise-connectors/issues/111) | **[Dell XtremIO - REST](./connectors/dellemcxtremiorest.html)**: The Storage System Subscribed and Configured Capacity metrics are now reported |
 | [**#136**](https://github.com/MetricsHub/enterprise-connectors/issues/136) | **[EMC Isilon Cluster (REST)](./connectors/emcisilonrest.html)**: Added vendor and model attributes to the Storage System metrics               |
 
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                                                                                                                                |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**#114**](https://github.com/MetricsHub/enterprise-connectors/issues/114) | **[HPE iLO 6 (ProLiant Gen11)](./connectors/hpeilo6rest.html)**: An "Invalid credentials" error message was incorrectly displayed for HTTP detection criteria that did not require authentication          |
 | [**#115**](https://github.com/MetricsHub/enterprise-connectors/issues/115) | **[HPE iLO 5 (ProLiant Gen10)](./connectors/hpegen10ilorest.html)**: An "Invalid credentials" error message was incorrectly displayed for HTTP detection criteria that did not require authentication      |
 | [**#116**](https://github.com/MetricsHub/enterprise-connectors/issues/116) | **[HPE iLO4 (ProLiant Gen8 or Gen9)](./connectors/hpegen9ilorest.html)**: An "Invalid credentials" error message was incorrectly displayed for HTTP detection criteria that did not require authentication |
@@ -52,15 +52,15 @@ description: Learn more about the new features, changes and improvements, and bu
 
 #### What's New
 
-| ID                                                                        | Description                                                                                                                                 |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| [**#766**](https://github.com/MetricsHub/metricshub-community/issues/766) | [MCP Tools](./integrations/ai-agent-mcp.md) now support running custom requests (SNMP GET, HTTP GET, WMI, IPMI, etc.).                      |
-| [**#851**](https://github.com/MetricsHub/metricshub-community/issues/851) | MetricsHub Community can now be installed directly via [get.metricshub.com](./installation/debian-linux.md#option-1-automatic-recommended). |
+| ID                                                                        | Description                                                                                                                                                |
+|---------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**#766**](https://github.com/MetricsHub/metricshub-community/issues/766) | AI Agents: A new set of [MCP Tools](./integrations/ai-agent-mcp.md) is now available to run custom requests (`SNMP GET`, `HTTP GET`, `WMI`, `IPMI`, etc.). |
+| [**#851**](https://github.com/MetricsHub/metricshub-community/issues/851) | MetricsHub Community can now be installed directly via [get.metricshub.com](./installation/debian-linux.md#option-1-automatic-recommended).                |
 
 #### Changes and Improvements
 
 | ID                                                                        | Description                                                                                                                |
-| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
 | [**#771**](https://github.com/MetricsHub/metricshub-community/issues/771) | Metrics metadata can now be included directly within [monitoring jobs](./custom/index.md).                                 |
 | [**#834**](https://github.com/MetricsHub/metricshub-community/issues/834) | [Programmable Configurations](./configuration/configure-monitoring.md#programmable-configuration) now support SQL queries. |
 | [**#837**](https://github.com/MetricsHub/metricshub-community/issues/837) | [MCP Tools](./integrations/ai-agent-mcp.md) are now able to report information for multiple hosts through a single query.  |
@@ -68,24 +68,24 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                        | Description                                                   |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------- |
+|---------------------------------------------------------------------------|---------------------------------------------------------------|
 | [**#843**](https://github.com/MetricsHub/metricshub-community/issues/843) | Connectors may fail to load due to unmanaged external scripts |
 | [**#869**](https://github.com/MetricsHub/metricshub-community/issues/869) | Security Vulnerability CVE-2025-41249                         |
 
 #### Documentation Updates
 
 | ID                                                                        | Description                                                                                                                                                         |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**#849**](https://github.com/MetricsHub/metricshub-community/issues/849) | Clarified Velocity Template Syntax in the [Programmable Configuration example](./configuration/configure-monitoring.md#example-loading-resources-from-an-http-api). |
 
 ### MetricsHub Community Connectors v1.0.15
 
 #### Fixed Issues
 
-| ID                                                                        | Description                                                                                                                  |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| [**#283**](https://github.com/MetricsHub/community-connectors/issues/283) | **[Linux System](./connectors/linux.html)**: Unreliable interface name parsing when using `ls -l /sys/class/net` description |
-| [**#291**](https://github.com/MetricsHub/community-connectors/issues/291) | **[Linux System](./connectors/linux.html)**: Negative `system.network.bandwidth.limit` reported                              |
+| ID                                                                        | Description                                                                                                                                       |
+|---------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**#283**](https://github.com/MetricsHub/community-connectors/issues/283) | **[Linux System](./connectors/linux.html)**: Network interface names may be parsed incorrectly or not detected when using `ls -l /sys/class/net`. |
+| [**#291**](https://github.com/MetricsHub/community-connectors/issues/291) | **[Linux System](./connectors/linux.html)**: A negative value is reported for `system.network.bandwidth.limit`                                    |
 
 ## MetricsHub Enterprise Edition v3.0.01
 
@@ -94,7 +94,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                          | Description                                                                                                                                                                                                                                                    |
-| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#98**](https://github.com/MetricsHub/metricshub-enterprise/issues/98)   | Added a CLI tool (`user`) to securely create, list, and delete REST API users for JWT-based authentication.                                                                                                                                                    |
 | [**\#100**](https://github.com/MetricsHub/metricshub-enterprise/issues/100) | Upgraded OpenTelemetry Collector Contrib to version [0.136.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.136.0). Refer to [Upgrading to v3.0.01](./upgrade.md#upgrading-to-v3001) for installation upgrade instructions |
 
@@ -103,20 +103,20 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                        | Description                                                                                      |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+|---------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
 | [**\#30**](https://github.com/MetricsHub/enterprise-connectors/issues/30) | Added support for [**AIX**](./connectors/aix.html) systems via command lines                     |
 | [**\#70**](https://github.com/MetricsHub/enterprise-connectors/issues/70) | Added support for [**EMC Isilon**](./connectors/emcisilonrest.html) storage systems via REST API |
 
 #### Changes and Improvements
 
 | ID                                                                        | Description                                                                                                                                                                                                                                                                                                                                                                                     |
-| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#72**](https://github.com/MetricsHub/enterprise-connectors/issues/72) | The `storage.size` metric is now collected for storage systems and physical disks by the following storage array connectors: <ul><li>**[Dell EMC PowerMax Storage (REST)](./connectors/dellemcpowermaxrest.html)**</li><li>**[Pure Storage FA Series (REST)](./connectors/purestoragerest.html)**</li><li>**[Pure Storage FA Series v2 (REST)](./connectors/purestoragerestv2.html)**</li></ul> |
 
 #### Fixed Issues
 
 | ID                                                                          | Description                                                                                                                                                                                                                                                                                             |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#90**](https://github.com/MetricsHub/enterprise-connectors/issues/90)   | **[Hitachi (REST)](./connectors/hitachirest.html)**: <ul><li>The consumed capacity metric uses the wrong unit for storage pools</li><li>The configured capacity metric is missing for storage pools</li><li>The consumed capacity for traditional volumes does not match their total capacity</li></ul> |
 | [**\#94**](https://github.com/MetricsHub/enterprise-connectors/issues/94)   | **[NetApp Filer (REST)](./connectors/netapprest.html)**: The physical disk `speed` is wrongly exposed as a metric instead of an attribute.                                                                                                                                                              |
 | [**\#100**](https://github.com/MetricsHub/enterprise-connectors/issues/100) | **[Cisco UCS Manager (REST)](./connectors/ciscoucsrest.html)**: Early logout during discovery and collect invalidates the session cookie and breaks metric collection                                                                                                                                   |
@@ -130,7 +130,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                                                                                                                                                                      |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#765**](https://github.com/MetricsHub/metricshub-community/issues/765) | Added the [GetHostDetails MCP Tool](./integrations/ai-agent-mcp.md) to retrieve detailed information about a host                                                                                                |
 | [**\#772**](https://github.com/MetricsHub/metricshub-community/issues/772) | [Connector Design] Added the ability to refer to [resource attributes](https://metricshub.org/community-connectors/develop/references.html#resource-attribute-reference) when configuring custom monitoring jobs |
 | [**\#773**](https://github.com/MetricsHub/metricshub-community/issues/773) | [Connector Design] Added the ability to refer to [protocol properties](https://metricshub.org/community-connectors/develop/references.html#protocol-reference) when configuring custom monitoring jobs           |
@@ -139,7 +139,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                                                                    |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|----------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#768**](https://github.com/MetricsHub/metricshub-community/issues/768) | MetricsHub no longer passes the deprecated `pkg.translator.prometheus.NormalizeName` feature gate when starting the OpenTelemetry Collector                                    |
 | [**\#775**](https://github.com/MetricsHub/metricshub-community/issues/775) | On Windows, the logs are now written to the working directory (`.\logs`) if it is writable, instead of the system logs path                                                    |
 | [**\#788**](https://github.com/MetricsHub/metricshub-community/issues/788) | The `metricshub -V` command now outputs both log and config directories                                                                                                        |
@@ -150,7 +150,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------|
 | [**\#777**](https://github.com/MetricsHub/metricshub-community/issues/777) | Table unions are not performed correctly by the core engine on raw results |
 
 ### MetricsHub Community Connectors v1.0.14
@@ -158,13 +158,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                                                           |
-| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
 | [**\#277**](https://github.com/MetricsHub/community-connectors/issues/277) | The system semantic conventions now include `system.disk.limit` and `system.filesystem.limit` metrics |
 
 #### Documentation Updates
 
 | ID                                                                         | Description                                                                                                                                                         |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#273**](https://github.com/MetricsHub/community-connectors/issues/273) | Documented [${esc.d}{resource.attribute::ATTRIBUTE}](https://metricshub.org/community-connectors/develop/references.html#!#resource-attribute-reference) references |
 | [**\#278**](https://github.com/MetricsHub/community-connectors/issues/278) | Documented [${esc.d}{protocol::PROTOCOL.PROPERTY}](https://metricshub.org/community-connectors/develop/references.html#!#protocol-reference) references             |
 
@@ -175,13 +175,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                        | Description                                        |
-| ------------------------------------------------------------------------- | -------------------------------------------------- |
+|---------------------------------------------------------------------------|----------------------------------------------------|
 | [**\#83**](https://github.com/MetricsHub/metricshub-enterprise/issues/83) | Added CLI executable to manage API keys (`apikey`) |
 
 #### Changes and Improvements
 
 | ID                                                                        | Description                                                                |
-| ------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|----------------------------------------------------------------------------|
 | [**\#75**](https://github.com/MetricsHub/metricshub-enterprise/issues/75) | Added `JDBC` and `JMX` configuration examples to `metricshub-example.yaml` |
 | [**\#78**](https://github.com/MetricsHub/metricshub-enterprise/issues/78) | Dynamic configuration reloading has been enhanced                          |
 
@@ -190,7 +190,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                        | Description                                                                                                                         |
-| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#56**](https://github.com/MetricsHub/enterprise-connectors/issues/56) | Added support for [**Citrix NetScaler**](./connectors/citrixnetscalerrest.html) via REST API                                        |
 | [**\#61**](https://github.com/MetricsHub/enterprise-connectors/issues/61) | Added support for [**Cisco ASA Firewall**](./connectors/ciscosecurefirewallasa.html) via SNMP                                       |
 | [**\#62**](https://github.com/MetricsHub/enterprise-connectors/issues/62) | Added support for [**Arista Switch**](./connectors/aristabgpswitch.html) via SNMP to report `Border Gateway Protocol` (BGP) metrics |
@@ -198,7 +198,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                        | Description                                                                                                          |
-| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
 | [**\#55**](https://github.com/MetricsHub/enterprise-connectors/issues/55) | **[NetApp Filer (REST)](./connectors/netapprest.html)**: Added QoS latency metrics                                   |
 | [**\#59**](https://github.com/MetricsHub/enterprise-connectors/issues/59) | **[EMC SMI-S Agent (ECOM)](./connectors/emcdiskarray.html)**: Fan names now use `+` instead of `-+-`                 |
 | [**\#71**](https://github.com/MetricsHub/enterprise-connectors/issues/71) | **[Dell XtremIO (REST)](./connectors/dellemcxtremiorest.html)**: Added performance and capacity metrics via REST API |
@@ -206,7 +206,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#73**](https://github.com/MetricsHub/enterprise-connectors/issues/73) | The storage array connectors use the `direction` and `storage.direction` attributes whereas they should use the `storage.io.direction` attribute: <ul><li>**[Dell EMC PowerMax Storage (REST)](./connectors/dellemcpowermaxrest.html)**</li><li>**[NetApp Filer (REST)](./connectors/netapprest.html)**</li><li>**[Pure Storage FA Series (REST)](./connectors/purestoragerest.html)**</li><li>**[Pure Storage FA Series v2 (REST)](./connectors/purestoragerestv2.html)**</li><li>**[Dot Hill System (REST)](./connectors/dothillrest.html)**</li></ul> |
 | [**\#76**](https://github.com/MetricsHub/enterprise-connectors/issues/76) | **[Dell EMC PowerMax Storage (REST)](./connectors/dellemcpowermaxrest.html)**: Incorrect unit for the `storage.size` metric                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | [**\#80**](https://github.com/MetricsHub/enterprise-connectors/issues/80) | **[NetApp Filer (REST)](./connectors/netapprest.html)**: <ul><li>Storage pools are missing</li><li>Volume capacities are incorrectly calculated</li><li>Disk discovery is inaccurate</li></ul>                                                                                                                                                                                                                                                                                                                                                           |
@@ -219,7 +219,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                    |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
 | [**\#762**](https://github.com/MetricsHub/metricshub-community/issues/762) | Devices configured with SNMPv3 AES cannot be monitored in MetricsHub Community Edition v1.0.06 |
 
 ### MetricsHub Community Edition v1.0.06
@@ -227,7 +227,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                                                                                                                                  |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#438**](https://github.com/MetricsHub/metricshub-community/issues/438) | Added support for [programmable configurations](./configuration/configure-monitoring.md#programmable-configuration) to generate the list of resources to monitor dynamically |
 | [**\#744**](https://github.com/MetricsHub/metricshub-community/issues/744) | Added [MCP tool](./integrations/ai-agent-mcp.md) to list configured hosts                                                                                                    |
 | [**\#746**](https://github.com/MetricsHub/metricshub-community/issues/746) | Added CLI executable to manage API keys (`apikey`)                                                                                                                           |
@@ -237,7 +237,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                 |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | [**\#671**](https://github.com/MetricsHub/metricshub-community/issues/671) | Dynamic configuration reloading has been enhanced                                           |
 | [**\#739**](https://github.com/MetricsHub/metricshub-community/issues/739) | Redesigned documentation to look more like the [MetricsHub](https://metricshub.com) website |
 | [**\#741**](https://github.com/MetricsHub/metricshub-community/issues/741) | Added support for **SNMP v3** `AES192` and `AES256` encryptions                             |
@@ -245,7 +245,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                                                                                    |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#734**](https://github.com/MetricsHub/metricshub-community/issues/734) | The logs incorrectly report that the `connector_id` attribute is missing on `host` monitors, although the `connector_id` attribute is not applicable to hosts. |
 | [**\#754**](https://github.com/MetricsHub/metricshub-community/issues/754) | `UserPrincipalNotFoundException` is thrown when **MetricsHub** starts on Windows and cannot find the `Users` group.                                            |
 
@@ -254,13 +254,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------|
 | [**\#253**](https://github.com/MetricsHub/community-connectors/issues/253) | Added `storage.latency` metric to the semantic conventions |
 
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                    |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+|----------------------------------------------------------------------------|--------------------------------------------------------------------------------|
 | [**\#250**](https://github.com/MetricsHub/community-connectors/issues/250) | The `hw.network.dropped` metric reports `{packet}` instead of `{packets}` unit |
 
 ## MetricsHub Enterprise Edition v2.1.00
@@ -270,7 +270,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                        | Description                                                                 |
-| ------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | [**\#60**](https://github.com/MetricsHub/metricshub-enterprise/issues/60) | Included the [**IBM Informix**](./connectors/informix.html) JDBC driver     |
 | [**\#68**](https://github.com/MetricsHub/metricshub-enterprise/issues/68) | Added support for Java Management Extension (JMX)                           |
 | [**\#69**](https://github.com/MetricsHub/metricshub-enterprise/issues/69) | Added support for [REST API and remote MCP](./integrations/ai-agent-mcp.md) |
@@ -278,7 +278,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                        | Description                                         |
-| ------------------------------------------------------------------------- | --------------------------------------------------- |
+|---------------------------------------------------------------------------|-----------------------------------------------------|
 | [**\#57**](https://github.com/MetricsHub/metricshub-enterprise/issues/57) | Upgraded OpenTelemetry Collector Contrib to 0.127.0 |
 
 ### MetricsHub Enterprise Connectors v107
@@ -286,14 +286,14 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                        | Description                                                                              |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
 | [**\#27**](https://github.com/MetricsHub/enterprise-connectors/issues/27) | Added support for [**IBM Informix**](./connectors/informix.html) databases via JDBC      |
 | [**\#32**](https://github.com/MetricsHub/enterprise-connectors/issues/32) | Added support for [**Palo Alto**](./connectors/paloaltofirewall.html) firewalls via SNMP |
 
 #### Changes and Improvements
 
 | ID                                                                        | Description                                                                                                        |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+|---------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
 | [**\#57**](https://github.com/MetricsHub/enterprise-connectors/issues/57) | **[Nvidia DGX Server (REST)](./connectors/nvidiadgxrest.html)**: Improved HTTP requests initiated by the connector |
 
 ### MetricsHub Community Edition v1.0.05
@@ -301,7 +301,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                                                                         |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | [**\#718**](https://github.com/MetricsHub/metricshub-community/issues/718) | **AI Agents**: A new set of [MCP Tools](./integrations/ai-agent-mcp.md) is now available to perform protocol checks |
 
 ### MetricsHub Community Edition v1.0.04
@@ -309,14 +309,14 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                                 |
-| -------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | [**\#692**](https://github.com/MetricsHub/metricshub-community/issues/692) | Added support for [REST API and remote MCP](./integrations/ai-agent-mcp.md) |
 | [**\#694**](https://github.com/MetricsHub/metricshub-community/issues/694) | Added support for Java Management Extensions (JMX)                          |
 
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                                                                                                                |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#357**](https://github.com/MetricsHub/metricshub-community/issues/357) | **MetricsHub CLI**: Added the ability to specify connector variables                                                                                                                                                       |
 | [**\#658**](https://github.com/MetricsHub/metricshub-community/issues/658) | The `database` property is no longer required under the `jdbc` configuration                                                                                                                                               |
 | [**\#698**](https://github.com/MetricsHub/metricshub-community/issues/698) | **Prometheus Alert Rules**: Three categories of [alert rules](./prometheus/alertmanager.md#prometheus-alertmanager) are provided to inform you of MetricsHub issues, hardware failures, and system performance degradation |
@@ -325,7 +325,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                               |
-| -------------------------------------------------------------------------- | --------------------------------------------------------- |
+|----------------------------------------------------------------------------|-----------------------------------------------------------|
 | [**\#693**](https://github.com/MetricsHub/metricshub-community/issues/693) | Monitor names are generated for non-hardware monitors     |
 | [**\#703**](https://github.com/MetricsHub/metricshub-community/issues/703) | Metrics processing failure due to `NumberFormatException` |
 | [**\#708**](https://github.com/MetricsHub/metricshub-community/issues/708) | Incorrect SchemaStore link in the documentation           |
@@ -333,7 +333,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Documentation Updates
 
 | ID                                                                         | Description                                                                                    |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
 | [**\#684**](https://github.com/MetricsHub/metricshub-community/issues/684) | Documented [custom monitoring](./custom/index.md) examples                                     |
 | [**\#702**](https://github.com/MetricsHub/metricshub-community/issues/702) | Explained how to implement [custom monitoring through SQL queries](./custom/database-query.md) |
 | [**\#704**](https://github.com/MetricsHub/metricshub-community/issues/704) | Documented [Prometheus Alert Rules](./prometheus/alertmanager.md)                              |
@@ -344,13 +344,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                                             |
-| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | [**\#162**](https://github.com/MetricsHub/community-connectors/issues/162) | Added support for [**Apache Cassandra**](./connectors/cassandra.html) databases via JMX |
 
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                        |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#233**](https://github.com/MetricsHub/community-connectors/issues/233) | **[MIB-2 Standard SNMP Agent - Network Interfaces](./connectors/mib2.html)**: Added discarded inbound and outbound packets metrics |
 
 ## MetricsHub Enterprise Edition v2.0.00
@@ -360,14 +360,14 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                        | Description                                                     |
-| ------------------------------------------------------------------------- | --------------------------------------------------------------- |
+|---------------------------------------------------------------------------|-----------------------------------------------------------------|
 | [**\#13**](https://github.com/MetricsHub/metricshub-enterprise/issues/13) | Enabled self-observability through the OpenTelemetry Java Agent |
 | [**\#33**](https://github.com/MetricsHub/metricshub-enterprise/issues/33) | Added support for multiple configuration files                  |
 
 #### Changes and Improvements
 
 | ID                                                                        | Description                                                            |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|------------------------------------------------------------------------|
 | [**\#6**](https://github.com/MetricsHub/metricshub-enterprise/issues/6)   | Updated MetricsHub Enterprise EULA                                     |
 | [**\#11**](https://github.com/MetricsHub/metricshub-enterprise/issues/11) | Added the ability to define custom connector variables                 |
 | [**\#23**](https://github.com/MetricsHub/metricshub-enterprise/issues/23) | Added digital signature to MetricsHub Enterprise Windows MSI installer |
@@ -378,13 +378,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                        | Description                                                                   |
-| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | [**\#18**](https://github.com/MetricsHub/enterprise-connectors/issues/18) | Added support for **[Nvidia's DGX servers](./connectors/nvidiadgxrest.html)** |
 
 #### Changes and Improvements
 
 | ID                                                                        | Description                                                                                                                                                                      |
-| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#19**](https://github.com/MetricsHub/enterprise-connectors/issues/19) | **[HPE Synergy](./connectors/hpesynergy.html)**: Added the ability to configure login domain through the `authLoginDomain` variable                                              |
 | [**\#21**](https://github.com/MetricsHub/enterprise-connectors/issues/21) | **[Dell iDRAC9 (REST)](./connectors/dellidracrest.html)**: Added status and firmware version for the iDRAC management interface                                                  |
 | [**\#26**](https://github.com/MetricsHub/enterprise-connectors/issues/26) | **[Brocade SAN Switch](./connectors/brocadeswitch.html)**: `hw.network.name` now reported                                                                                        |
@@ -396,7 +396,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#11**](https://github.com/MetricsHub/enterprise-connectors/issues/11) | **[Pure Storage FA Series (REST)](./connectors/purestoragerest.html)** and **[Pure Storage FA Series v2 (REST)](./connectors/purestoragerestv2.html)**: Redundant `disk_controller` monitor already reported by the `blade` monitor                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | [**\#34**](https://github.com/MetricsHub/enterprise-connectors/issues/34) | Incorrect monitor names reported by various connectors: <ul><li>**[Brocade SAN Switch](./connectors/brocadeswitch.html)**</li> <li>**[Dell EMC PowerStore (REST)](./connectors/dellemcpowerstorerest.html)**</li> <li>**[Dell OpenManage Server Administrator](./connectors/dellopenmanage.html)**</li> <li>**[EMC SMI-S Agent (ECOM)](./connectors/emcdiskarray.html)**</li> <li>**[Fibre Alliance SNMP Agent (Switches)](./connectors/fibreallianceswitch.html)**</li> <li>**[Hitachi HNAS (SNMP)](./connectors/hitachihnas.html)**</li> <li>**[IBM AIX - Common](./connectors/ibmaix.html)**</li> <li>**[IBM AIX - SCSI disks](./connectors/ibmaixdisk.html)**</li> <li>**[NetApp Filer (SNMP)](./connectors/netapp.html)**</li> <li>**[MegaCLI Managed RAID Controllers](./connectors/sunmegacli.html)**</li></ul> |
 | [**\#47**](https://github.com/MetricsHub/enterprise-connectors/issues/47) | **[Cisco Entity Sensor (SNMP)](./connectors/ciscoentitysensor.html)**: Excessive power consumption values observed on certain Cisco devices                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
@@ -407,20 +407,20 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                    |
-| -------------------------------------------------------------------------- | ---------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------|
 | [**\#650**](https://github.com/MetricsHub/metricshub-community/issues/650) | Added support for multiple configuration files |
 
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                 |
-| -------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | [**\#628**](https://github.com/MetricsHub/metricshub-community/issues/628) | Enhanced connectors parser to better handle Enterprise Connector variables  |
 | [**\#651**](https://github.com/MetricsHub/metricshub-community/issues/651) | The MetricsHub core engine now dynamically generates Hardware monitor names |
 
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                             |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | [**\#503**](https://github.com/MetricsHub/metricshub-community/issues/503) | `hw.host.power` metric incorrectly reported as both estimated and measured for the same host            |
 | [**\#662**](https://github.com/MetricsHub/metricshub-community/issues/662) | Incorrect conversion of WMI unsigned 32-bit integers caused invalid performance counter values          |
 | [**\#674**](https://github.com/MetricsHub/metricshub-community/issues/674) | NullPointerException in Connector AWK scripts caused by race condition in the MetricsHub JAWK extension |
@@ -428,7 +428,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Documentation Updates
 
 | ID                                                                         | Description                             |
-| -------------------------------------------------------------------------- | --------------------------------------- |
+|----------------------------------------------------------------------------|-----------------------------------------|
 | [**\#486**](https://github.com/MetricsHub/metricshub-community/issues/486) | Documented the Datadog Integration      |
 | [**\#655**](https://github.com/MetricsHub/metricshub-community/issues/655) | Documented the Self-Observability setup |
 
@@ -437,13 +437,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                      |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------------|
 | [**\#200**](https://github.com/MetricsHub/community-connectors/issues/200) | Added support for **[PostgreSQL](./connectors/postgresql.html)** |
 
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                                                                                          |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#199**](https://github.com/MetricsHub/community-connectors/issues/199) | **[lm_sensors](./connectors/lmsensors.html)**: Connector now acts as fallback when temperatures are unavailable from other connectors                                                                |
 | [**\#212**](https://github.com/MetricsHub/community-connectors/issues/212) | **[MySQL](./connectors/mysql.html)**: Renamed metric `db.server.active_connections` to `db.server.current_connections`                                                                               |
 | [**\#218**](https://github.com/MetricsHub/community-connectors/issues/218) | **[Linux System](./connectors/linux.html)**: Added memory swap metrics                                                                                                                               |
@@ -453,7 +453,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                                                                                                                                                                                                                        |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#202**](https://github.com/MetricsHub/community-connectors/issues/202) | **[SmartMon Tools](./connectors/smartmonlinux.html)**: Failed to discover physical disks                                                                                                                                                                                                           |
 | [**\#204**](https://github.com/MetricsHub/community-connectors/issues/204) | **[Windows System](./connectors/windows.html)**: Incorrect values reported for `system.disk.io_time` and `system.disk.operation_time` metrics                                                                                                                                                      |
 | [**\#205**](https://github.com/MetricsHub/community-connectors/issues/205) | **[Linux System](./connectors/linux.html)**: Incorrect unit reported for `system.disk.io_time` and `system.disk.operation.time` metrics                                                                                                                                                            |
@@ -472,7 +472,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID       | Description                                                                                         |
-| -------- | --------------------------------------------------------------------------------------------------- |
+|----------|-----------------------------------------------------------------------------------------------------|
 | M8BEE-45 | Simplified deployment with new Docker image for MetricsHub Enterprise                               |
 | M8BEE-49 | Added `jawk` CLI, a command-line interface for executing AWK scripts                                |
 | M8BEE-50 | Integrated MetricsHub Community metrics exporter for optimized resource usage and memory efficiency |
@@ -482,14 +482,14 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID       | Description                                                                                       |
-| -------- | ------------------------------------------------------------------------------------------------- |
+|----------|---------------------------------------------------------------------------------------------------|
 | M8BEE-46 | Prometheus Alertmanager: Alerts are now triggered for degraded voltage levels (both low and high) |
 | M8BEE-48 | Added SNMPv3 authentication examples to `metricshub-example.yaml`                                 |
 
 #### Fixed Issues
 
 | ID       | Description                                                                                             |
-| -------- | ------------------------------------------------------------------------------------------------------- |
+|----------|---------------------------------------------------------------------------------------------------------|
 | M8BEE-47 | Security Vulnerabilities: CVE-2022-46364, CVE-2024-28752, CVE-2022-46363, CVE-2025-23184, CVE-2024-7254 |
 
 ### MetricsHub Enterprise Connectors v105
@@ -497,7 +497,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID     | Description                                                                      |
-| ------ | -------------------------------------------------------------------------------- |
+|--------|----------------------------------------------------------------------------------|
 | EC-3   | Added support for **[Dell EMC PowerMax](./connectors/dellemcpowermaxrest.html)** |
 | EC-4   | Added support for **[Hitachi Disk Arrays](./connectors/hitachidiskarray.html)**  |
 | EC-70  | Added support for **[HPE MSA](./connectors/hpemsarest.html)** 2060 via HTTP API  |
@@ -508,7 +508,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID     | Description                                                                                                                     |
-| ------ | ------------------------------------------------------------------------------------------------------------------------------- |
+|--------|---------------------------------------------------------------------------------------------------------------------------------|
 | EC-32  | **[HPE OneView (Frames and Blades)](./connectors/hpesynergy.html)**: Blade ID now corresponds to the Blade Server Hostname/FQDN |
 | EC-33  | **[HPE OneView (Frames and Blades)](./connectors/hpesynergy.html)**: Added Ambient Temperature on Enclosure Frames              |
 | EC-36  | **[HPE OneView (Frames and Blades)](./connectors/hpesynergy.html)**: Added Blades Server Network Card monitoring                |
@@ -521,7 +521,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID     | Description                                                                                                                                           |
-| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
 | EC-34  | **[HPE OneView (Frames and Blades)](./connectors/hpesynergy.html)**: CPU instances are not reported under Blades                                      |
 | EC-117 | **[Dell MX Chassis and Blades (REST)](./connectors/dellmxrest.html)**: Sled Inlet Temperature is in ALARM after blade reboot                          |
 | EC-119 | **[Lenovo ThinkSystem (IMM, XCC)](./connectors/lenovothinksystem.html)**: Threshold is not computed for `hw.voltage.limit` metric                     |
@@ -535,13 +535,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                          |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------|
 | [**\#583**](https://github.com/metricshub/metricshub-community/issues/583) | Added `jawk` CLI, a command-line interface for executing AWK scripts |
 
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                            |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+|----------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
 | [**\#339**](https://github.com/metricshub/metricshub-community/issues/339) | **MetricsHub Agent**: Improved OpenTelemetry resource usage                                            |
 | [**\#575**](https://github.com/metricshub/metricshub-community/issues/575) | **Authentication Protocols**: Added support for SNMPv3 HMAC-SHA-2 (SHA224, SHA256, SHA384, and SHA512) |
 | [**\#576**](https://github.com/metricshub/metricshub-community/issues/576) | **Authentication Protocols**: Added support for IPMI-over-LAN (SHA-256 and MD5)                        |
@@ -553,7 +553,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                                 |
-| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
 | [**\#572**](https://github.com/metricshub/metricshub-community/issues/572) | **HTTP CLI**: A `NullPointerException` occurs when no password is provided                                  |
 | [**\#574**](https://github.com/metricshub/metricshub-community/issues/574) | Extensions are not updated during upgrade                                                                   |
 | [**\#577**](https://github.com/metricshub/metricshub-community/issues/577) | **IPMI CLI**: An `ArrayIndexOutOfBoundsException` occurs when running the `ipmitool` command                |
@@ -570,7 +570,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Documentation Updates
 
 | ID                                                                         | Description                                                      |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------------|
 | [**\#631**](https://github.com/metricshub/metricshub-community/issues/631) | Documented the Docker deployment setup for MetricsHub Enterprise |
 | [**\#632**](https://github.com/metricshub/metricshub-community/issues/632) | Listed the supported operating systems                           |
 
@@ -579,7 +579,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                                                                                            |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#188**](https://github.com/metricshub/community-connectors/issues/188) | Defined semantic conventions for **[Oracle](./connectors/oracle.html)** and **[SQL Server](./connectors/mssql.html)** database metrics |
 | [**\#190**](https://github.com/metricshub/community-connectors/issues/190) | **[MySQL](./connectors/mysql.html):** `db.server.name` attribute is now reported                                                       |
 | [**\#193**](https://github.com/metricshub/community-connectors/issues/193) | **[Generic Ethernet Switch](./connectors/genericswitchenclosure.html):** `hw.network.name` and `hw.network.alias` now reported         |
@@ -587,13 +587,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                                  |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#177**](https://github.com/metricshub/community-connectors/issues/177) | **[Linux System](./connectors/linux.html) and [Windows System](./connectors/windows.html)**: `network.interface.name` attribute now reported |
 
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                                                                      |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+|----------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#173**](https://github.com/metricshub/community-connectors/issues/173) | **[Generic UPS](./connectors/genericups.html):** Some voltage sensors are not discovered                                                         |
 | [**\#176**](https://github.com/metricshub/community-connectors/issues/176) | **[Linux](./connectors/linux.html) and [Windows](./connectors/windows.html) System**: `system.device` attribute missing from FS and disk metrics |
 | [**\#178**](https://github.com/metricshub/community-connectors/issues/178) | **[Linux System](./connectors/linux.html)**: Incorrect attribute names and invalid mapping syntax on disk metrics                                |
@@ -602,7 +602,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Documentation Updates
 
 | ID                                                                         | Description                                                |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------|
 | [**\#184**](https://github.com/metricshub/community-connectors/issues/184) | Documented `awk` source in the Connector Developer’s Guide |
 
 ## MetricsHub Enterprise Edition v1.1.00
@@ -612,13 +612,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID       | Description                                                                                                        |
-| -------- | ------------------------------------------------------------------------------------------------------------------ |
+|----------|--------------------------------------------------------------------------------------------------------------------|
 | M8BEE-37 | Added protocol CLIs to validate configurations, troubleshoot connectivity, and ensure successful metric extraction |
 
 #### Changes and Improvements
 
 | ID       | Description                                                |
-| -------- | ---------------------------------------------------------- |
+|----------|------------------------------------------------------------|
 | M8BEE-38 | Updated OpenTelemetry Collector Contrib to version 0.116.0 |
 
 ### MetricsHub Enterprise Connectors v103
@@ -626,7 +626,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID    | Description                                                                                                                              |
-| ----- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+|-------|------------------------------------------------------------------------------------------------------------------------------------------|
 | EC-72 | Added performance and capacity metrics for **[Pure Storage](./connectors/purestoragerest.html)** FlashArray storage systems via REST API |
 | EC-75 | Added performance and capacity metrics for **[NetApp](./connectors/netapprest.html)** FAS and AFF storage systems via ONTAP REST API     |
 | EC-86 | Added support for **[Citrix NetScaler](./connectors/citrixnetscaler.html)** via SNMP                                                     |
@@ -634,7 +634,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID     | Description                                                                                                                                                                                                                              |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | EC-10  | Enhanced detection criteria in the [EMC VPLEX Version 5](./connectors/vplex5.html), [EMC VPLEX Version 6](./connectors/vplex.html), and [Huawei OceanStor (REST)](./connectors/huaweioceanstorrest.html) connectors                      |
 | EC-57  | **[Pure Storage FA Series (REST Token Authentication)](./connectors/purestorageresttoken.html)**: NVRAM modules are now reported as memory monitors                                                                                      |
 | EC-88  | Added support for HPE ProLiant Gen 11 servers via [iLO 6](./connectors/hpeilo6rest.html)                                                                                                                                                 |
@@ -645,7 +645,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID    | Description                                                                                                                                                                                   |
-| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | EC-84 | **[Pure Storage FA Series (REST Token Authentication)](./connectors/purestorageresttoken.html)**: The `hw.parent.type` attribute is reported as `DiskController` instead of `disk_controller` |
 | EC-95 | **[Dell EMC PowerStore (REST)](./connectors/dellemcpowerstorerest.html)**: Metrics are missing for physical disks, network cards, memory modules, fans and power supplies                     |
 | EC-97 | **[Pure Storage FA Series (SSH)](./connectors/purestorage.html)**: `hw.temperature` metrics are not collected                                                                                 |
@@ -656,7 +656,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID     | Description                                                                                                                                                                |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | EC-112 | Reduced high CPU usage caused by internal DB queries in [NetAppRESTv2](./connectors/netapprestv2.html) and [PureStorageREST](./connectors/purestoragerest.html) connectors |
 
 ### MetricsHub Community Edition v1.0.00
@@ -664,13 +664,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                                                                        |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+|----------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
 | [**\#424**](https://github.com/metricshub/metricshub-community/issues/424) | Added protocol CLIs to validate configurations, troubleshoot connectivity, and ensure successful metric extraction |
 
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                            |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#519**](https://github.com/metricshub/metricshub-community/issues/519) | Updated connector semantics by replacing `leftConcat` with `prepend`, `rightConcat` with `append`, and `osCommand` with `commandLine`. |
 | [**\#521**](https://github.com/metricshub/metricshub-community/issues/521) | Updated OpenTelemetry Java dependencies to version `1.45.0`                                                                            |
 | [**\#525**](https://github.com/metricshub/metricshub-community/issues/525) | Added the ability to enable or disable self-monitoring                                                                                 |
@@ -678,13 +678,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                 |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
 | [**\#523**](https://github.com/metricshub/metricshub-community/issues/523) | The `hw.network.up` metric is not reported for connectors with `WARN` or `ALARM` link state |
 
 #### Documentation Updates
 
 | ID                                                                         | Description                                                                                       |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | [**\#546**](https://github.com/metricshub/metricshub-community/issues/546) | Integrated platform icons and enhanced connectors directory page                                  |
 | [**\#541**](https://github.com/metricshub/metricshub-community/issues/541) | Moved use cases from the documentation to [MetricsHub Use Cases](https://metricshub.com/usecases) |
 | [**\#533**](https://github.com/metricshub/metricshub-community/issues/533) | Documented the self-monitoring feature                                                            |
@@ -695,7 +695,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                        |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|------------------------------------------------------------------------------------|
 | [**\#563**](https://github.com/metricshub/metricshub-community/issues/563) | MetricsHub Engine Internal DB: Improved memory usage and data types identification |
 
 ### MetricsHub Community Connectors v1.0.08
@@ -703,13 +703,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### What's New
 
 | ID                                                                         | Description                                                                 |
-| -------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | [**\#137**](https://github.com/metricshub/community-connectors/issues/137) | Added support for **[MySQL](./connectors/mysql.html)** databases via `JDBC` |
 
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                                               |
-| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#158**](https://github.com/metricshub/community-connectors/issues/158) | Updated platforms for community connectors                                                                                                                |
 | [**\#160**](https://github.com/metricshub/community-connectors/issues/160) | Created Storage metric semantic conventions                                                                                                               |
 | [**\#163**](https://github.com/metricshub/community-connectors/issues/163) | [MIB2Switch](./connectors/mib2switch.html) and [GenericSwitchEnclosure](./connectors/genericswitchenclosure.html) connectors now support Arista platforms |
@@ -717,7 +717,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                   |
-| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
 | [**\#111**](https://github.com/metricshub/community-connectors/issues/111) | [LinuxIPNetwork](./connectors/linuxipnetwork.html): Fails to monitor some Ethernet interfaces |
 
 ## MetricsHub Enterprise Edition v1.0.02
@@ -727,7 +727,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID       | Description                                                                              |
-| -------- | ---------------------------------------------------------------------------------------- |
+|----------|------------------------------------------------------------------------------------------|
 | M8BEE-35 | Replaced deprecated `loggingexporter` with `debugexporter` in `otel-config-example.yaml` |
 
 ### MetricsHub Enterprise Connectors v102
@@ -735,13 +735,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID    | Description                                                                       |
-| ----- | --------------------------------------------------------------------------------- |
+|-------|-----------------------------------------------------------------------------------|
 | EC-87 | The `StatusInformation` of the `led` monitor now reports the `LedIndicator` value |
 
 #### Fixed Issues
 
 | ID    | Description                                                                                                                                                    |
-| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | EC-74 | **[HP Insight Management Agent - Drive Array](./connectors/cpqdrivearraynt.html)**: The `disk_controller` status is not reported                               |
 | EC-77 | **[Redfish](./connectors/redfish.html)**: Enclosures are duplicated for Dell iDRAC and HP                                                                      |
 | EC-78 | **[Dell OpenManage Server Administrator](./connectors/dellopenmanage.html)**: The `hw.enclosure.energy` metric is not converted to Joules                      |
@@ -753,7 +753,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                        |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
 | [**\#379**](https://github.com/metricshub/metricshub-community/issues/379) | Added support for escaped macros                                                                   |
 | [**\#422**](https://github.com/metricshub/metricshub-community/issues/422) | Developed a **JDBC** Extension to enable support for SQL-based connectors                          |
 | [**\#432**](https://github.com/metricshub/metricshub-community/issues/432) | Standardized the log messages for all the criteria tests                                           |
@@ -767,7 +767,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                       |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | [**\#478**](https://github.com/metricshub/metricshub-community/issues/478) | A NullPointerException occurs when processing `HTTP` detection criteria                           |
 | [**\#480**](https://github.com/metricshub/metricshub-community/issues/480) | [IPMITool](./connectors/ipmitool.html) criteria and source fail due to invalid `ipmitool` command |
 | [**\#500**](https://github.com/metricshub/metricshub-community/issues/500) | Only one monitor is processed due to incorrect indexing                                           |
@@ -776,7 +776,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Documentation Updates
 
 | ID                                                                         | Description                                                                                                                                                                                                                                                                |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#462**](https://github.com/metricshub/metricshub-community/issues/462) | Reviewed **Configure Monitoring** documentation                                                                                                                                                                                                                            |
 | [**\#462**](https://github.com/metricshub/metricshub-community/issues/462) | Moved the CLI documentation to the Appendix section                                                                                                                                                                                                                        |
 | [**\#463**](https://github.com/metricshub/metricshub-community/issues/463) | Combined the Linux and Windows Prometheus quick starts into a unique Prometheus quick start                                                                                                                                                                                |
@@ -789,7 +789,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                                                                     |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#112**](https://github.com/metricshub/community-connectors/issues/112) | **[Windows Process](./connectors/windowsprocess.html)**: The process user name is now retrieved and selectable through configuration variables                                  |
 | [**\#143**](https://github.com/metricshub/community-connectors/issues/143) | **[Linux System](./connectors/linux.html)**: The connector no longer reports services, as these are now handled by the [LinuxService](./connectors/linuxservice.html) connector |
 | [**\#148**](https://github.com/metricshub/community-connectors/issues/148) | **[Linux System](./connectors/linux.html)**: Enhanced `filesystem` utilization calculation                                                                                      |
@@ -797,7 +797,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                                                                                                     |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#140**](https://github.com/metricshub/community-connectors/issues/140) | `Platform` mispelling in [Linux System](./connectors/linux.html) & [LinuxService](./connectors/linuxservice.html) connectors                                                    |
 | [**\#145**](https://github.com/metricshub/community-connectors/issues/145) | **[IpmiTool](./connectors/ipmitool.html)**: The `hw.status` metric is not collected because `enclosure.awk` reports `OK`, `WARN`, `ALARM` instead of `ok`, `degraded`, `failed` |
 | [**\#152**](https://github.com/metricshub/community-connectors/issues/152) | Connectors reporting voltage metrics do not set the `high.critical` threshold                                                                                                   |
@@ -805,7 +805,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Documentation Updates
 
 | ID                                                                         | Description                                             |
-| -------------------------------------------------------------------------- | ------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------|
 | [**\#128**](https://github.com/metricshub/community-connectors/issues/128) | Documented default connector `variables`                |
 | [**\#129**](https://github.com/metricshub/community-connectors/issues/129) | Replaced all references to `sql` with `internalDbQuery` |
 
@@ -816,7 +816,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID           | Description                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------ |
+|--------------|--------------------------------------------------------------------------------------------------------------------------|
 | **M8BEE-29** | Removed Otel collector resourcedetection processor to prevent localhost system resource attributes from being overridden |
 | **M8BEE-32** | Moved the localhost resource configuration to the `data center 1` resource group in `metricshub-example.yaml`            |
 
@@ -825,13 +825,13 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID       | Description                                                    |
-| -------- | -------------------------------------------------------------- |
+|----------|----------------------------------------------------------------|
 | **EC-9** | The hw.network.bandwidth.limit metric is now reported in bytes |
 
 #### Fixed Issues
 
 | ID        | Description                                                                                               |
-| --------- | --------------------------------------------------------------------------------------------------------- |
+|-----------|-----------------------------------------------------------------------------------------------------------|
 | **EC-73** | [Dell iDRAC9 (REST)](./connectors/dellidracrest.html): Some network link physical addresses are incorrect |
 
 ### MetricsHub Community Edition v0.9.07
@@ -839,7 +839,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                                                                       |
-| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#433**](https://github.com/metricshub/metricshub-community/issues/433) | **[BREAKING_CHANGE]** Disabled Automatic Hostname to FQDN resolution                                                                                                              |
 | [**\#427**](https://github.com/metricshub/metricshub-community/issues/427) | BMC Helix Integration: Added the `StatusInformation` internal text parameter to the connector monitor                                                                             |
 | [**\#421**](https://github.com/metricshub/metricshub-community/issues/421) | Reduced Alert noise for `hw.status{state="present"}`                                                                                                                              |
@@ -853,7 +853,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                                                             |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | [**\#436**](https://github.com/metricshub/metricshub-community/issues/436) | The log message for SNMP v3 credential validation is incorrect                                          |
 | [**\#439**](https://github.com/metricshub/metricshub-community/issues/439) | Connector default variables are not serializable                                                        |
 | [**\#417**](https://github.com/metricshub/metricshub-community/issues/417) | JavaDoc references are incorrect                                                                        |
@@ -866,7 +866,7 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Changes and Improvements
 
 | ID                                                                         | Description                                                                                                                                                                                                                                              |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [**\#125**](https://github.com/metricshub/community-connectors/issues/125) | Disabled automatic detection for [Windows Process](./connectors/windowsprocess.html), [WindowsService](./connectors/windowsservice.html), and [LinuxService](./connectors/linuxservice.html)                                                             |
 | [**\#122**](https://github.com/metricshub/community-connectors/issues/122) | Added default values for connector variables in [WindowsService](./connectors/windowsservice.html), [LinuxService](./connectors/linuxservice.html), [Windows Process](./connectors/windowsprocess.html) & [LinuxProcess](./connectors/linuxprocess.html) |
 | [**\#114**](https://github.com/metricshub/community-connectors/issues/114) | The `hw.network.bandwidth.limit` metric is now displayed in bytes                                                                                                                                                                                        |
@@ -874,5 +874,5 @@ description: Learn more about the new features, changes and improvements, and bu
 #### Fixed Issues
 
 | ID                                                                         | Description                                                              |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+|----------------------------------------------------------------------------|--------------------------------------------------------------------------|
 | [**\#120**](https://github.com/metricshub/community-connectors/issues/120) | The `hw.vm.power_ratio` unit is incorrect. It should be 1 instead of Cel |


### PR DESCRIPTION
This pull request updates the release notes for MetricsHub products, documenting new features, improvements, and bug fixes across Enterprise and Community editions and their connectors. The changes provide a clear summary of recent releases, including new supported platforms, expanded hardware integrations, and several resolved issues.

**Release Note Additions**

* Added release notes for `MetricsHub Enterprise Edition v3.0.02`, highlighting new ARM64 installable packages for Red Hat and Debian, and an upgrade to OpenTelemetry Collector Contrib v0.138.0.
* Documented new features in `MetricsHub Enterprise Connectors v110`, including support for Cisco UCS C885A servers, Dell PowerFlex 3 & 4 storage systems, and enhanced metrics for Dell EMC PowerStore.
* Listed improvements and fixes for Enterprise Connectors, such as better reporting for Dell XtremIO and EMC Isilon, and corrected error messages for HPE iLO connectors.

**Community Edition Updates**

* Added release notes for `MetricsHub Community Edition v1.0.09`, featuring new MCP Tools capabilities, direct installation options, and improved monitoring job metadata and SQL query support.
* Included documentation updates and fixed issues, notably security vulnerability CVE-2025-41249 and connector loading reliability. (Fe322cc5L5R


<img width="2533" height="1157" alt="image" src="https://github.com/user-attachments/assets/8bc36784-066f-48dd-9c9a-40f36e2a62bb" />
