### PR TITLE
Issue #1058: Upload tool outputs to prevent context window overflow

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/web/controller/ChatController.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/controller/ChatController.java
@@ -238,7 +238,13 @@ public class ChatController {
 			.model(model)
 			.input(ResponseCreateParams.Input.ofResponse(initialInputs))
 			.tools(tools)
-			.addTool(WebSearchTool.builder().type(Type.WEB_SEARCH).build());
+			.addTool(WebSearchTool.builder().type(Type.WEB_SEARCH).build())
+			.addCodeInterpreterTool(
+				Tool.CodeInterpreter.Container.CodeInterpreterToolAuto
+					.builder()
+					.memoryLimit(Tool.CodeInterpreter.Container.CodeInterpreterToolAuto.MemoryLimit._4G)
+					.build()
+			);
 
 		// Enable reasoning if enabled in the configuration
 		if (chatConfig.getReasoning().isEnabled()) {

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/TroubleshootHostService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/TroubleshootHostService.java
@@ -23,6 +23,7 @@ package org.metricshub.web.mcp;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.metricshub.engine.client.ClientsExecutor;
 import org.metricshub.engine.strategy.collect.CollectStrategy;
 import org.metricshub.engine.strategy.collect.PrepareCollectStrategy;
@@ -46,6 +47,30 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class TroubleshootHostService implements IMCPToolService {
+
+	/**
+	 * Tool name for collecting metrics for a host.
+	 */
+	private static final String COLLECT_METRICS_FOR_HOST = "CollectMetricsForHost";
+
+	/**
+	 * Tool name for getting metrics from cache for a host.
+	 */
+	private static final String GET_METRICS_FROM_CACHE_FOR_HOST = "GetMetricsFromCacheForHost";
+
+	/**
+	 * Tool name for testing available connectors for a host.
+	 */
+	private static final String TEST_AVAILABLE_CONNECTORS_FOR_HOST = "TestAvailableConnectorsForHost";
+
+	/**
+	 * Set of tool names.
+	 */
+	public static final Set<String> TOOL_NAMES = Set.of(
+		COLLECT_METRICS_FOR_HOST,
+		GET_METRICS_FROM_CACHE_FOR_HOST,
+		TEST_AVAILABLE_CONNECTORS_FOR_HOST
+	);
 
 	/**
 	 * Message to be returned when the hostname is not configured in MetricsHub.
@@ -83,7 +108,7 @@ public class TroubleshootHostService implements IMCPToolService {
 	 * @return a multi-host response mapping each input hostname to one or more {@link TelemetryResult}, or an error message
 	 */
 	@Tool(
-		name = "CollectMetricsForHost",
+		name = COLLECT_METRICS_FOR_HOST,
 		description = """
 		Fetch and collect metrics for the specified host(s) using the configured protocols and credentials,
 		and the applicable MetricsHub connectors (MIB2, Linux, Windows, Dell, RedFish, etc.).
@@ -144,7 +169,7 @@ public class TroubleshootHostService implements IMCPToolService {
 	 * @return a multi-host response mapping each input hostname to one or more {@link TelemetryResult}, or an error message
 	 */
 	@Tool(
-		name = "GetMetricsFromCacheForHost",
+		name = GET_METRICS_FROM_CACHE_FOR_HOST,
 		description = """
 		Retrieves metrics from the MetricsHub cache for the specified host(s).
 		Returns the collected metrics and all attributes.
@@ -198,7 +223,7 @@ public class TroubleshootHostService implements IMCPToolService {
 	 * @return a multi-host response mapping each input hostname to one or more {@link TelemetryResult}, or an error message
 	 */
 	@Tool(
-		name = "TestAvailableConnectorsForHost",
+		name = TEST_AVAILABLE_CONNECTORS_FOR_HOST,
 		description = """
 		Test all applicable MetricsHub connectors (MIB2, Linux, Windows, Dell, RedFish, etc.) against the specified host(s)
 		using the configured credentials and return the list of connectors that work with these hosts.

--- a/metricshub-agent/src/test/java/org/metricshub/web/service/openai/ToolResponseManagerServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/service/openai/ToolResponseManagerServiceTest.java
@@ -1,0 +1,207 @@
+package org.metricshub.web.service.openai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.metricshub.web.config.OpenAiToolOutputProperties;
+import org.metricshub.web.dto.openai.PersistedToolOutputFile;
+import org.metricshub.web.dto.openai.UploadedToolOutputManifest;
+import org.metricshub.web.mcp.TroubleshootHostService;
+
+class ToolResponseManagerServiceTest {
+
+	private ObjectMapper objectMapper;
+	private ToolOutputFilePersistService persistService;
+	private ToolOutputFileUploadService uploadService;
+
+	@BeforeEach
+	void setUp() {
+		objectMapper = new ObjectMapper();
+		persistService = mock(ToolOutputFilePersistService.class);
+		uploadService = mock(ToolOutputFileUploadService.class);
+	}
+
+	/**
+	 * Creates a new instance of ToolResponseManagerService with the given properties.
+	 *
+	 * @param properties the OpenAiToolOutputProperties to pass to the service constructor
+	 * @return a new ToolResponseManagerService instance
+	 */
+	private ToolResponseManagerService newService(final OpenAiToolOutputProperties properties) {
+		return new ToolResponseManagerService(objectMapper, properties, persistService, uploadService);
+	}
+
+	@Test
+	void testReturnNullWhenToolResultIsNull() {
+		final var properties = new OpenAiToolOutputProperties();
+		final var service = newService(properties);
+
+		final String adapted = service.adaptToolOutputOrManifest("RegularTool", null);
+
+		assertNull(adapted, "Null tool result should be returned unchanged");
+		verifyNoInteractions(persistService, uploadService);
+	}
+
+	@Test
+	void testReturnOriginalWhenWithinLimitForNonTroubleshootingTool() {
+		final var properties = new OpenAiToolOutputProperties();
+		properties.setMaxToolOutputBytes(1_000);
+		properties.setSafetyDeltaBytes(100);
+
+		final var service = newService(properties);
+		final String toolName = "RegularTool";
+		final String toolResultJson = "{\"result\":\"ok\"}";
+
+		final String adapted = service.adaptToolOutputOrManifest(toolName, toolResultJson);
+
+		assertEquals(
+			toolResultJson,
+			adapted,
+			"Should return original output when size is within authorized limit for standard tools"
+		);
+		verifyNoInteractions(persistService, uploadService);
+	}
+
+	@Test
+	void testPersistUploadAndReturnManifestForOversizedOutput() throws Exception {
+		final var properties = new OpenAiToolOutputProperties();
+		properties.setMaxToolOutputBytes(1_100);
+		properties.setSafetyDeltaBytes(100); // Authorized limit = 1_000 bytes
+
+		final var service = newService(properties);
+		final String toolName = "RegularTool";
+		final String toolResultJson = "x".repeat(1_050); // Larger than authorized limit
+
+		final Path tempFile = Files.createTempFile("mh-oversize-", ".json");
+		Files.writeString(tempFile, "temporary");
+
+		final var persisted = PersistedToolOutputFile
+			.builder()
+			.absolutePath(tempFile.toAbsolutePath().toString())
+			.resultId("oversize-result-id")
+			.sizeBytes(toolResultJson.length())
+			.toolName(toolName)
+			.build();
+		final var manifest = UploadedToolOutputManifest.builder().openaiFileId("file-id").fileName("file.json").build();
+
+		try {
+			when(persistService.persist(toolName, toolResultJson)).thenReturn(persisted);
+			when(uploadService.uploadToOpenAi(tempFile)).thenReturn(manifest);
+
+			final String adapted = service.adaptToolOutputOrManifest(toolName, toolResultJson);
+
+			assertEquals(
+				objectMapper.writeValueAsString(manifest),
+				adapted,
+				"Oversized outputs should return the uploaded manifest JSON"
+			);
+			verify(persistService).persist(toolName, toolResultJson);
+			verify(uploadService).uploadToOpenAi(tempFile);
+			assertTrue(Files.notExists(tempFile), "Persisted file should be deleted after upload");
+		} finally {
+			Files.deleteIfExists(tempFile);
+		}
+	}
+
+	@Test
+	void testTroubleshootingToolAlwaysUploadsEvenWhenSmall() throws Exception {
+		final var properties = new OpenAiToolOutputProperties();
+		properties.setMaxToolOutputBytes(2_000);
+		properties.setSafetyDeltaBytes(500); // Authorized limit = 1_500 bytes
+
+		final var service = newService(properties);
+		final String toolName = TroubleshootHostService.TOOL_NAMES.iterator().next();
+		final String toolResultJson = "{\"status\":\"short\"}";
+
+		final Path tempFile = Files.createTempFile("mh-troubleshoot-", ".json");
+		Files.writeString(tempFile, "temporary");
+
+		final var persisted = PersistedToolOutputFile
+			.builder()
+			.absolutePath(tempFile.toAbsolutePath().toString())
+			.resultId("troubleshoot-result-id")
+			.sizeBytes(toolResultJson.length())
+			.toolName(toolName)
+			.build();
+		final var manifest = UploadedToolOutputManifest
+			.builder()
+			.openaiFileId("troubleshoot-file-id")
+			.fileName("troubleshoot.json")
+			.build();
+
+		try {
+			when(persistService.persist(toolName, toolResultJson)).thenReturn(persisted);
+			when(uploadService.uploadToOpenAi(tempFile)).thenReturn(manifest);
+
+			final String adapted = service.adaptToolOutputOrManifest(toolName, toolResultJson);
+
+			assertEquals(
+				objectMapper.writeValueAsString(manifest),
+				adapted,
+				"Troubleshooting tools should always return manifest JSON even when small"
+			);
+			verify(persistService).persist(toolName, toolResultJson);
+			verify(uploadService).uploadToOpenAi(tempFile);
+			assertTrue(Files.notExists(tempFile), "Persisted troubleshooting file should be deleted after upload");
+		} finally {
+			Files.deleteIfExists(tempFile);
+		}
+	}
+
+	@Test
+	void testThrowsWhenManifestExceedsAuthorizedLimit() throws Exception {
+		final var properties = new OpenAiToolOutputProperties();
+		properties.setMaxToolOutputBytes(60);
+		properties.setSafetyDeltaBytes(50); // Authorized limit = 10 bytes
+
+		final var service = newService(properties);
+		final String toolName = "RegularTool";
+		final String toolResultJson = "x".repeat(20); // Force oversized path
+
+		final Path tempFile = Files.createTempFile("mh-manifest-limit-", ".json");
+		Files.writeString(tempFile, "temporary");
+
+		final var persisted = PersistedToolOutputFile
+			.builder()
+			.absolutePath(tempFile.toAbsolutePath().toString())
+			.resultId("manifest-limit-id")
+			.sizeBytes(toolResultJson.length())
+			.toolName(toolName)
+			.build();
+		final var manifest = UploadedToolOutputManifest
+			.builder()
+			.openaiFileId("file-id-too-long")
+			.fileName("manifest.json")
+			.build();
+
+		try {
+			when(persistService.persist(toolName, toolResultJson)).thenReturn(persisted);
+			when(uploadService.uploadToOpenAi(tempFile)).thenReturn(manifest);
+
+			assertThrows(
+				IllegalStateException.class,
+				() -> service.adaptToolOutputOrManifest(toolName, toolResultJson),
+				"Manifest larger than authorized limit should trigger an IllegalStateException"
+			);
+			verify(persistService).persist(toolName, toolResultJson);
+			verify(uploadService).uploadToOpenAi(tempFile);
+			assertTrue(
+				Files.notExists(tempFile),
+				"Persisted file should be deleted even when manifest serialization fails the size check"
+			);
+		} finally {
+			Files.deleteIfExists(tempFile);
+		}
+	}
+}


### PR DESCRIPTION
This pull request improves how tool outputs are handled before being sent to OpenAI, especially for troubleshooting tools, and adds comprehensive tests for these behaviors. The most significant updates are the introduction of special handling for troubleshooting tool outputs, refactoring of tool name constants, and expanded test coverage.

### Tool Output Handling Improvements

* The `ToolResponseManagerService` now always persists and uploads outputs from troubleshooting tools (defined in `TroubleshootHostService.TOOL_NAMES`), returning an upload manifest, regardless of output size. Standard tools only upload if output exceeds the authorized size limit. [[1]](diffhunk://#diff-6b16c58da99d9d5a6db26fc3ea8f3b7d091a544307d23b9d73888ef01d56cbbcL48-R50) [[2]](diffhunk://#diff-6b16c58da99d9d5a6db26fc3ea8f3b7d091a544307d23b9d73888ef01d56cbbcR60-R74) [[3]](diffhunk://#diff-6b16c58da99d9d5a6db26fc3ea8f3b7d091a544307d23b9d73888ef01d56cbbcR101-R109)

### Troubleshooting Tool Refactoring

* Refactored `TroubleshootHostService` to define troubleshooting tool names as constants and a set (`TOOL_NAMES`), and updated all tool annotations to use these constants for consistency and easier maintenance. [[1]](diffhunk://#diff-f87458e02beaed3b721de3ce3f17344d7aeec401330b8ec6536fbd949c269e77R51-R74) [[2]](diffhunk://#diff-f87458e02beaed3b721de3ce3f17344d7aeec401330b8ec6536fbd949c269e77L86-R111) [[3]](diffhunk://#diff-f87458e02beaed3b721de3ce3f17344d7aeec401330b8ec6536fbd949c269e77L147-R172) [[4]](diffhunk://#diff-f87458e02beaed3b721de3ce3f17344d7aeec401330b8ec6536fbd949c269e77L201-R226)

### Test Coverage

* Added a new test class `ToolResponseManagerServiceTest` with thorough unit tests for tool output adaptation logic, including cases for troubleshooting tools, oversized outputs, null outputs, and manifest size limits.

### Minor Updates

* Updated imports in affected files to support new logic and tests. [[1]](diffhunk://#diff-f87458e02beaed3b721de3ce3f17344d7aeec401330b8ec6536fbd949c269e77R26) [[2]](diffhunk://#diff-6b16c58da99d9d5a6db26fc3ea8f3b7d091a544307d23b9d73888ef01d56cbbcR32-R37)

These changes ensure troubleshooting tool outputs are always handled securely and reliably, and the new tests help prevent regressions in this critical logic.

<img width="2523" height="1249" alt="multi-hosts" src="https://github.com/user-attachments/assets/7da0a572-85ec-47b4-b5e7-706054a9459a" />

