### PR TITLE
Issue #1236: Display fallback icon for unknown monitors in Connector Explorer accordion

### DIFF
--- a/metricshub-web/react/src/components/explorer/views/monitor-type/MonitorTypeView.jsx
+++ b/metricshub-web/react/src/components/explorer/views/monitor-type/MonitorTypeView.jsx
@@ -29,6 +29,7 @@ import EntityHeader from "../common/EntityHeader";
 import InstanceMetricsTable from "../monitors/components/InstanceMetricsTable";
 import InstanceNameWithAttributes from "../monitors/components/InstanceNameWithAttributes";
 import MonitorTypeIcon from "../monitors/icons/MonitorTypeIcon";
+import { MonitorIcon } from "../../../common/MetricIcons";
 import MetricValueCell from "../common/MetricValueCell";
 import { renderMetricHeader } from "../common/metric-column-helper";
 import {
@@ -229,7 +230,13 @@ const MonitorTypeView = ({ resourceName, resourceGroupName, connectorId, monitor
 		<Box sx={{ p: 3, display: "flex", flexDirection: "column" }}>
 			<EntityHeader
 				title={`${decodedName} : ${decodedMonitorType} (${monitorData.connectorName})`}
-				icon={<MonitorTypeIcon type={decodedMonitorType} fontSize="large" />}
+				icon={
+					<MonitorTypeIcon
+						type={decodedMonitorType}
+						fontSize="large"
+						fallback={<MonitorIcon sx={{ fontSize: 32 }} />}
+					/>
+				}
 			/>
 
 			<Box sx={{ borderBottom: 1, borderColor: "divider", mb: 2 }}>

--- a/metricshub-web/react/src/components/explorer/views/monitors/components/ConnectorAccordion.jsx
+++ b/metricshub-web/react/src/components/explorer/views/monitors/components/ConnectorAccordion.jsx
@@ -35,6 +35,7 @@ import { paths } from "../../../../../paths";
 import { flashBlueAnimation } from "../../../../../utils/animations";
 import { SUPPORT_URL } from "../../../../../utils/constants";
 import AppAlert from "../../../../common/AppAlert";
+import { MonitorIcon } from "../../../../common/MetricIcons";
 import MonitorTypeIcon from "../icons/MonitorTypeIcon";
 
 import { useDataGridColumnWidths } from "../../common/use-data-grid-column-widths";
@@ -168,7 +169,10 @@ const MonitorAccordion = React.memo(function MonitorAccordion({
 							gap: 1,
 						}}
 					>
-						<MonitorTypeIcon type={prettifyKey(monitor.name)} />
+						<MonitorTypeIcon
+							type={prettifyKey(monitor.name)}
+							fallback={<MonitorIcon sx={{ fontSize: 20 }} />}
+						/>
 						<Tooltip title="Open Monitor Type Page" arrow placement="top" disableInteractive>
 							<Box component="span" sx={{ display: "inline-block" }}>
 								<Typography


### PR DESCRIPTION
Pass MonitorIcon as the `fallback` prop to MonitorTypeIcon in ConnectorAccordion so unknown/custom monitor types render a default icon instead of nothing, matching the visual treatment of known monitor types.

<img width="1157" height="1183" alt="image" src="https://github.com/user-attachments/assets/4fd76f3c-dee8-497f-b373-e941c518e444" />
