### PR TITLE
Web UI Explorer: Only the arrow unfolds tree view item

### DIFF
--- a/metricshub-web/react/src/components/explorer/tree/TreeItem.jsx
+++ b/metricshub-web/react/src/components/explorer/tree/TreeItem.jsx
@@ -6,13 +6,33 @@ import NodeTypeIcons from "./icons/NodeTypeIcons";
 /**
  * Generic explorer tree item label.
  * Displays icon + name.
+ *
+ * NOTE:
+ * - Clicks on this label intentionally do NOT toggle expand/collapse.
+ * - We stop propagation so only the built-in arrow icon controls unfolding.
+ * - An optional `onLabelClick` makes it easy to later plug in
+ *   "focus this node on the right side" behavior.
  */
 const ExplorerTreeItemLabel = React.memo(function ExplorerTreeItemLabel({
 	name,
 	type,
 	isFolder,
 	right,
+	onLabelClick,
+	node,
 }) {
+	const handleClick = React.useCallback(
+		(event) => {
+			// Prevent TreeItem's default toggle-on-content-click behavior.
+			// This ensures only the arrow icon expands/collapses the node.
+			event.stopPropagation();
+			if (onLabelClick) {
+				onLabelClick(node);
+			}
+		},
+		[onLabelClick, node],
+	);
+
 	return (
 		<Box
 			sx={{
@@ -22,6 +42,7 @@ const ExplorerTreeItemLabel = React.memo(function ExplorerTreeItemLabel({
 				justifyContent: "space-between",
 				pr: 1,
 			}}
+			onClick={handleClick}
 		>
 			<Box sx={{ display: "flex", alignItems: "center", minWidth: 0 }}>
 				<NodeTypeIcons type={type} />
@@ -41,9 +62,18 @@ const ExplorerTreeItemLabel = React.memo(function ExplorerTreeItemLabel({
 
 /**
  * Generic explorer tree item wrapper.
- * @param {{ node:{ id:string, name:string, type?:string, children?:any[] }, right?:React.ReactNode }} props
+ * @param {{ node:{ id:string, name:string, type?:string, children?:any[] }, right?:React.ReactNode, onLabelClick?:(node:any) => void }} props
  */
-const ExplorerTreeItem = React.memo(function ExplorerTreeItem({ node, right }) {
+const ExplorerTreeItem = React.memo(function ExplorerTreeItem({ node, right, onLabelClick }) {
+	const isFolder = Array.isArray(node.children) && node.children.length > 0;
+
+	// Keep the object passed into the label small & stable
+	// so memoization stays effective as the tree grows.
+	const labelNode = React.useMemo(
+		() => ({ id: node.id, name: node.name, type: node.type }),
+		[node.id, node.name, node.type],
+	);
+
 	return (
 		<TreeItem
 			itemId={node.id}
@@ -51,14 +81,18 @@ const ExplorerTreeItem = React.memo(function ExplorerTreeItem({ node, right }) {
 				<ExplorerTreeItemLabel
 					name={node.name}
 					type={node.type}
-					isFolder={Array.isArray(node.children) && node.children.length > 0}
+					isFolder={isFolder}
 					right={right}
+					onLabelClick={onLabelClick}
+					node={labelNode}
 				/>
 			}
 			slotProps={{ content: { sx: { width: "100%" } } }}
 		>
-			{Array.isArray(node.children) &&
-				node.children.map((c) => <ExplorerTreeItem key={c.id} node={c} />)}
+			{isFolder &&
+				node.children.map((c) => (
+					<ExplorerTreeItem key={c.id} node={c} onLabelClick={onLabelClick} />
+				))}
 		</TreeItem>
 	);
 });


### PR DESCRIPTION
This pulls request makes that only the arrow on the tree view items trigger the unfolding, so that later these items can also trigger focus of said item on the right side of the screen.

The speed of the unfolding was impractical and abandonned after research.