### PR TITLE
(deps): Updated MCC to v1.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 	</developers>
 
 	<properties>
-		<community-connectors.version>1.0.17-SNAPSHOT</community-connectors.version>
+		<community-connectors.version>1.0.17</community-connectors.version>
 		<maven.compiler.release>17</maven.compiler.release>
 		<metricshub-jre.version>17.0.15_6</metricshub-jre.version>
 		<project.build.outputTimestamp>2025-11-21T11:38:39Z</project.build.outputTimestamp>


### PR DESCRIPTION
This pull request makes a small update to the `pom.xml` file, changing the `community-connectors.version` property from a snapshot version to a release version. 

* Updated `community-connectors.version` from `1.0.17-SNAPSHOT` to `1.0.17` in `pom.xml` to use the stable release instead of a development snapshot.