### PR TITLE
Issue #1249: A backup folder under /config causes the Configuration page to break

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
@@ -58,6 +58,7 @@ import org.metricshub.engine.extension.ExtensionManager;
 import org.metricshub.web.AgentContextHolder;
 import org.metricshub.web.dto.ConfigurationFile;
 import org.metricshub.web.exception.ConfigFilesException;
+import org.metricshub.web.util.BackupFileNames;
 import org.springframework.stereotype.Service;
 
 /**
@@ -694,6 +695,7 @@ public class ConfigurationFilesService {
 			return files
 				.filter(Files::isRegularFile)
 				.filter(ConfigurationFilesService::hasAllowedExtension)
+				.filter(path -> BackupFileNames.isBackupFileName(path.getFileName().toString()))
 				.map(this::buildConfigurationFile)
 				.filter(Objects::nonNull)
 				.sorted(Comparator.comparing(ConfigurationFile::getName, String.CASE_INSENSITIVE_ORDER))

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/OtelConfigurationFilesService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/OtelConfigurationFilesService.java
@@ -51,6 +51,7 @@ import org.metricshub.agent.helper.ConfigHelper;
 import org.metricshub.agent.helper.OtelConfigHelper;
 import org.metricshub.web.dto.ConfigurationFile;
 import org.metricshub.web.exception.ConfigFilesException;
+import org.metricshub.web.util.BackupFileNames;
 import org.springframework.stereotype.Service;
 
 /**
@@ -710,6 +711,7 @@ public class OtelConfigurationFilesService {
 			return files
 				.filter(Files::isRegularFile)
 				.filter(OtelConfigurationFilesService::hasAllowedExtension)
+				.filter(path -> BackupFileNames.isBackupFileName(path.getFileName().toString()))
 				.map(this::buildConfigurationFile)
 				.filter(Objects::nonNull)
 				.sorted(Comparator.comparing(ConfigurationFile::getName, String.CASE_INSENSITIVE_ORDER))

--- a/metricshub-agent/src/main/java/org/metricshub/web/util/BackupFileNames.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/util/BackupFileNames.java
@@ -1,0 +1,50 @@
+package org.metricshub.web.util;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.regex.Pattern;
+
+/**
+ * Utility for backup file naming conventions used by the configuration UI.
+ * <p>
+ * Backup files follow the pattern {@code backup-YYYYMMDD-HHMMSS__<original-name>},
+ * matching the frontend {@code backup-names.js} module.
+ */
+public final class BackupFileNames {
+
+	/**
+	 * Pattern for valid backup filenames produced by the UI backup feature.
+	 */
+	private static final Pattern BACKUP_FILE_NAME_PATTERN = Pattern.compile("^backup-(\\d{8}-\\d{6})__(.+)$");
+
+	private BackupFileNames() {}
+
+	/**
+	 * Returns {@code true} when the given filename follows the backup naming convention.
+	 *
+	 * @param fileName the simple file name (no path separators)
+	 * @return {@code true} if the name matches the backup pattern
+	 */
+	public static boolean isBackupFileName(final String fileName) {
+		return fileName != null && BACKUP_FILE_NAME_PATTERN.matcher(fileName).matches();
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/service/ConfigurationFilesServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/service/ConfigurationFilesServiceTest.java
@@ -351,13 +351,30 @@ class ConfigurationFilesServiceTest {
 	@Test
 	void testBackupVmFile() throws Exception {
 		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+		final String backupName = "backup-20250101-120000__config.vm";
 
-		service.saveOrUpdateBackupFile("backup-config.vm", "#set($x=1)");
+		service.saveOrUpdateBackupFile(backupName, "#set($x=1)");
 		final Path backupDir = tempConfigDir.resolve("backup");
-		assertTrue(Files.exists(backupDir.resolve("backup-config.vm")), "VM backup file should be created");
+		assertTrue(Files.exists(backupDir.resolve(backupName)), "VM backup file should be created");
 
 		List<ConfigurationFile> backups = service.listAllBackupFiles();
 		assertEquals(1, backups.size(), "Backup list should contain one entry");
-		assertEquals("backup-config.vm", backups.get(0).getName(), "Backup name should match");
+		assertEquals(backupName, backups.get(0).getName(), "Backup name should match");
+	}
+
+	@Test
+	void testListAllBackupFilesIgnoresUnexpectedFiles() throws Exception {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+		final Path backupDir = tempConfigDir.resolve("backup");
+		Files.createDirectories(backupDir);
+		Files.writeString(backupDir.resolve("backup-20250101-120000__config.yaml"), "key: value");
+		Files.writeString(backupDir.resolve("random-notes.txt"), "ignore me");
+		Files.writeString(backupDir.resolve("legacy-backup.yaml"), "legacy");
+		Files.writeString(backupDir.resolve("backup-config.vm"), "#set($x=1)");
+
+		final List<ConfigurationFile> backups = service.listAllBackupFiles();
+
+		assertEquals(1, backups.size(), "Only convention-compliant backup files should be listed");
+		assertEquals("backup-20250101-120000__config.yaml", backups.get(0).getName());
 	}
 }

--- a/metricshub-agent/src/test/java/org/metricshub/web/service/OtelConfigurationFilesServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/service/OtelConfigurationFilesServiceTest.java
@@ -195,4 +195,19 @@ class OtelConfigurationFilesServiceTest {
 		backups = service.listAllBackupFiles();
 		assertEquals(1, backups.size());
 	}
+
+	@Test
+	void testListAllBackupFilesIgnoresUnexpectedFiles() throws Exception {
+		final OtelConfigurationFilesService service = newService();
+		final Path backupDir = tempOtelDir.resolve("backup");
+		Files.createDirectories(backupDir);
+		Files.writeString(backupDir.resolve("backup-20250101-120000__otel-config.yaml"), "receivers: {}");
+		Files.writeString(backupDir.resolve("random.yaml"), "junk");
+		Files.writeString(backupDir.resolve("backup-config.yaml"), "legacy");
+
+		final List<ConfigurationFile> backups = service.listAllBackupFiles();
+
+		assertEquals(1, backups.size(), "Only convention-compliant backup files should be listed");
+		assertEquals("backup-20250101-120000__otel-config.yaml", backups.get(0).getName());
+	}
 }

--- a/metricshub-agent/src/test/java/org/metricshub/web/util/BackupFileNamesTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/util/BackupFileNamesTest.java
@@ -1,0 +1,39 @@
+package org.metricshub.web.util;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class BackupFileNamesTest {
+
+	@Test
+	void testIsBackupFileName() {
+		assertTrue(BackupFileNames.isBackupFileName("backup-20260506-191418__otel-config.yaml"));
+		assertTrue(BackupFileNames.isBackupFileName("backup-20250101-120000__config.vm"));
+		assertFalse(BackupFileNames.isBackupFileName("backup-config.vm"));
+		assertFalse(BackupFileNames.isBackupFileName("random.yaml"));
+		assertFalse(BackupFileNames.isBackupFileName(null));
+	}
+}

--- a/metricshub-web/react/src/store/thunks/config-thunks.js
+++ b/metricshub-web/react/src/store/thunks/config-thunks.js
@@ -27,8 +27,10 @@ export const fetchConfigList = createAsyncThunk(
 					return [];
 				}),
 			]);
