### PR TITLE
Issue #1108: optimize troubleshooting tool responses for the ai assistant p2

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/MonitorTypeItem.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/MonitorTypeItem.java
@@ -1,0 +1,41 @@
+package org.metricshub.web.dto.mcp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Polymorphic base interface for items in a monitor type list.
+ * Each monitor type list contains individual monitors (MonitorVo) and
+ * ends with a summary object (MonitorTypeSummaryVo).
+ *
+ * Jackson uses the "type" property to distinguish between subtypes.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+	{
+		@JsonSubTypes.Type(value = MonitorVo.class, name = "monitor"),
+		@JsonSubTypes.Type(value = MonitorTypeSummaryVo.class, name = "summary")
+	}
+)
+public interface MonitorTypeItem {}

--- a/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/MonitorTypeSummaryVo.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/MonitorTypeSummaryVo.java
@@ -1,0 +1,61 @@
+package org.metricshub.web.dto.mcp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Summary object appended as the last element of each monitor type list.
+ * Provides aggregated statistics so the AI assistant can answer questions
+ * like "how many disks are degraded?" without examining every monitor.
+ *
+ * Serializes with "type": "summary" as the Jackson discriminator.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class MonitorTypeSummaryVo implements MonitorTypeItem {
+
+	/** Total number of monitors of this type. */
+	private int totalMonitors;
+
+	/**
+	 * Aggregated stats for each numeric metric (NumberMetric only).
+	 * Key = metric name, Value = { avg, min, max, sum, count }.
+	 */
+	private Map<String, NumericMetricStatsVo> numericMetrics;
+
+	/**
+	 * Distribution of state values for each StateSet metric.
+	 * Key = metric name, Value = list of { value, count } entries.
+	 * Example: "hw.status" -&gt; [{ "value": "ok", "count": 195 }, { "value": "degraded", "count": 5 }]
+	 */
+	private Map<String, List<StateSetCountVo>> stateSetMetrics;
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/MonitorVo.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/MonitorVo.java
@@ -1,0 +1,64 @@
+package org.metricshub.web.dto.mcp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Value object representing a single monitor with its attributes, metrics, and text parameters.
+ * Null or empty fields are excluded during serialization.
+ * Serializes with "type": "monitor" as the Jackson discriminator.
+ *
+ * <p>For Counter metrics (metricType == "Counter"), the key is renamed to
+ * "rate(originalKey)" and the value is the computed rate (units per second)
+ * rather than the raw cumulative value. If the rate is null (first collect
+ * cycle), the Counter metric is omitted entirely.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class MonitorVo implements MonitorTypeItem {
+
+	/**
+	 * Key-value pairs of monitor attributes (e.g., device name, mount point).
+	 */
+	private Map<String, String> attributes;
+
+	/**
+	 * Key-value pairs of monitor metrics.
+	 * Values can be numeric (Double) or state strings (e.g., "ok", "degraded", "failed")
+	 * for StateSet metrics following OpenTelemetry conventions.
+	 */
+	private Map<String, Object> metrics;
+
+	/**
+	 * Key-value pairs of text parameters associated with the monitor.
+	 */
+	private Map<String, String> textParams;
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/MonitorsVo.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/MonitorsVo.java
@@ -1,0 +1,51 @@
+package org.metricshub.web.dto.mcp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Value object containing monitors grouped by their type.
+ * The key is the monitor type (e.g., "disk", "cpu", "memory", "enclosure").
+ * The value is a polymorphic list of MonitorTypeItem instances:
+ *   - Individual monitors (MonitorVo, "type": "monitor")
+ *   - A summary object as the LAST element (MonitorTypeSummaryVo, "type": "summary")
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class MonitorsVo {
+
+	/**
+	 * Monitors indexed by their type.
+	 * Each list contains MonitorVo items followed by a single MonitorTypeSummaryVo as the last element.
+	 */
+	private Map<String, List<MonitorTypeItem>> monitors;
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/NumericMetricStatsVo.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/NumericMetricStatsVo.java
@@ -1,10 +1,10 @@
-package org.metricshub.web.dto;
+package org.metricshub.web.dto.mcp;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * MetricsHub Agent
  * ჻჻჻჻჻჻
- * Copyright 2023 - 2025 MetricsHub
+ * Copyright 2023 - 2026 MetricsHub
  * ჻჻჻჻჻჻
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -21,27 +21,34 @@ package org.metricshub.web.dto;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import org.metricshub.engine.telemetry.MonitorsVo;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
- * Represents the result of a engine operation, including telemetry data,
+ * Aggregated statistics for a single numeric metric across all monitors of a given type.
  */
-public record TelemetryResult(MonitorsVo telemetry, String errorMessage) {
-	/**
-	 * Constructs a TelemetryResult with telemetry data and no error.
-	 *
-	 * @param telemetry the telemetry data
-	 */
-	public TelemetryResult(MonitorsVo telemetry) {
-		this(telemetry, null);
-	}
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NumericMetricStatsVo {
 
-	/**
-	 * Constructs a TelemetryResult with an error message and no telemetry data.
-	 *
-	 * @param errorMessage the error message
-	 */
-	public TelemetryResult(String errorMessage) {
-		this(null, errorMessage);
-	}
+	/** Average value across all monitors. */
+	private Double avg;
+
+	/** Minimum value across all monitors. */
+	private Double min;
+
+	/** Maximum value across all monitors. */
+	private Double max;
+
+	/** Sum of values across all monitors. */
+	private Double sum;
+
+	/** Count of monitors that contributed to these stats (for avg calculation). */
+	private Integer count;
 }

--- a/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/StateSetCountVo.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/StateSetCountVo.java
@@ -1,0 +1,45 @@
+package org.metricshub.web.dto.mcp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents the count of monitors having a specific state value for a StateSet metric.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StateSetCountVo {
+
+	/** The state value (e.g., "ok", "degraded", "failed"). */
+	private String value;
+
+	/** Number of monitors in this state. */
+	private Integer count;
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/TelemetryResult.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/TelemetryResult.java
@@ -1,0 +1,67 @@
+package org.metricshub.web.dto.mcp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Result wrapper containing compressed telemetry data or an error message.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class TelemetryResult {
+
+	/**
+	 * Compressed telemetry data with monitors grouped by type.
+	 */
+	private MonitorsVo telemetry;
+
+	/**
+	 * Error message when telemetry collection fails or host is not configured.
+	 */
+	private String errorMessage;
+
+	/**
+	 * Constructs a TelemetryResult with an error message and no telemetry data.
+	 *
+	 * @param errorMessage the error message
+	 */
+	public TelemetryResult(final String errorMessage) {
+		this.errorMessage = errorMessage;
+	}
+
+	/**
+	 * Constructs a TelemetryResult with telemetry data and no error.
+	 *
+	 * @param telemetry the compressed telemetry data
+	 */
+	public TelemetryResult(final MonitorsVo telemetry) {
+		this.telemetry = telemetry;
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/TelemetryResultConverter.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/dto/mcp/TelemetryResultConverter.java
@@ -1,0 +1,316 @@
+package org.metricshub.web.dto.mcp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.ArrayList;
+import java.util.DoubleSummaryStatistics;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.metricshub.engine.telemetry.Monitor;
+import org.metricshub.engine.telemetry.TelemetryManager;
+import org.metricshub.engine.telemetry.metric.AbstractMetric;
+import org.metricshub.engine.telemetry.metric.NumberMetric;
+import org.metricshub.engine.telemetry.metric.StateSetMetric;
+
+/**
+ * Converts TelemetryManager data to the compressed MonitorsVo format.
+ * Groups monitors by type, excludes null/empty values and internal keys
+ * (starting with "__"), and appends a summary as the last element of each
+ * monitor type list.
+ *
+ * <p>Counter metrics (metricType == "Counter") are emitted as their computed
+ * rate (units per second) under the key {@code rate(originalKey)}. If the rate
+ * is {@code null} (first collect cycle), the Counter metric is discarded.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TelemetryResultConverter {
+
+	/**
+	 * Prefix for internal keys that should be excluded from output.
+	 */
+	private static final String INTERNAL_KEY_PREFIX = "__";
+
+	/**
+	 * Converts a TelemetryManager's monitors to the compressed MonitorsVo format.
+	 *
+	 * @param telemetryManager the source telemetry manager
+	 * @return MonitorsVo with monitors grouped by type, each list ending with a summary,
+	 *         or {@code null} if the manager is null or contains no monitors
+	 */
+	public static MonitorsVo toMonitorsVo(final TelemetryManager telemetryManager) {
+		if (telemetryManager == null || telemetryManager.getMonitors() == null) {
+			return null;
+		}
+
+		// Step 1: Group MonitorVo by type
+		final Map<String, List<MonitorVo>> monitorsByType = new LinkedHashMap<>();
+
+		telemetryManager
+			.getMonitors()
+			.forEach((monitorType, monitorsMap) -> {
+				if (monitorType == null || monitorType.isEmpty() || monitorsMap == null) {
+					return;
+				}
+
+				monitorsMap
+					.values()
+					.forEach(monitor -> {
+						final MonitorVo monitorVo = convertMonitor(monitor);
+						monitorsByType.computeIfAbsent(monitorType, k -> new ArrayList<>()).add(monitorVo);
+					});
+			});
+
+		if (monitorsByType.isEmpty()) {
+			return null;
+		}
+
+		// Step 2: Build polymorphic lists with summary as the last element
+		final Map<String, List<MonitorTypeItem>> monitors = new LinkedHashMap<>();
+
+		monitorsByType.forEach((type, monitorList) -> {
+			final List<MonitorTypeItem> items = new ArrayList<>(monitorList);
+			items.add(buildSummary(monitorList));
+			monitors.put(type, items);
+		});
+
+		return MonitorsVo.builder().monitors(monitors).build();
+	}
+
+	/**
+	 * Builds a MonitorTypeSummaryVo from a list of MonitorVo.
+	 * Computes:
+	 * <ul>
+	 *   <li>totalMonitors: count of monitors</li>
+	 *   <li>numericMetrics: AVG, MIN, MAX, SUM, COUNT for each numeric metric</li>
+	 *   <li>stateSetMetrics: count of monitors per state value for each state metric</li>
+	 * </ul>
+	 *
+	 * @param monitorList the monitors of a given type
+	 * @return the summary object
+	 */
+	private static MonitorTypeSummaryVo buildSummary(final List<MonitorVo> monitorList) {
+		final int totalMonitors = monitorList.size();
+
+		final Map<String, List<Double>> numericValues = new LinkedHashMap<>();
+		final Map<String, Map<String, Integer>> stateCounts = new LinkedHashMap<>();
+
+		for (final MonitorVo monitorVo : monitorList) {
+			final Map<String, Object> metrics = monitorVo.getMetrics();
+			if (metrics == null) {
+				continue;
+			}
+			metrics.forEach((key, value) -> {
+				if (value instanceof Double doubleValue) {
+					numericValues.computeIfAbsent(key, k -> new ArrayList<>()).add(doubleValue);
+				} else if (value instanceof String stringValue) {
+					stateCounts.computeIfAbsent(key, k -> new LinkedHashMap<>()).merge(stringValue, 1, Integer::sum);
+				}
+			});
+		}
+
+		// Build numeric metrics summary
+		Map<String, NumericMetricStatsVo> numericMetrics = null;
+		if (!numericValues.isEmpty()) {
+			numericMetrics = new LinkedHashMap<>();
+			for (final Map.Entry<String, List<Double>> entry : numericValues.entrySet()) {
+				final DoubleSummaryStatistics stats = entry
+					.getValue()
+					.stream()
+					.mapToDouble(Double::doubleValue)
+					.summaryStatistics();
+				numericMetrics.put(
+					entry.getKey(),
+					NumericMetricStatsVo
+						.builder()
+						.avg(stats.getAverage())
+						.min(stats.getMin())
+						.max(stats.getMax())
+						.sum(stats.getSum())
+						.count((int) stats.getCount())
+						.build()
+				);
+			}
+		}
+
+		// Build state set metrics summary
+		Map<String, List<StateSetCountVo>> stateSetMetrics = null;
+		if (!stateCounts.isEmpty()) {
+			stateSetMetrics = new LinkedHashMap<>();
+			for (final Map.Entry<String, Map<String, Integer>> entry : stateCounts.entrySet()) {
+				final List<StateSetCountVo> counts = new ArrayList<>();
+				entry
+					.getValue()
+					.forEach((state, count) -> counts.add(StateSetCountVo.builder().value(state).count(count).build()));
+				stateSetMetrics.put(entry.getKey(), counts);
+			}
+		}
+
+		return MonitorTypeSummaryVo
+			.builder()
+			.totalMonitors(totalMonitors)
+			.numericMetrics(numericMetrics)
+			.stateSetMetrics(stateSetMetrics)
+			.build();
+	}
+
+	/**
+	 * Converts a single Monitor to MonitorVo.
+	 *
+	 * @param monitor the monitor to convert
+	 * @return the converted MonitorVo
+	 */
+	private static MonitorVo convertMonitor(final Monitor monitor) {
+		return MonitorVo
+			.builder()
+			.attributes(extractNonEmptyAttributes(monitor))
+			.metrics(extractNonEmptyMetrics(monitor))
+			.textParams(extractNonEmptyTextParams(monitor))
+			.build();
+	}
+
+	/**
+	 * Checks if a key is an internal key (starts with "__").
+	 *
+	 * @param key the key to check
+	 * @return true if the key is internal, false otherwise
+	 */
+	private static boolean isInternalKey(final String key) {
+		return key != null && key.startsWith(INTERNAL_KEY_PREFIX);
+	}
+
+	/**
+	 * Extracts non-empty attributes from a monitor, excluding internal keys.
+	 *
+	 * @param monitor the source monitor
+	 * @return map of attributes or null if empty
+	 */
+	private static Map<String, String> extractNonEmptyAttributes(final Monitor monitor) {
+		final Map<String, String> attributes = monitor.getAttributes();
+		if (attributes == null || attributes.isEmpty()) {
+			return null;
+		}
+
+		final Map<String, String> result = new LinkedHashMap<>();
+		attributes.forEach((key, value) -> {
+			if (key != null && !key.isEmpty() && !isInternalKey(key) && value != null && !value.isEmpty()) {
+				result.put(key, value);
+			}
+		});
+
+		return result.isEmpty() ? null : result;
+	}
+
+	/**
+	 * Extracts non-empty metrics from a monitor, excluding internal keys.
+	 * Counter metrics are emitted as their rate under the key {@code rate(originalKey)}.
+	 * Counter metrics with a {@code null} rate are excluded.
+	 *
+	 * @param monitor the source monitor
+	 * @return map of metrics or null if empty
+	 */
+	private static Map<String, Object> extractNonEmptyMetrics(final Monitor monitor) {
+		final Map<String, AbstractMetric> metrics = monitor.getMetrics();
+		if (metrics == null || metrics.isEmpty()) {
+			return null;
+		}
+
+		final Map<String, Object> result = new LinkedHashMap<>();
+		metrics.forEach((key, metric) -> {
+			if (key == null || key.isEmpty() || isInternalKey(key) || metric == null) {
+				return;
+			}
+
+			final Object value = extractMetricValue(metric);
+			if (value != null) {
+				// Counter metrics -> rename key to rate(key)
+				final String outputKey = isCounterMetric(metric) ? "rate(" + key + ")" : key;
+				result.put(outputKey, value);
+			}
+		});
+
+		return result.isEmpty() ? null : result;
+	}
+
+	/**
+	 * Checks whether a metric is a Counter.
+	 *
+	 * @param metric the metric to check
+	 * @return {@code true} if the metric is a NumberMetric with metricType "Counter" (case-insensitive)
+	 */
+	private static boolean isCounterMetric(final AbstractMetric metric) {
+		return metric instanceof NumberMetric numberMetric && "Counter".equalsIgnoreCase(numberMetric.getMetricType());
+	}
+
+	/**
+	 * Extracts the displayable value from a metric.
+	 *
+	 * <p>For {@link NumberMetric}:
+	 * <ul>
+	 *   <li>If metricType is "Counter" (case-insensitive), returns the rate.
+	 *       If the rate is null (first collect cycle), returns null to exclude this metric.</li>
+	 *   <li>For all other metric types, returns the raw value.</li>
+	 * </ul>
+	 *
+	 * <p>For {@link StateSetMetric}, returns the state string (e.g., "ok").
+	 *
+	 * @param metric the metric to extract value from
+	 * @return the metric value, rate, or null to signal exclusion
+	 */
+	private static Object extractMetricValue(final AbstractMetric metric) {
+		if (metric instanceof NumberMetric numberMetric) {
+			// Counter metrics -> emit rate instead of raw cumulative value
+			if ("Counter".equalsIgnoreCase(numberMetric.getMetricType())) {
+				return numberMetric.getRate(); // null rate -> metric excluded
+			}
+			return numberMetric.getValue();
+		} else if (metric instanceof StateSetMetric stateSetMetric) {
+			return stateSetMetric.getValue();
+		}
+		return null;
+	}
+
+	/**
+	 * Extracts non-empty text parameters from a monitor's legacy text parameters,
+	 * excluding internal keys.
+	 *
+	 * @param monitor the source monitor
+	 * @return map of text parameters or null if empty
+	 */
+	private static Map<String, String> extractNonEmptyTextParams(final Monitor monitor) {
+		final Map<String, String> legacyTextParameters = monitor.getLegacyTextParameters();
+		if (legacyTextParameters == null || legacyTextParameters.isEmpty()) {
+			return null;
+		}
+
+		final Map<String, String> result = new LinkedHashMap<>();
+		legacyTextParameters.forEach((key, value) -> {
+			if (key != null && !key.isEmpty() && !isInternalKey(key) && value != null && !value.isEmpty()) {
+				result.put(key, value);
+			}
+		});
+
+		return result.isEmpty() ? null : result;
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/TroubleshootHostService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/TroubleshootHostService.java
@@ -36,7 +36,8 @@ import org.metricshub.hardware.strategy.HardwareMonitorNameGenerationStrategy;
 import org.metricshub.hardware.strategy.HardwarePostCollectStrategy;
 import org.metricshub.hardware.strategy.HardwarePostDiscoveryStrategy;
 import org.metricshub.web.AgentContextHolder;
-import org.metricshub.web.dto.TelemetryResult;
+import org.metricshub.web.dto.mcp.TelemetryResult;
+import org.metricshub.web.dto.mcp.TelemetryResultConverter;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -307,7 +308,7 @@ public class TroubleshootHostService implements IMCPToolService {
 			new HardwareMonitorNameGenerationStrategy(newTelemetryManager, collectTime, clientsExecutor, extensionManager)
 		);
 
-		return new TelemetryResult(newTelemetryManager.getVo());
+		return new TelemetryResult(TelemetryResultConverter.toMonitorsVo(newTelemetryManager));
 	}
 
 	/**
@@ -317,7 +318,7 @@ public class TroubleshootHostService implements IMCPToolService {
 	 * @return a {@link TelemetryResult} populated with the cached value
 	 */
 	private TelemetryResult getMetricsFromCacheForHostInternal(final TelemetryManager telemetryManager) {
-		return new TelemetryResult(telemetryManager.getVo());
+		return new TelemetryResult(TelemetryResultConverter.toMonitorsVo(telemetryManager));
 	}
 
 	/**
@@ -345,7 +346,7 @@ public class TroubleshootHostService implements IMCPToolService {
 			new HardwareMonitorNameGenerationStrategy(newTelemetryManager, detectionTime, clientsExecutor, extensionManager)
 		);
 
-		return new TelemetryResult(newTelemetryManager.getVo());
+		return new TelemetryResult(TelemetryResultConverter.toMonitorsVo(newTelemetryManager));
 	}
 
 	/**

--- a/metricshub-agent/src/test/java/org/metricshub/web/dto/mcp/TelemetryResultConverterTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/dto/mcp/TelemetryResultConverterTest.java
@@ -1,0 +1,404 @@
+package org.metricshub.web.dto.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.metricshub.engine.telemetry.Monitor;
+import org.metricshub.engine.telemetry.TelemetryManager;
+import org.metricshub.engine.telemetry.metric.NumberMetric;
+import org.metricshub.engine.telemetry.metric.StateSetMetric;
+
+class TelemetryResultConverterTest {
+
+	private static final double TOLERANCE = 0.001;
+
+	@Test
+	void testNullTelemetryManagerReturnsNull() {
+		assertNull(TelemetryResultConverter.toMonitorsVo(null));
+	}
+
+	@Test
+	void testNullMonitorsMapReturnsNull() {
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		tm.setMonitors(null);
+		assertNull(TelemetryResultConverter.toMonitorsVo(tm));
+	}
+
+	@Test
+	void testEmptyMonitorsMapReturnsNull() {
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		assertNull(TelemetryResultConverter.toMonitorsVo(tm));
+	}
+
+	@Test
+	void testInternalKeysExcluded() {
+		final Monitor monitor = Monitor.builder().build();
+		monitor.setType("disk");
+		monitor.getAttributes().put("__internal_attr", "hidden");
+		monitor.getAttributes().put("device", "/dev/sda");
+
+		final NumberMetric internalMetric = NumberMetric.builder().name("__internal.metric").value(42.0).build();
+		monitor.addMetric("__internal.metric", internalMetric);
+
+		final NumberMetric normalMetric = NumberMetric.builder().name("disk.utilization").value(45.5).build();
+		monitor.addMetric("disk.utilization", normalMetric);
+
+		monitor.getLegacyTextParameters().put("__internal_param", "hidden");
+		monitor.getLegacyTextParameters().put("filesystem", "ext4");
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		tm.getMonitors().put("disk", Map.of("disk-1", monitor));
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+		assertNotNull(result);
+
+		final List<MonitorTypeItem> diskItems = result.getMonitors().get("disk");
+		assertNotNull(diskItems);
+		assertEquals(2, diskItems.size());
+
+		final MonitorVo monitorVo = (MonitorVo) diskItems.get(0);
+		assertFalse(monitorVo.getAttributes().containsKey("__internal_attr"));
+		assertTrue(monitorVo.getAttributes().containsKey("device"));
+		assertFalse(monitorVo.getMetrics().containsKey("__internal.metric"));
+		assertTrue(monitorVo.getMetrics().containsKey("disk.utilization"));
+		assertFalse(monitorVo.getTextParams().containsKey("__internal_param"));
+		assertTrue(monitorVo.getTextParams().containsKey("filesystem"));
+	}
+
+	@Test
+	void testCounterMetricEmitsRate() {
+		final Monitor monitor = Monitor.builder().build();
+		monitor.setType("enclosure");
+
+		final NumberMetric counterMetric = NumberMetric
+			.builder()
+			.name("hw.enclosure.energy")
+			.value(5000.0)
+			.metricType("Counter")
+			.build();
+		counterMetric.setRate(20.84);
+		monitor.addMetric("hw.enclosure.energy", counterMetric);
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		tm.getMonitors().put("enclosure", Map.of("enc-1", monitor));
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+		final MonitorVo monitorVo = (MonitorVo) result.getMonitors().get("enclosure").get(0);
+
+		assertFalse(monitorVo.getMetrics().containsKey("hw.enclosure.energy"));
+		assertTrue(monitorVo.getMetrics().containsKey("rate(hw.enclosure.energy)"));
+		assertEquals(20.84, (Double) monitorVo.getMetrics().get("rate(hw.enclosure.energy)"), TOLERANCE);
+	}
+
+	@Test
+	void testCounterNullRateExcluded() {
+		final Monitor monitor = Monitor.builder().build();
+		monitor.setType("enclosure");
+
+		// Counter with null rate (first collect cycle)
+		final NumberMetric counterMetric = NumberMetric
+			.builder()
+			.name("hw.enclosure.energy")
+			.value(5000.0)
+			.metricType("Counter")
+			.build();
+		// rate is null by default
+		monitor.addMetric("hw.enclosure.energy", counterMetric);
+
+		// Also add a Gauge metric
+		final NumberMetric gaugeMetric = NumberMetric
+			.builder()
+			.name("hw.enclosure.power")
+			.value(200.0)
+			.metricType("Gauge")
+			.build();
+		monitor.addMetric("hw.enclosure.power", gaugeMetric);
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		tm.getMonitors().put("enclosure", Map.of("enc-1", monitor));
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+		final MonitorVo monitorVo = (MonitorVo) result.getMonitors().get("enclosure").get(0);
+
+		// Counter with null rate is excluded
+		assertFalse(monitorVo.getMetrics().containsKey("hw.enclosure.energy"));
+		assertFalse(monitorVo.getMetrics().containsKey("rate(hw.enclosure.energy)"));
+		// Gauge is included
+		assertTrue(monitorVo.getMetrics().containsKey("hw.enclosure.power"));
+		assertEquals(200.0, (Double) monitorVo.getMetrics().get("hw.enclosure.power"), TOLERANCE);
+	}
+
+	@Test
+	void testGaugeMetricKeepsOriginalKey() {
+		final Monitor monitor = Monitor.builder().build();
+		monitor.setType("host");
+
+		final NumberMetric gauge = NumberMetric.builder().name("hw.host.power").value(250.0).metricType("Gauge").build();
+		monitor.addMetric("hw.host.power", gauge);
+
+		final NumberMetric unknownType = NumberMetric.builder().name("some.metric").value(100.0).build();
+		monitor.addMetric("some.metric", unknownType);
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		tm.getMonitors().put("host", Map.of("host-1", monitor));
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+		final MonitorVo monitorVo = (MonitorVo) result.getMonitors().get("host").get(0);
+
+		assertTrue(monitorVo.getMetrics().containsKey("hw.host.power"));
+		assertEquals(250.0, (Double) monitorVo.getMetrics().get("hw.host.power"), TOLERANCE);
+
+		assertTrue(monitorVo.getMetrics().containsKey("some.metric"));
+		assertEquals(100.0, (Double) monitorVo.getMetrics().get("some.metric"), TOLERANCE);
+	}
+
+	@Test
+	void testStateSetMetricEmitsStringValue() {
+		final Monitor monitor = Monitor.builder().build();
+		monitor.setType("disk");
+
+		final StateSetMetric status = StateSetMetric
+			.builder()
+			.name("hw.status")
+			.value("ok")
+			.stateSet(new String[] { "ok", "degraded", "failed" })
+			.build();
+		monitor.addMetric("hw.status", status);
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		tm.getMonitors().put("disk", Map.of("disk-1", monitor));
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+		final MonitorVo monitorVo = (MonitorVo) result.getMonitors().get("disk").get(0);
+
+		assertTrue(monitorVo.getMetrics().containsKey("hw.status"));
+		assertEquals("ok", monitorVo.getMetrics().get("hw.status"));
+	}
+
+	@Test
+	void testSummaryStatistics() {
+		final Monitor disk1 = Monitor.builder().build();
+		disk1.setType("disk");
+		disk1.getAttributes().put("device", "/dev/sda");
+		disk1.addMetric("disk.utilization", NumberMetric.builder().name("disk.utilization").value(45.5).build());
+		disk1.addMetric(
+			"hw.status",
+			StateSetMetric
+				.builder()
+				.name("hw.status")
+				.value("ok")
+				.stateSet(new String[] { "ok", "degraded", "failed" })
+				.build()
+		);
+
+		final Monitor disk2 = Monitor.builder().build();
+		disk2.setType("disk");
+		disk2.getAttributes().put("device", "/dev/sdb");
+		disk2.addMetric("disk.utilization", NumberMetric.builder().name("disk.utilization").value(78.2).build());
+		disk2.addMetric(
+			"hw.status",
+			StateSetMetric
+				.builder()
+				.name("hw.status")
+				.value("degraded")
+				.stateSet(new String[] { "ok", "degraded", "failed" })
+				.build()
+		);
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		final Map<String, Monitor> diskMonitors = new LinkedHashMap<>();
+		diskMonitors.put("disk-1", disk1);
+		diskMonitors.put("disk-2", disk2);
+		tm.getMonitors().put("disk", diskMonitors);
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+		final List<MonitorTypeItem> diskItems = result.getMonitors().get("disk");
+		assertEquals(3, diskItems.size());
+
+		final MonitorTypeSummaryVo summary = (MonitorTypeSummaryVo) diskItems.get(2);
+		assertEquals(2, summary.getTotalMonitors());
+
+		// Numeric stats
+		assertNotNull(summary.getNumericMetrics());
+		final NumericMetricStatsVo utilStats = summary.getNumericMetrics().get("disk.utilization");
+		assertNotNull(utilStats);
+		assertEquals(2, utilStats.getCount());
+		assertEquals(45.5 + 78.2, utilStats.getSum(), TOLERANCE);
+		assertEquals(45.5, utilStats.getMin(), TOLERANCE);
+		assertEquals(78.2, utilStats.getMax(), TOLERANCE);
+		assertEquals((45.5 + 78.2) / 2, utilStats.getAvg(), TOLERANCE);
+
+		// State set counts
+		assertNotNull(summary.getStateSetMetrics());
+		final List<StateSetCountVo> statusCounts = summary.getStateSetMetrics().get("hw.status");
+		assertNotNull(statusCounts);
+		assertEquals(2, statusCounts.size());
+		final Map<String, Integer> countMap = new HashMap<>();
+		statusCounts.forEach(sc -> countMap.put(sc.getValue(), sc.getCount()));
+		assertEquals(1, countMap.get("ok"));
+		assertEquals(1, countMap.get("degraded"));
+	}
+
+	@Test
+	void testCounterRateInSummary() {
+		final Monitor enc1 = Monitor.builder().build();
+		enc1.setType("enclosure");
+		final NumberMetric energy1 = NumberMetric
+			.builder()
+			.name("hw.enclosure.energy")
+			.value(5000.0)
+			.metricType("Counter")
+			.build();
+		energy1.setRate(20.84);
+		enc1.addMetric("hw.enclosure.energy", energy1);
+
+		final Monitor enc2 = Monitor.builder().build();
+		enc2.setType("enclosure");
+		final NumberMetric energy2 = NumberMetric
+			.builder()
+			.name("hw.enclosure.energy")
+			.value(8000.0)
+			.metricType("Counter")
+			.build();
+		energy2.setRate(30.16);
+		enc2.addMetric("hw.enclosure.energy", energy2);
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		final Map<String, Monitor> encMonitors = new LinkedHashMap<>();
+		encMonitors.put("enc-1", enc1);
+		encMonitors.put("enc-2", enc2);
+		tm.getMonitors().put("enclosure", encMonitors);
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+		final MonitorTypeSummaryVo summary = (MonitorTypeSummaryVo) result.getMonitors().get("enclosure").get(2);
+
+		assertNotNull(summary.getNumericMetrics());
+		assertTrue(summary.getNumericMetrics().containsKey("rate(hw.enclosure.energy)"));
+		assertFalse(summary.getNumericMetrics().containsKey("hw.enclosure.energy"));
+
+		final NumericMetricStatsVo stats = summary.getNumericMetrics().get("rate(hw.enclosure.energy)");
+		assertEquals(2, stats.getCount());
+		assertEquals(20.84 + 30.16, stats.getSum(), TOLERANCE);
+	}
+
+	@Test
+	void testCounterNullRateExcludedFromSummary() {
+		final Monitor enc = Monitor.builder().build();
+		enc.setType("enclosure");
+
+		final NumberMetric energy = NumberMetric
+			.builder()
+			.name("hw.enclosure.energy")
+			.value(5000.0)
+			.metricType("Counter")
+			.build();
+		// rate is null (first collect)
+		enc.addMetric("hw.enclosure.energy", energy);
+
+		final StateSetMetric status = StateSetMetric
+			.builder()
+			.name("hw.status")
+			.value("ok")
+			.stateSet(new String[] { "ok" })
+			.build();
+		enc.addMetric("hw.status", status);
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		tm.getMonitors().put("enclosure", Map.of("enc-1", enc));
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+		final MonitorTypeSummaryVo summary = (MonitorTypeSummaryVo) result.getMonitors().get("enclosure").get(1);
+
+		// No numeric metrics since the only numeric was a counter with null rate
+		assertNull(summary.getNumericMetrics());
+		// StateSet should still be present
+		assertNotNull(summary.getStateSetMetrics());
+	}
+
+	@Test
+	void testEmptyAttributesAndMetricsExcluded() {
+		final Monitor monitor = Monitor.builder().build();
+		monitor.setType("cpu");
+		// No attributes, no metrics, no text params
+		// getAttributes() returns empty HashMap, getMetrics() returns empty HashMap
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		tm.getMonitors().put("cpu", Map.of("cpu-0", monitor));
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+		assertNotNull(result);
+
+		final MonitorVo monitorVo = (MonitorVo) result.getMonitors().get("cpu").get(0);
+		assertNull(monitorVo.getAttributes());
+		assertNull(monitorVo.getMetrics());
+		assertNull(monitorVo.getTextParams());
+	}
+
+	@Test
+	void testMultipleMonitorTypes() {
+		final Monitor disk = Monitor.builder().build();
+		disk.setType("disk");
+		disk.addMetric("disk.utilization", NumberMetric.builder().name("disk.utilization").value(50.0).build());
+
+		final Monitor cpu = Monitor.builder().build();
+		cpu.setType("cpu");
+		cpu.addMetric("cpu.utilization", NumberMetric.builder().name("cpu.utilization").value(30.0).build());
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		tm.getMonitors().put("disk", Map.of("disk-1", disk));
+		tm.getMonitors().put("cpu", Map.of("cpu-0", cpu));
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+		assertNotNull(result);
+		assertEquals(2, result.getMonitors().size());
+		assertTrue(result.getMonitors().containsKey("disk"));
+		assertTrue(result.getMonitors().containsKey("cpu"));
+
+		// Each type has 1 monitor + 1 summary = 2 items
+		assertEquals(2, result.getMonitors().get("disk").size());
+		assertEquals(2, result.getMonitors().get("cpu").size());
+	}
+
+	@Test
+	void testJacksonPolymorphicSerialization() throws Exception {
+		final Monitor monitor = Monitor.builder().build();
+		monitor.setType("cpu");
+		monitor.getAttributes().put("core", "0");
+		monitor.addMetric("cpu.utilization", NumberMetric.builder().name("cpu.utilization").value(23.4).build());
+		monitor.addMetric(
+			"hw.status",
+			StateSetMetric
+				.builder()
+				.name("hw.status")
+				.value("ok")
+				.stateSet(new String[] { "ok", "degraded", "failed" })
+				.build()
+		);
+
+		final TelemetryManager tm = TelemetryManager.builder().build();
+		tm.getMonitors().put("cpu", Map.of("cpu-0", monitor));
+
+		final MonitorsVo result = TelemetryResultConverter.toMonitorsVo(tm);
+
+		final ObjectMapper mapper = new ObjectMapper();
+		final String json = mapper.writeValueAsString(result);
+
+		// JSON should contain the Jackson type discriminators
+		assertTrue(json.contains("\"type\":\"monitor\""));
+		assertTrue(json.contains("\"type\":\"summary\""));
+
+		// Round-trip deserialization
+		final MonitorsVo deserialized = mapper.readValue(json, MonitorsVo.class);
+		assertNotNull(deserialized);
+		assertEquals(result.getMonitors().size(), deserialized.getMonitors().size());
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/TroubleshootHostServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/TroubleshootHostServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,12 +19,11 @@ import org.metricshub.engine.configuration.HostConfiguration;
 import org.metricshub.engine.connector.model.ConnectorStore;
 import org.metricshub.engine.connector.model.common.DeviceKind;
 import org.metricshub.engine.extension.ExtensionManager;
-import org.metricshub.engine.telemetry.MonitorsVo;
 import org.metricshub.engine.telemetry.TelemetryManager;
 import org.metricshub.extension.snmp.SnmpConfiguration;
 import org.metricshub.extension.snmp.SnmpExtension;
 import org.metricshub.web.AgentContextHolder;
-import org.metricshub.web.dto.TelemetryResult;
+import org.metricshub.web.dto.mcp.TelemetryResult;
 import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 
@@ -104,14 +104,12 @@ class TroubleshootHostServiceTest {
 				)
 				.thenCallRealMethod();
 
-			final var expected = new MonitorsVo();
-			when(telemetryManagerMock.getVo()).thenReturn(expected);
+			// Mock returns empty monitors map so the converter produces null telemetry
+			when(telemetryManagerMock.getMonitors()).thenReturn(new HashMap<>());
 
-			assertEquals(
-				new TelemetryResult(expected),
-				collectMetrics(null),
-				"Unexpected result when triggering resource detection."
-			);
+			final var result = collectMetrics(null);
+
+			assertNotNull(result, "Result should not be null when triggering resource collection.");
 
 			verify(telemetryManagerMock, times(1)).run(any(), any(), any(), any(), any());
 
@@ -202,14 +200,12 @@ class TroubleshootHostServiceTest {
 				)
 				.thenCallRealMethod();
 
-			final var expected = new MonitorsVo();
-			when(telemetryManagerMock.getVo()).thenReturn(expected);
+			// Mock returns empty monitors map so the converter produces null telemetry
+			when(telemetryManagerMock.getMonitors()).thenReturn(new HashMap<>());
 
-			assertEquals(
-				new TelemetryResult(expected),
-				testAvailableConnectors(null),
-				"Unexpected result when triggering resource detection."
-			);
+			final var result = testAvailableConnectors(null);
+
+			assertNotNull(result, "Result should not be null when triggering connector test.");
 			verify(telemetryManagerMock, times(1)).run(any(), any(), any(), any(), any());
 		}
 	}


### PR DESCRIPTION
This pull request introduces a new set of value objects (VOs) to provide a structured, polymorphic, and serializable representation of monitor telemetry data for the MetricsHub Agent. It defines a hierarchy for monitor data, including individual monitors, per-type summaries, and aggregated statistics, all designed for efficient serialization and downstream AI processing. The changes also clarify and separate responsibilities for telemetry result handling.

Key changes include:

### Introduction of Polymorphic Monitor Data Model

- Added the `MonitorTypeItem` interface as a polymorphic base for monitor list items, with Jackson annotations for type discrimination between individual monitors and summary objects. (`MonitorTypeItem.java`)
- Created `MonitorVo` for representing individual monitor instances, including attributes, metrics, and text parameters. (`MonitorVo.java`)
- Created `MonitorTypeSummaryVo` for aggregating and summarizing monitor data per type, including numeric and state set metrics. (`MonitorTypeSummaryVo.java`)
- Added `MonitorsVo` to group monitors by type, where each list contains multiple monitors followed by a summary object. (`MonitorsVo.java`)

### Aggregated Metrics Support

- Introduced `NumericMetricStatsVo` to hold aggregated statistics (average, min, max, sum, count) for each numeric metric across all monitors of a type. (`NumericMetricStatsVo.java`)
- Introduced `StateSetCountVo` (renamed from `TelemetryResult`) to represent the count of monitors in each state for StateSet metrics. (`StateSetCountVo.java`) [[1]](diffhunk://#diff-eeea9d2aa175e09fce24ec202432d279bf63eaa18308abf20e8143437a810227L1-R7) [[2]](diffhunk://#diff-eeea9d2aa175e09fce24ec202432d279bf63eaa18308abf20e8143437a810227L24-R44)

### Telemetry Result Handling

- Replaced the previous `TelemetryResult` record with a new class under the `mcp` package, now wrapping either compressed telemetry data (`MonitorsVo`) or an error message, with appropriate constructors for each case. (`TelemetryResult.java`)

These changes lay the groundwork for more flexible and robust telemetry data handling, enabling downstream consumers (such as AI assistants) to efficiently process and summarize monitor data.