### PR TITLE
Issue #1080: Develop GetAgentInfo mcp tool

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/AgentInfoResponse.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/AgentInfoResponse.java
@@ -173,4 +173,53 @@ public class AgentInfoResponse {
 	 */
 	@JsonProperty("cpu.usage.percent")
 	private Double cpuUsagePercent;
+
+	// Application Status Information
+
+	/**
+	 * The current status of the agent (UP or DOWN).
+	 */
+	private String status;
+
+	/**
+	 * The status of the OpenTelemetry Collector (running, disabled, errored, not-installed).
+	 */
+	@JsonProperty("otel.collector.status")
+	private String otelCollectorStatus;
+
+	/**
+	 * The number of resources currently being observed by the agent.
+	 */
+	@JsonProperty("observed.resources.count")
+	private Long numberOfObservedResources;
+
+	/**
+	 * The number of resources configured in the agent.
+	 */
+	@JsonProperty("configured.resources.count")
+	private Long numberOfConfiguredResources;
+
+	/**
+	 * The number of monitors currently active.
+	 */
+	@JsonProperty("monitors.count")
+	private Long numberOfMonitors;
+
+	/**
+	 * The number of scheduled jobs.
+	 */
+	@JsonProperty("jobs.count")
+	private Long numberOfJobs;
+
+	/**
+	 * The number of days remaining on the license (null for Community Edition).
+	 */
+	@JsonProperty("license.days.remaining")
+	private Long licenseDaysRemaining;
+
+	/**
+	 * The type of license (Community or Enterprise).
+	 */
+	@JsonProperty("license.type")
+	private String licenseType;
 }


### PR DESCRIPTION
This pull request introduces a new MCP tool for exposing detailed MetricsHub Agent metadata and runtime information, including memory and CPU usage, and provides comprehensive test coverage for the new functionality. The main changes are the addition of the `AgentInfoService` and its response DTO, as well as a new test class to ensure correctness.

**New MCP Tool for Agent Information**

* Added `AgentInfoService`, a Spring service that implements the `GetAgentInfo` MCP tool. This service collects agent metadata, host details, runtime information, and current memory/CPU usage, and returns them in a structured response.
* Created `AgentInfoResponse`, a DTO that defines the structure of the agent information returned by the tool, including fields for agent metadata, runtime environment, memory, and CPU usage.

**Testing and Validation**

* Added `AgentInfoServiceTest`, a test class that uses mocks to verify that `AgentInfoService` correctly retrieves and computes agent metadata, runtime, memory, and CPU information, and that memory calculations are consistent.
<img width="1909" height="1180" alt="image" src="https://github.com/user-attachments/assets/7b0e1fcc-9dc8-4384-b9bd-f84976b5b4c4" />
<img width="1191" height="985" alt="image" src="https://github.com/user-attachments/assets/d7a536d3-afcc-4dc5-9aa7-c2a5d86bab8e" />
