### PR TITLE
Issue #1254: MetricsHub CLI hangs due to a blocking `whoami` Windows command

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/helper/ConfigHelper.java
@@ -33,20 +33,13 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.AclEntry;
-import java.nio.file.attribute.AclEntryPermission;
-import java.nio.file.attribute.AclEntryType;
-import java.nio.file.attribute.AclFileAttributeView;
-import java.nio.file.attribute.GroupPrincipal;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -298,9 +291,6 @@ public class ConfigHelper {
 		// Generate the configuration file config/metricshub.yaml if not present
 		generateDefaultConfigurationFileIfEmptyDir(configDirectory);
 
-		// Set the configuration files write-permissions on Windows to allow writing
-		setUserPermissionsOnWindows(configDirectory);
-
 		return configDirectory;
 	}
 
@@ -372,110 +362,6 @@ public class ConfigHelper {
 
 		// Copy the example configuration file to the configuration directory
 		Files.copy(exampleConfigPath, targetConfigPath, StandardCopyOption.REPLACE_EXISTING).toFile();
-	}
-
-	/**
-	 * Set user write permissions on the configuration files
-	 *
-	 * @param configDirectory the configuration directory where all the configuration files are located
-	 *
-	 * @throws IOException if the permissions cannot be set
-	 */
-	static void setUserPermissionsOnWindows(final Path configDirectory) throws IOException {
-		if (LocalOsHandler.isWindows()) {
-			// Set write permissions configuration files on Windows
-			try (Stream<Path> stream = Files.list(configDirectory).filter(Files::isRegularFile)) {
-				// Set write permissions for all files in the configuration directory
-				stream.forEach(ConfigHelper::setUserPermissions);
-			}
-		}
-	}
-
-	/**
-	 * Finds the Windows "Users" group name for the current user by executing
-	 * the {@code whoami /groups} command and searching for the well-known
-	 * SID {@code S-1-5-32-545}.
-	 *
-	 * @return the localized "Users" group name if found, or {@code null} if not found or on error
-	 */
-	static String findUserGroup() {
-		Process process = null;
-		try {
-			// Run the Windows "whoami /groups" command
-			process = new ProcessBuilder("whoami", "/groups").start();
-
-			try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-				// Filter for the "Users" group SID and extract the group name
-				String group = reader
-					.lines()
-					.filter(line -> line.contains("S-1-5-32-545")) // SID for "Users"
-					.map(line -> line.split("\\s+")[0]) // extract localized group name
-					.findFirst()
-					.orElse(null);
-
-				process.waitFor();
-				return group;
-			}
-		} catch (IOException e) {
-			log.error("Failed to execute 'whoami /groups' command", e);
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt(); // restore interrupted status
-			log.error("Process was interrupted while waiting for completion", e);
-		} catch (Exception e) {
-			log.error("Unexpected error while finding user group", e);
-		} finally {
-			if (process != null) {
-				process.destroy();
-			}
-		}
-		return null;
-	}
-
-	/**
-	 * Set write permission for this configuration file identified by its path.
-	 *
-	 * @param configPath the configuration file absolute path
-	 */
-	static void setUserPermissions(final Path configPath) {
-		try {
-			final GroupPrincipal users = configPath
-				.getFileSystem()
-				.getUserPrincipalLookupService()
-				.lookupPrincipalByGroupName(findUserGroup());
-
-			// get view
-			final AclFileAttributeView view = Files.getFileAttributeView(configPath, AclFileAttributeView.class);
-
-			// create ACE to give "Users" access
-			final AclEntry entry = AclEntry.newBuilder()
-				.setType(AclEntryType.ALLOW)
-				.setPrincipal(users)
-				.setPermissions(
-					AclEntryPermission.WRITE_DATA,
-					AclEntryPermission.WRITE_ATTRIBUTES,
-					AclEntryPermission.WRITE_ACL,
-					AclEntryPermission.WRITE_OWNER,
-					AclEntryPermission.WRITE_NAMED_ATTRS,
-					AclEntryPermission.READ_DATA,
-					AclEntryPermission.READ_ACL,
-					AclEntryPermission.READ_ATTRIBUTES,
-					AclEntryPermission.READ_NAMED_ATTRS,
-					AclEntryPermission.DELETE,
-					AclEntryPermission.APPEND_DATA,
-					AclEntryPermission.DELETE
-				)
-				.build();
-
-			// read ACL, insert ACE, re-write ACL
-			final List<AclEntry> acl = view.getAcl();
-
-			// insert before any DENY entries
-			acl.add(0, entry);
-			view.setAcl(acl);
-		} catch (Exception e) {
-			log.error("Could not set write permissions to file: {}. Error: {}", configPath.toString(), e.getMessage());
-			log.debug("Exception: ", e);
-		}
 	}
 
 	/**

--- a/metricshub-agent/src/test/java/org/metricshub/agent/helper/ConfigHelperTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/helper/ConfigHelperTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -127,23 +126,10 @@ class ConfigHelperTest {
 	}
 
 	@Test
-	@EnabledOnOs(OS.WINDOWS)
-	void testFindUserGroup_onWindows() {
-		String group = ConfigHelper.findUserGroup();
-
-		// Assert we got a group name
-		assertNotNull(group, "The Users group should be found on Windows");
-		assertFalse(group.isBlank(), "The Users group name should not be blank");
-	}
-
-	@Test
-	@EnabledOnOs(OS.WINDOWS)
-	void testGenerateDefaultConfigFileWithWritePermissions() throws IOException {
+	void testGenerateDefaultConfigurationFileIfEmptyDir() throws IOException {
 		try (final MockedStatic<ConfigHelper> mockedConfigHelper = mockStatic(ConfigHelper.class)) {
-			// Build a config directory
-			final Path configDir = Files.createDirectories(tempDir.resolve("metricshub\\config").toAbsolutePath());
+			final Path configDir = Files.createDirectories(tempDir.resolve("config"));
 
-			// Create the example file
 			final Path examplePath = Files.createDirectories(configDir.resolve("example")).resolve(CONFIG_EXAMPLE_FILENAME);
 			Files.copy(
 				Path.of("src", "test", "resources", "config", "metricshub", DEFAULT_CONFIG_FILENAME),
@@ -151,28 +137,17 @@ class ConfigHelperTest {
 				StandardCopyOption.REPLACE_EXISTING
 			);
 
-			// Generating default config should be a real call
 			mockedConfigHelper
 				.when(() -> ConfigHelper.generateDefaultConfigurationFileIfEmptyDir(configDir))
 				.thenCallRealMethod();
-
-			// Setting user permissions should be a real call
-			mockedConfigHelper.when(() -> ConfigHelper.setUserPermissionsOnWindows(configDir)).thenCallRealMethod();
-			mockedConfigHelper.when(() -> ConfigHelper.setUserPermissions(any(Path.class))).thenCallRealMethod();
-
-			// Mock getSubPath as it will try to retrieve the example file deployed in production environment
 			mockedConfigHelper.when(() -> ConfigHelper.getSubPath(anyString())).thenReturn(examplePath);
 
-			// Mock getSourceDirectory as it will try to retrieve the example file deployed in production environment
 			ConfigHelper.generateDefaultConfigurationFileIfEmptyDir(configDir);
 
-			final File file = configDir.resolve(DEFAULT_CONFIG_FILENAME).toFile();
-
-			assertTrue(file.exists(), "File should exist");
-
-			ConfigHelper.setUserPermissionsOnWindows(configDir);
-
-			assertTrue(file.canWrite(), "File should be writable");
+			assertTrue(
+				Files.exists(configDir.resolve(DEFAULT_CONFIG_FILENAME)),
+				"Default configuration file should be created in an empty directory"
+			);
 		}
 	}
 


### PR DESCRIPTION
- Added filtering for backup file names in both ConfigurationFilesService and OtelConfigurationFilesService to ensure only valid backup files are processed.
- Updated tests to verify that only convention-compliant backup files are listed, ignoring unexpected files.
- Adjusted the fetchConfigList and fetchOtelConfigList thunks to filter out invalid backup files from the response.