-			// Merge and return; server already returns flat names
-			return [...(configs || []), ...(backups || [])];
+			// Merge and return; server already returns flat names.
+			// Ignore unexpected files in the backup folder that do not follow the backup naming convention.
+			const validBackups = (backups || []).filter((f) => isBackupFileName(f?.name));
+			return [...(configs || []), ...validBackups];
 		} catch (e) {
 			return rejectWithValue(e.message);
 		}

--- a/metricshub-web/react/src/store/thunks/otel-config-thunks.js
+++ b/metricshub-web/react/src/store/thunks/otel-config-thunks.js
@@ -17,7 +17,8 @@ export const fetchOtelConfigList = createAsyncThunk(
 					return [];
 				}),
 			]);
-			return [...(configs || []), ...(backups || [])];
+			const validBackups = (backups || []).filter((f) => isBackupFileName(f?.name));
+			return [...(configs || []), ...validBackups];
 		} catch (e) {
 			return rejectWithValue(e.message);
 		}


### PR DESCRIPTION

- Added filtering for backup file names in both ConfigurationFilesService and OtelConfigurationFilesService to ensure only valid backup files are processed.
- Updated tests to verify that only convention-compliant backup files are listed, ignoring unexpected files.
- Adjusted the fetchConfigList and fetchOtelConfigList thunks to filter out invalid backup files from the response.

# Tests
<img width="743" height="173" alt="image" src="https://github.com/user-attachments/assets/b21f4723-4a86-4ab4-a2a3-db0c5192889c" />
<img width="2556" height="1355" alt="image" src="https://github.com/user-attachments/assets/52cce523-cbce-446a-84d0-e83a29e46d15" />
