### PR TITLE
Fix windows package installation test script

### DIFF
--- a/.github/workflows/package-installation-tests.yml
+++ b/.github/workflows/package-installation-tests.yml
@@ -305,25 +305,20 @@ jobs:
           }
 
           if ($status -eq 'passed') {
-            $candidates = @(
-              "$env:ProgramFiles\\MetricsHub\\bin\\metricshub.bat",
-              "$env:ProgramFiles\\MetricsHub\\bin\\metricshub.exe",
-              "$env:ProgramFiles\\MetricsHub Community\\bin\\metricshub.bat",
-              "$env:ProgramFiles\\MetricsHub Community\\bin\\metricshub.exe",
-              "$env:ProgramFiles\\Metricshub\\bin\\metricshub.bat",
-              "$env:ProgramFiles\\Metricshub\\bin\\metricshub.exe"
-            )
+            $installRoot = Join-Path $env:ProgramFiles 'MetricsHub'
+            $binary = $null
 
-            $binary = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+            if (Test-Path $installRoot) {
+              $binary = Get-ChildItem -Path $installRoot -Recurse -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -ieq 'MetricsHub.exe' } |
+                Select-Object -ExpandProperty FullName -First 1
+            }
+
             if (-not $binary) {
               $status = 'failed'
-              $details = 'metricshub binary not found after msi installation'
+              $details = "MetricsHub.exe not found under $installRoot after msi installation"
             } else {
-              if ($binary.ToLowerInvariant().EndsWith('.bat')) {
-                $versionOutput = cmd /c "`"$binary`" --version" 2>&1 | Out-String
-              } else {
-                $versionOutput = & $binary --version 2>&1 | Out-String
-              }
+              $versionOutput = & $binary --version 2>&1 | Out-String
             }
           }
         }
@@ -335,19 +330,15 @@ jobs:
           }
           Expand-Archive -Path $package.FullName -DestinationPath $extractPath -Force
 
-          $binary = Get-ChildItem -Path $extractPath -Recurse -File |
-            Where-Object { $_.Name -ieq 'metricshub.bat' -or $_.Name -ieq 'metricshub.exe' } |
-            Select-Object -First 1
+          $binary = Get-ChildItem -Path $extractPath -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -ieq 'MetricsHub.exe' } |
+            Select-Object -ExpandProperty FullName -First 1
 
           if (-not $binary) {
             $status = 'failed'
-            $details = 'metricshub binary not found in zip archive'
+            $details = "MetricsHub.exe not found in zip archive under $extractPath"
           } else {
-            if ($binary.Extension -ieq '.bat') {
-              $versionOutput = cmd /c "`"$($binary.FullName)`" --version" 2>&1 | Out-String
-            } else {
-              $versionOutput = & $binary.FullName --version 2>&1 | Out-String
-            }
+            $versionOutput = & $binary --version 2>&1 | Out-String
           }
         }
 


### PR DESCRIPTION
This pull request updates the Windows binary detection logic in the `package-installation-tests` GitHub Actions workflow to improve reliability and consistency. The main changes involve searching for only the `MetricsHub.exe` binary (case-insensitive) after installation, rather than also allowing `.bat` files or community edition variants. This simplifies the test logic and error messages for both MSI and ZIP package types.

**Improvements to binary detection and test logic:**

* For MSI installations, the workflow now recursively searches under the `MetricsHub` installation directory for `MetricsHub.exe` only, and updates error messages to reflect this change. (`.github/workflows/package-installation-tests.yml`)
* For ZIP installations, the workflow now recursively searches for `MetricsHub.exe` only (case-insensitive), and updates error messages accordingly. (`.github/workflows/package-installation-tests.yml`)

These changes ensure that the workflow consistently validates the presence and version of the main executable, reducing ambiguity and potential false positives in the test suite.