### PR TITLE
Issue #1010: Fixed startup crash on Windows when log directory isn't writable

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/helper/ConfigHelper.java
@@ -123,9 +123,11 @@ public class ConfigHelper {
 	 * @return {@link Path} instance
 	 */
 	public static Path getDefaultOutputDirectory() {
-		var subDirectory = getSubDirectory(LOG_DIRECTORY_NAME, true);
 		if (LocalOsHandler.isWindows()) {
 			try {
+				final var subDirectory = getSubDirectory(LOG_DIRECTORY_NAME, true);
+				// This should be always writable after directory creation
+				// but let's double check in case of ACL changes after MetricsHub restart
 				if (Files.isWritable(subDirectory)) {
 					return subDirectory;
 				}
@@ -139,7 +141,7 @@ public class ConfigHelper {
 			}
 		}
 
-		return subDirectory;
+		return getSubDirectory(LOG_DIRECTORY_NAME, true);
 	}
 
 	/**


### PR DESCRIPTION
Refactor `getDefaultOutputDirectory` to improve directory handling logic

- Moved `subDirectory` initialization inside Windows-specific block
- Added comments to clarify writable directory checks on Windows
- Ensured `getSubDirectory` is called consistently for non-Windows paths

<img width="2517" height="1077" alt="image" src="https://github.com/user-attachments/assets/7eb6cc30-7108-4580-803c-972fe3bc2bfb" />

_Non admin user_
<img width="2491" height="979" alt="image" src="https://github.com/user-attachments/assets/6ee66139-cb5e-4d3c-a8eb-c0ca2f945bd9" />
