### PR TITLE
Issue #990: Exclude metricshub  job duration metric from checks in IT

### DIFF
--- a/metricshub-it-common/src/it/java/org/metricshub/it/job/AbstractITJob.java
+++ b/metricshub-it-common/src/it/java/org/metricshub/it/job/AbstractITJob.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 import lombok.Data;
@@ -20,19 +21,31 @@ import org.metricshub.engine.telemetry.MonitorsVo;
 import org.metricshub.engine.telemetry.TelemetryManager;
 import org.metricshub.engine.telemetry.metric.AbstractMetric;
 
+/**
+ * Abstract implementation of an integration test job.<br>
+ * This class provides common functionality for executing strategies and verifying expected telemetry data.
+ */
 @Data
 public abstract class AbstractITJob implements ITJob {
 
 	@NonNull
 	protected final TelemetryManager telemetryManager;
 
-	private static final Pattern JOB_DURATION_PATTERN = Pattern.compile("^metricshub\\.job\\.duration(\\{.*})?$");
+	/**
+	 * Pattern to match job duration metrics, which are ignored in comparisons.
+	 */
+	private static final Pattern JOB_DURATION_PATTERN = Pattern.compile("^metricshub\\.job\\.duration(\\{.*\\})?$");
+
+	/**
+	 * List of metric patterns to skip during comparison.
+	 */
+	private static final List<Pattern> SKIP_METRIC_PATTERNS = List.of(JOB_DURATION_PATTERN);
 
 	/**
 	 * Assert that expected and actual are equal.
 	 *
-	 * @param expected
-	 * @param actual
+	 * @param expected The expected monitor instance
+	 * @param actual   The actual monitor instance
 	 */
 	private static void assertMonitor(final Monitor expected, final Monitor actual) {
 		assertMetrics(expected, actual);
@@ -93,9 +106,12 @@ public abstract class AbstractITJob implements ITJob {
 		for (final Entry<String, AbstractMetric> expectedEntry : expectedMonitor.getMetrics().entrySet()) {
 			final AbstractMetric expectedMetric = expectedEntry.getValue();
 			final String expectedKey = expectedEntry.getKey();
-			if (JOB_DURATION_PATTERN.matcher(expectedKey).matches()) {
+
+			// Should we skip assertions for this metric?
+			if (skipMetric(expectedKey)) {
 				continue;
 			}
+
 			final String expectedMonitorId = expectedMonitor.getId();
 
 			assertNotNull(
@@ -164,6 +180,16 @@ public abstract class AbstractITJob implements ITJob {
 					)
 			);
 		}
+	}
+
+	/**
+	 * Decide whether to skip the metric check based on the expected key.
+	 *
+	 * @param metricKey The expected metric key
+	 * @return true to skip the check, false otherwise
+	 */
+	static boolean skipMetric(final String metricKey) {
+		return SKIP_METRIC_PATTERNS.stream().anyMatch(pattern -> pattern.matcher(metricKey).matches());
 	}
 
 	/**

--- a/metricshub-it-common/src/test/java/org/metricshub/it/job/AbstractITJobTest.java
+++ b/metricshub-it-common/src/test/java/org/metricshub/it/job/AbstractITJobTest.java
@@ -1,0 +1,30 @@
+package org.metricshub.it.job;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AbstractITJobTest {
+
+	@Test
+	void testSkipMetric() {
+		final record TestCase(String metricName, boolean expected) {}
+		final var testCases = List.of(
+			new TestCase("metricshub.job.duration", true),
+			new TestCase("metricshub.job.duration.last_run", false),
+			new TestCase("metricshub.job.duration{}", true),
+			new TestCase("metricshub.job.duration{job.type=\"discovery\", monitor.type=\"connector\"}", true),
+			new TestCase("metricshub.job.success", false),
+			new TestCase("metricshub.system.cpu.usage", false)
+		);
+		// Execute test cases
+		for (var testCase : testCases) {
+			assertEquals(
+				testCase.expected(),
+				AbstractITJob.skipMetric(testCase.metricName()),
+				"skipMetric failed for metric name: " + testCase.metricName()
+			);
+		}
+	}
+}


### PR DESCRIPTION
* Exclude metricshub.job.duration in assertMetrics