### PR TITLE
Web UI monitor view metrics tab select all by default

### DIFF
--- a/metricshub-web/react/src/hooks/use-metric-selection.js
+++ b/metricshub-web/react/src/hooks/use-metric-selection.js
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 
 /**
  * Hook to manage metric selection and settings dialog.
@@ -9,6 +9,7 @@ import { useState, useMemo, useCallback } from "react";
 export const useMetricSelection = (instances) => {
 	const [selectedMetrics, setSelectedMetrics] = useState([]);
 	const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+	const [hasInitialized, setHasInitialized] = useState(false);
 
 	const availableMetrics = useMemo(() => {
 		const metricsSet = new Set();
@@ -24,6 +25,13 @@ export const useMetricSelection = (instances) => {
 		}
 		return Array.from(metricsSet).sort();
 	}, [instances]);
+
+	useEffect(() => {
+		if (!hasInitialized && availableMetrics.length > 0) {
+			setSelectedMetrics(availableMetrics);
+			setHasInitialized(true);
+		}
+	}, [availableMetrics, hasInitialized]);
 
 	const handleMetricToggle = useCallback((metric) => {
 		setSelectedMetrics((prev) =>


### PR DESCRIPTION
This pull request enhances the `useMetricSelection` hook by introducing automatic initialization of the selected metrics. Now, when metrics become available, all available metrics are automatically selected the first time, improving the user experience by providing sensible defaults.

**Enhancement to metric selection initialization:**

* Added a `hasInitialized` state and a `useEffect` that automatically sets `selectedMetrics` to all available metrics when they are first loaded. This ensures users see all metrics selected by default on initial load. [[1]](diffhunk://#diff-829fef18bfdc06839e941c29a7e077f33c806961bfcbbed916c54b19d9386e14R12) [[2]](diffhunk://#diff-829fef18bfdc06839e941c29a7e077f33c806961bfcbbed916c54b19d9386e14R29-R35)

**Dependency update:**

* Included `useEffect` in the imports from React to support the new initialization logic.