### PR TITLE
Issue #1234: Fix incorrect auto-indentation in YAML editor after pressing Enter

### DIFF
--- a/metricshub-web/react/src/components/yaml-editor/YamlEditor.jsx
+++ b/metricshub-web/react/src/components/yaml-editor/YamlEditor.jsx
@@ -4,13 +4,13 @@ import { useTheme } from "@mui/material/styles";
 
 import CodeMirror from "@uiw/react-codemirror";
 import { yaml as cmYaml } from "@codemirror/lang-yaml";
-import { history, historyKeymap, defaultKeymap } from "@codemirror/commands";
 import { keymap, EditorView, Decoration, ViewPlugin } from "@codemirror/view";
 import { RangeSetBuilder } from "@codemirror/state";
 import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 import "./lint-fallback.css";
 import { buildYamlLinterExtension } from "../../utils/yaml-lint-utils";
 import { velocity } from "../../utils/codemirror-velocity";
+import { yamlMappingIndentService } from "../../utils/codemirror-yaml-indent";
 import { isVmFile } from "../../utils/file-type-utils";
 
 const LOCAL_STORAGE_KEY = "yaml-editor-doc";
@@ -105,18 +105,21 @@ export default function YamlEditor({
 	);
 
 	const extensions = React.useMemo(() => {
-		const km = [...defaultKeymap, ...historyKeymap];
-		if (onSave) {
-			km.unshift({
-				key: "Mod-s",
-				preventDefault: true,
-				run: (view) => {
-					if (!canSave) return true;
-					onSave(view.state.doc.toString());
-					return true;
-				},
-			});
-		}
+		// basicSetup already provides the default keymap, history, and history keymap,
+		// so only the editor-specific save binding is added here.
+		const saveKeymap = onSave
+			? [
+					{
+						key: "Mod-s",
+						preventDefault: true,
+						run: (view) => {
+							if (!canSave) return true;
+							onSave(view.state.doc.toString());
+							return true;
+						},
+					},
+				]
+			: [];
 
 		// Track selection changes and rebuild markers only for selected ranges
 		const selectionWhitespaceMarkers = ViewPlugin.fromClass(
@@ -160,10 +163,12 @@ export default function YamlEditor({
 		});
 
 		// Select language mode based on file type
-		const langExtension = isVmFile(fileName) ? velocity() : cmYaml();
+		const isVelocityFile = isVmFile(fileName);
+		const langExtension = isVelocityFile ? velocity() : cmYaml();
 
 		return [
 			langExtension,
+			...(isVelocityFile ? [] : [yamlMappingIndentService]),
 			indentationMarkers({
 				// Make indent guides clearer in dark mode and a bit darker in light mode
 				colors: {
@@ -174,8 +179,7 @@ export default function YamlEditor({
 				},
 			}),
 			selectionWhitespaceMarkers,
-			history(),
-			keymap.of(km),
+			keymap.of(saveKeymap),
 			followSelection,
 			...validationExtension,
 		];
@@ -241,9 +245,8 @@ export default function YamlEditor({
 						lineNumbers: true,
 						highlightActiveLine: true,
 						foldGutter: true,
-						// Re-enable default search behavior and keymap (Ctrl/Cmd+F)
+						// Keep the default search keymap (Ctrl/Cmd+F)
 						searchKeymap: true,
-						search: true,
 					}}
 					theme={theme.palette.mode}
 					onCreateEditor={(view) => {

--- a/metricshub-web/react/src/utils/codemirror-yaml-indent.js
+++ b/metricshub-web/react/src/utils/codemirror-yaml-indent.js
@@ -1,0 +1,249 @@
+import { indentService } from "@codemirror/language";
+
+/**
+ * Finds the indentation column CodeMirror should use after pressing Enter on a
+ * YAML mapping line.
+ *
+ * @param {string} lineText The full current line text.
+ * @param {import("@codemirror/language").IndentContext} context The indentation context.
+ * @param {string} [previousLineText] The immediately preceding physical line, when available.
+ * @returns {number|null} The desired indentation column, or null to use the default behavior.
+ */
+export function getYamlMappingNewlineIndentColumn(lineText, context, previousLineText) {
+	const leadingWhitespace = lineText.match(/^\s*/)?.[0] ?? "";
+	const trimmedLine = lineText.slice(leadingWhitespace.length);
+	const leadingColumn = context.countColumn(leadingWhitespace);
+
+	if (!trimmedLine) {
+		return null;
+	}
+
+	// A comment line keeps its own indentation on the next line, except when it
+	// directly opens a deeper block (see resolveCommentIndentColumn).
+	if (trimmedLine.startsWith("#")) {
+		return resolveCommentIndentColumn(leadingColumn, previousLineText, context);
+	}
+
+	const sequenceMatch = trimmedLine.match(/^-\s+/);
+	const mappingText = sequenceMatch ? trimmedLine.slice(sequenceMatch[0].length) : trimmedLine;
+	const mappingColonIndex = findUnquotedMappingColon(mappingText);
+
+	if (mappingColonIndex <= 0) {
+		return sequenceMatch ? leadingColumn : null;
+	}
+
+	const valueText = mappingText.slice(mappingColonIndex + 1).trimStart();
+	const sequenceOffset = sequenceMatch ? context.unit : 0;
+
+	if (!valueText || valueText.startsWith("#")) {
+		return leadingColumn + sequenceOffset + context.unit;
+	}
+
+	// Block scalars (| and >) and open flow collections defer to CodeMirror, which
+	// understands how to indent their continuation lines.
+	if (/^[|>](?:\s|$)/.test(valueText) || hasUnbalancedFlowOpener(valueText)) {
+		return null;
+	}
+
+	return leadingColumn + sequenceOffset;
+}
+
+/**
+ * CodeMirror indentation service that fixes YAML mapping indentation when the
+ * native Enter command asks for it.
+ */
+export const yamlMappingIndentService = indentService.of((context, pos) => {
+	if (context.simulatedBreak !== pos) {
+		return undefined;
+	}
+
+	const currentLine = context.lineAt(pos, -1);
+	const previousLineText = getPreviousLineText(context, currentLine.from);
+
+	return (
+		getYamlMappingNewlineIndentColumn(currentLine.text, context, previousLineText) ?? undefined
+	);
+});
+
+/**
+ * Resolves the indentation for the line following a comment line.
+ *
+ * Comments keep their own indentation by default. The only exception is the
+ * narrow, unambiguous case where the comment directly follows a block-opening
+ * key (a line ending with an unquoted colon) and is indented at or shallower
+ * than that key: there the next line belongs inside the freshly opened block.
+ * Intentional dedents are preserved because a dedented comment's preceding
+ * physical line is another comment, not a colon line.
+ *
+ * @param {number} commentColumn The comment line's own indentation column.
+ * @param {string} [previousLineText] The immediately preceding physical line.
+ * @param {import("@codemirror/language").IndentContext} context The indentation context.
+ * @returns {number} The desired indentation column.
+ */
+function resolveCommentIndentColumn(commentColumn, previousLineText, context) {
+	if (previousLineText == null) {
+		return commentColumn;
+	}
+
+	const previousLeading = previousLineText.match(/^\s*/)?.[0] ?? "";
+	const previousTrimmed = previousLineText.slice(previousLeading.length);
+	const previousColumn = context.countColumn(previousLeading);
+	const mappingText = previousTrimmed.replace(/^-\s+/, "");
+	const colonIndex = findUnquotedMappingColon(mappingText);
+	const opensBlock = colonIndex >= 0 && mappingText.slice(colonIndex + 1).trim() === "";
+
+	if (opensBlock && commentColumn <= previousColumn) {
+		return previousColumn + context.unit;
+	}
+
+	return commentColumn;
+}
+
+/**
+ * Returns the text of the physical line immediately preceding the given line.
+ *
+ * @param {import("@codemirror/language").IndentContext} context The indentation context.
+ * @param {number} lineFrom The start position of the current line.
+ * @returns {string|undefined} The previous line text, or undefined when at the document start.
+ */
+function getPreviousLineText(context, lineFrom) {
+	const { doc } = context.state;
+	const currentLine = doc.lineAt(lineFrom);
+
+	if (currentLine.number <= 1) {
+		return undefined;
+	}
+
+	return doc.line(currentLine.number - 1).text;
+}
+
+/**
+ * Determines whether the given value text opens a flow collection ({ or [) that
+ * is not closed on the same line.
+ *
+ * @param {string} text The value text to inspect.
+ * @returns {boolean} True when an unbalanced flow opener is present.
+ */
+function hasUnbalancedFlowOpener(text) {
+	let depth = 0;
+	let i = 0;
+
+	while (i < text.length) {
+		const char = text[i];
+
+		if (char === '"') {
+			i = skipDoubleQuoted(text, i);
+			continue;
+		}
+
+		if (char === "'") {
+			i = skipSingleQuoted(text, i);
+			continue;
+		}
+
+		if (char === "#" && (i === 0 || /\s/.test(text[i - 1]))) {
+			break;
+		}
+
+		if (char === "{" || char === "[") {
+			depth += 1;
+		} else if (char === "}" || char === "]") {
+			depth = Math.max(0, depth - 1);
+		}
+
+		i += 1;
+	}
+
+	return depth > 0;
+}
+
+/**
+ * Finds the index of the unquoted colon that separates a YAML mapping key from
+ * its value, or -1 when the text is not a mapping entry.
+ *
+ * @param {string} text The text to scan (leading sequence markers removed).
+ * @returns {number} The colon index, or -1.
+ */
+function findUnquotedMappingColon(text) {
+	let i = 0;
+
+	while (i < text.length) {
+		const char = text[i];
+
+		if (char === '"') {
+			i = skipDoubleQuoted(text, i);
+			continue;
+		}
+
+		if (char === "'") {
+			i = skipSingleQuoted(text, i);
+			continue;
+		}
+
+		if (char === "#" && (i === 0 || /\s/.test(text[i - 1]))) {
+			return -1;
+		}
+
+		if (char === ":" && isMappingSeparator(text, i)) {
+			return i;
+		}
+
+		i += 1;
+	}
+
+	return -1;
+}
+
+/**
+ * Skips a double-quoted scalar starting at the opening quote. Backslash escapes
+ * the following character (YAML double-quote escaping).
+ *
+ * @param {string} text The text being scanned.
+ * @param {number} start The index of the opening double quote.
+ * @returns {number} The index just past the closing quote, or the text length when unterminated.
+ */
+function skipDoubleQuoted(text, start) {
+	for (let i = start + 1; i < text.length; i += 1) {
+		const char = text[i];
+
+		if (char === "\\") {
+			i += 1;
+			continue;
+		}
+
+		if (char === '"') {
+			return i + 1;
+		}
+	}
+
+	return text.length;
+}
+
+/**
+ * Skips a single-quoted scalar starting at the opening quote. A doubled quote
+ * ('') is a literal quote; backslash is literal (YAML single-quote escaping).
+ *
+ * @param {string} text The text being scanned.
+ * @param {number} start The index of the opening single quote.
+ * @returns {number} The index just past the closing quote, or the text length when unterminated.
+ */
+function skipSingleQuoted(text, start) {
+	for (let i = start + 1; i < text.length; i += 1) {
+		if (text[i] === "'") {
+			if (text[i + 1] === "'") {
+				i += 1;
+				continue;
+			}
+
+			return i + 1;
+		}
+	}
+
+	return text.length;
+}
+
+function isMappingSeparator(text, index) {
+	const nextChar = text[index + 1] ?? "";
+
+	return nextChar === "" || /\s/.test(nextChar);
+}

--- a/metricshub-web/react/src/utils/codemirror-yaml-indent.js
+++ b/metricshub-web/react/src/utils/codemirror-yaml-indent.js
@@ -1,5 +1,10 @@
 import { indentService } from "@codemirror/language";
 
+// Matches a YAML block scalar header: a literal (|) or folded (>) indicator,
+// optionally followed by indentation (1-9) and chomping (- or +) indicators in
+// either order, then end-of-line or whitespace (e.g. |, >, |-, |+, >2, |2-, >+1).
+const BLOCK_SCALAR_HEADER = /^[|>](?:[1-9][-+]?|[-+][1-9]?)?(?:\s|$)/;
+
 /**
  * Finds the indentation column CodeMirror should use after pressing Enter on a
  * YAML mapping line.
@@ -41,7 +46,7 @@ export function getYamlMappingNewlineIndentColumn(lineText, context, previousLin
 
 	// Block scalars (| and >) and open flow collections defer to CodeMirror, which
 	// understands how to indent their continuation lines.
-	if (/^[|>](?:\s|$)/.test(valueText) || hasUnbalancedFlowOpener(valueText)) {
+	if (BLOCK_SCALAR_HEADER.test(valueText) || hasUnbalancedFlowOpener(valueText)) {
 		return null;
 	}
 
@@ -242,6 +247,14 @@ function skipSingleQuoted(text, start) {
 	return text.length;
 }
 
+/**
+ * Tests whether the character at the given index is a mapping separator colon
+ * (:) followed by end-of-line or whitespace.
+ *
+ * @param {string} text The text being scanned.
+ * @param {number} index The index of the colon to test.
+ * @returns {boolean} True when the colon is a mapping separator.
+ */
 function isMappingSeparator(text, index) {
 	const nextChar = text[index + 1] ?? "";
 

--- a/metricshub-web/react/src/utils/codemirror-yaml-indent.test.js
+++ b/metricshub-web/react/src/utils/codemirror-yaml-indent.test.js
@@ -1,0 +1,122 @@
+import { EditorState } from "@codemirror/state";
+import { getIndentation, IndentContext } from "@codemirror/language";
+import { yaml as cmYaml } from "@codemirror/lang-yaml";
+import { describe, expect, it } from "vitest";
+import {
+	getYamlMappingNewlineIndentColumn,
+	yamlMappingIndentService,
+} from "./codemirror-yaml-indent";
+
+const indentContext = {
+	unit: 2,
+	countColumn: (value) => value.length,
+};
+
+/**
+ * Computes the indentation column the native Enter command would apply at the end
+ * of the given document, using the same extension stack as the editor: the YAML
+ * language plus our indentation service layered on top. This proves the service
+ * overrides CodeMirror's native YAML indentation rather than running in isolation.
+ *
+ * @param {string} doc The document text; indentation is queried at its end.
+ * @returns {number|null} The resolved indentation column.
+ */
+function indentAtEnd(doc) {
+	const state = EditorState.create({
+		doc,
+		extensions: [cmYaml(), yamlMappingIndentService],
+	});
+	const context = new IndentContext(state, { simulateBreak: doc.length });
+
+	return getIndentation(context, doc.length);
+}
+
+describe("codemirror-yaml-indent", () => {
+	it("keeps the current indentation after an inline mapping value with a comment", () => {
+		expect(
+			getYamlMappingNewlineIndentColumn("           https: true # enter key", indentContext),
+		).toBe(11);
+	});
+
+	it("keeps sequence item mappings aligned with the current item", () => {
+		expect(getYamlMappingNewlineIndentColumn("  - name: localhost", indentContext)).toBe(4);
+	});
+
+	it("keeps sequence scalars aligned with the current sequence item", () => {
+		expect(
+			getYamlMappingNewlineIndentColumn(
+				"  - --config=file:C:\\ProgramData\\MetricsHub\\otel\\otel-config.yaml",
+				indentContext,
+			),
+		).toBe(2);
+		expect(getYamlMappingNewlineIndentColumn("  - https://example:443/path", indentContext)).toBe(
+			2,
+		);
+	});
+
+	it("resolves quoted keys with escaped quotes as mappings", () => {
+		// Single-quote escaping is via doubling ('') and backslash is literal.
+		expect(getYamlMappingNewlineIndentColumn("  'it''s': value", indentContext)).toBe(2);
+		expect(getYamlMappingNewlineIndentColumn("  'a\\': value", indentContext)).toBe(2);
+		// Double-quote escaping uses backslash, so the inner colon is ignored.
+		expect(getYamlMappingNewlineIndentColumn('  "a\\":b": value', indentContext)).toBe(2);
+	});
+
+	it("defers for open flow collections but aligns balanced ones", () => {
+		expect(getYamlMappingNewlineIndentColumn("  key: {", indentContext)).toBeNull();
+		expect(getYamlMappingNewlineIndentColumn("  key: [1, 2,", indentContext)).toBeNull();
+		expect(getYamlMappingNewlineIndentColumn("  key: { a: 1 }", indentContext)).toBe(2);
+	});
+
+	it("indents one level deeper after nested mapping keys", () => {
+		expect(getYamlMappingNewlineIndentColumn("      localhost:", indentContext)).toBe(8);
+		expect(getYamlMappingNewlineIndentColumn("          http:", indentContext)).toBe(12);
+		expect(getYamlMappingNewlineIndentColumn("          http: # comment", indentContext)).toBe(12);
+	});
+
+	it("indents one level deeper after sequence mapping keys", () => {
+		expect(getYamlMappingNewlineIndentColumn("  - group:", indentContext)).toBe(6);
+	});
+
+	it("keeps comment lines at their own indentation", () => {
+		expect(
+			getYamlMappingNewlineIndentColumn("  # MetricsHub Default configuration", indentContext),
+		).toBe(2);
+		expect(getYamlMappingNewlineIndentColumn("          # https: true", indentContext)).toBe(10);
+	});
+
+	it("falls back to CodeMirror indentation for block scalars", () => {
+		expect(getYamlMappingNewlineIndentColumn("          script: |", indentContext)).toBeNull();
+	});
+
+	it("overrides native YAML indentation for an inline mapping value", () => {
+		expect(indentAtEnd("      protocols:\n        https: true # enter key")).toBe(8);
+	});
+
+	it("overrides native YAML indentation after a nested mapping key", () => {
+		expect(indentAtEnd("      localhost:")).toBe(8);
+	});
+
+	it("overrides native YAML indentation for a sequence scalar with a colon", () => {
+		const doc =
+			'otelCollector:\n  commandLine:\n  - "C:\\\\Program Files\\\\MetricsHub\\\\otel\\\\otelcol-contrib.exe"\n  - --config=file:C:\\ProgramData\\MetricsHub\\otel\\otel-config.yaml';
+
+		expect(indentAtEnd(doc)).toBe(2);
+	});
+
+	it("overrides native YAML indentation after a comment block", () => {
+		expect(
+			indentAtEnd(
+				"otel:\n  # OpenTelemetry SDK Autoconfigure properties\n  # MetricsHub Default configuration",
+			),
+		).toBe(2);
+	});
+
+	it("deepens a comment that opens an under-indented block", () => {
+		expect(indentAtEnd("attributes:\n# fill me in")).toBe(2);
+	});
+
+	it("preserves an intentionally dedented comment", () => {
+		expect(indentAtEnd("parent:\n  child:\n    # deep comment\n  # dedented comment")).toBe(2);
+	});
+});

--- a/metricshub-web/react/src/utils/codemirror-yaml-indent.test.js
+++ b/metricshub-web/react/src/utils/codemirror-yaml-indent.test.js
@@ -87,6 +87,18 @@ describe("codemirror-yaml-indent", () => {
 
 	it("falls back to CodeMirror indentation for block scalars", () => {
 		expect(getYamlMappingNewlineIndentColumn("          script: |", indentContext)).toBeNull();
+		expect(getYamlMappingNewlineIndentColumn("          script: >", indentContext)).toBeNull();
+		// Chomping and explicit indentation indicators, in either order.
+		expect(getYamlMappingNewlineIndentColumn("          script: |-", indentContext)).toBeNull();
+		expect(getYamlMappingNewlineIndentColumn("          script: |+", indentContext)).toBeNull();
+		expect(getYamlMappingNewlineIndentColumn("          script: >-", indentContext)).toBeNull();
+		expect(getYamlMappingNewlineIndentColumn("          script: |2", indentContext)).toBeNull();
+		expect(getYamlMappingNewlineIndentColumn("          script: |2-", indentContext)).toBeNull();
+		expect(getYamlMappingNewlineIndentColumn("          script: >+1", indentContext)).toBeNull();
+		// A block scalar header may be followed by a comment.
+		expect(
+			getYamlMappingNewlineIndentColumn("          script: |- # keep", indentContext),
+		).toBeNull();
 	});
 
 	it("overrides native YAML indentation for an inline mapping value", () => {


### PR DESCRIPTION
This pull request introduces a custom indentation service for YAML files in the CodeMirror-based `YamlEditor` component, improving the accuracy and user experience of YAML editing. The main focus is to override CodeMirror's default YAML indentation behavior with logic that better handles YAML mappings, sequences, comments, and edge cases, while leaving Velocity files and special YAML constructs unaffected. Comprehensive tests are included to ensure the new indentation logic works as intended.

**YAML indentation improvements:**

* Added a new `yamlMappingIndentService` in `codemirror-yaml-indent.js` that customizes how indentation is calculated when pressing Enter on YAML mapping lines, handling mappings, sequences, comments, block scalars, and flow collections more accurately.
* Integrated the new indentation service into the `YamlEditor` component so it is applied only for YAML files (not Velocity files).
* Added a thorough test suite (`codemirror-yaml-indent.test.js`) to verify the new indentation logic across a wide range of YAML scenarios, including mappings, sequences, quoted keys, comments, and block scalars.

**Editor configuration and cleanup:**

* Simplified the keymap setup in `YamlEditor.jsx` to only add a custom save binding, relying on CodeMirror's `basicSetup` for default keymaps and history. [[1]](diffhunk://#diff-2f96502341fd3679303102c74374d274a92eb1a7679fb2c654321fc69f257326L108-R122) [[2]](diffhunk://#diff-2f96502341fd3679303102c74374d274a92eb1a7679fb2c654321fc69f257326L177-R182)
* Cleaned up editor options to clarify that the default search keymap remains enabled.

**Dependency management:**

* Removed unused imports related to CodeMirror's default and history keymaps, since these are now handled by `basicSetup`.

<img width="853" height="624" alt="image" src="https://github.com/user-attachments/assets/4759b781-c133-4ef1-bb66-68cb68d90556" />
<img width="1176" height="503" alt="image" src="https://github.com/user-attachments/assets/a20017c1-8d83-4d2c-b35d-1bdabe212a3c" />
<img width="1075" height="382" alt="image" src="https://github.com/user-attachments/assets/b83a3033-3ec1-4548-8e07-5469dabca76c" />
<img width="1047" height="378" alt="image" src="https://github.com/user-attachments/assets/41cc56f8-083a-4179-a816-79cf3e1d59d9" />
<img width="826" height="209" alt="image" src="https://github.com/user-attachments/assets/f90dc8b4-8b23-45fc-abc8-021dd812e61e" />


