### PR TITLE
Fixed Fedora Version To Support JDK 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 		<nssm.checksum>be7b3577c6e3a280e5106a9e9db5b3775931cefc</nssm.checksum>
 		<jdkBuildVersion>21</jdkBuildVersion>
 		<debianTagName>trixie</debianTagName>
-		<fedoraTagName>44</fedoraTagName>
+		<fedoraTagName>43</fedoraTagName>
 
 	</properties>
 


### PR DESCRIPTION
Updated Fedora Version from 44 to 43, as the Fedora project removed official support of JDK 21 replaced with JDK 25.