### PR TITLE
Issue #1206: Web UI: Fix empty Connectors section when all connectors are failed

### DIFF
--- a/metricshub-web/react/src/components/explorer/views/monitors/MonitorsView.jsx
+++ b/metricshub-web/react/src/components/explorer/views/monitors/MonitorsView.jsx
@@ -52,14 +52,7 @@ const MonitorsView = ({
 		[lastUpdatedAt, _now],
 	);
 
-	// Check if there are any monitors across all connectors
-	const hasAnyMonitors = React.useMemo(
-		() =>
-			safeConnectors.some(
-				(connector) => Array.isArray(connector?.monitors) && connector.monitors.length > 0,
-			),
-		[safeConnectors],
-	);
+	const hasAnyConnectors = safeConnectors.length > 0;
 
 	const highlightedId = useScrollToHash();
 
@@ -69,7 +62,7 @@ const MonitorsView = ({
 		}
 	}, [highlightedId, resourceId, dispatch]);
 
-	if (!hasAnyMonitors) {
+	if (!hasAnyConnectors) {
 		return (
 			<Box>
 				<MonitorsHeader lastUpdatedLabel={lastUpdatedLabel} />

--- a/metricshub-web/react/src/components/explorer/views/monitors/MonitorsView.test.jsx
+++ b/metricshub-web/react/src/components/explorer/views/monitors/MonitorsView.test.jsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import MonitorsView from "./MonitorsView";
+import { renderWithReduxAndRouter } from "../../../../test/test-utils";
+
+vi.mock("./components/ConnectorAccordion", () => ({
+	default: ({ connector }) => <div>{`connector:${connector?.name || "unknown"}`}</div>,
+}));
+
+describe("MonitorsView", () => {
+	it("renders connectors even when they have no monitors", () => {
+		renderWithReduxAndRouter(
+			<MonitorsView connectors={[{ name: "ConnectorA", monitors: [] }]} lastUpdatedAt={Date.now()} />,
+		);
+
+		expect(screen.getByText("connector:ConnectorA")).toBeInTheDocument();
+		expect(screen.queryByText(/No connectors available for this resource/i)).not.toBeInTheDocument();
+	});
+
+	it("shows empty message when there are no connectors", () => {
+		renderWithReduxAndRouter(<MonitorsView connectors={[]} lastUpdatedAt={Date.now()} />);
+
+		expect(screen.getByText(/No connectors available for this resource/i)).toBeInTheDocument();
+	});
+});

--- a/metricshub-web/react/src/components/explorer/views/monitors/MonitorsView.test.jsx
+++ b/metricshub-web/react/src/components/explorer/views/monitors/MonitorsView.test.jsx
@@ -10,11 +10,16 @@ vi.mock("./components/ConnectorAccordion", () => ({
 describe("MonitorsView", () => {
 	it("renders connectors even when they have no monitors", () => {
 		renderWithReduxAndRouter(
-			<MonitorsView connectors={[{ name: "ConnectorA", monitors: [] }]} lastUpdatedAt={Date.now()} />,
+			<MonitorsView
+				connectors={[{ name: "ConnectorA", monitors: [] }]}
+				lastUpdatedAt={Date.now()}
+			/>,
 		);
 
 		expect(screen.getByText("connector:ConnectorA")).toBeInTheDocument();
-		expect(screen.queryByText(/No connectors available for this resource/i)).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/No connectors available for this resource/i),
+		).not.toBeInTheDocument();
 	});
 
 	it("shows empty message when there are no connectors", () => {


### PR DESCRIPTION

- On the explorer view, connectors that does not have monitors are not displayed. This have been fixed to make sure that all the connectors are displayed, no matter how many monitors they did detect.
- Tested on the UI.

# Tests
<img width="2506" height="542" alt="image" src="https://github.com/user-attachments/assets/d36213e9-065d-4a20-9ce3-32849eaec3ab" />
