### PR TITLE
Issue #1045: Document transform/system_for_helix

### DIFF
--- a/metricshub-doc/src/site/markdown/integrations/bmc-helix.md
+++ b/metricshub-doc/src/site/markdown/integrations/bmc-helix.md
@@ -262,6 +262,6 @@ processors:
           - set(metric.name, Concat([metric.name, attributes["network.io.direction"]], ".")) where attributes["network.io.direction"] != nil
           - set(metric.name, Concat([metric.name, attributes["system.filesystem.state"]], ".")) where attributes["system.filesystem.state"] != nil
           - set(metric.name, Concat([metric.name, attributes["system.process.status"]], ".")) where attributes["system.process.status"] != nil
-          # Make sure to not rename the metric here if it is already managed by transform/hardware_for_helix
+          # If the metric is managed by transform/hardware_for_helix, do not change its name
           # - set(metric.name, Concat([metric.name, attributes["state"]], ".")) where attributes["state"] != nil
 ```


### PR DESCRIPTION

This pull request enhances the documentation for BMC Helix integration by expanding the transformer configuration examples. It clarifies the hardware metrics example and introduces a comprehensive new example for system metrics, detailing how to dynamically assign key attributes and handle various metric types.

**Documentation improvements for transformer configuration:**

* Clarified the intent of the hardware metrics transformer example by specifying it is for hardware metrics.
* Added a new, detailed transformer example for system metrics, demonstrating how to dynamically assign `entityName`, `instanceName`, and `entityTypeId` for various system metric types. This includes logic for handling CPU, memory, paging, disk, filesystem, network, process, and service metrics, as well as optional handling for agent-like metrics and metric renaming based on state or direction attributes.