### PR TITLE
Issue #1267: flag patched connectors in the patch directory parser so they can be identified in the web UI configuration forms

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/helper/ConfigHelper.java
@@ -29,9 +29,12 @@ import static org.metricshub.agent.helper.AgentConstants.LOG_DIRECTORY_NAME;
 import static org.metricshub.agent.helper.AgentConstants.PRODUCT_WIN_DIR_NAME;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.File;
 import java.io.IOException;
@@ -79,6 +82,7 @@ import org.metricshub.engine.configuration.IConfiguration;
 import org.metricshub.engine.connector.deserializer.ConnectorDeserializer;
 import org.metricshub.engine.connector.model.Connector;
 import org.metricshub.engine.connector.model.ConnectorStore;
+import org.metricshub.engine.connector.model.RawConnector;
 import org.metricshub.engine.connector.model.RawConnectorStore;
 import org.metricshub.engine.connector.model.common.DeviceKind;
 import org.metricshub.engine.connector.model.identity.ConnectorIdentity;
@@ -1289,9 +1293,20 @@ public class ConfigHelper {
 		// Parse and add connectors from a specific subdirectory
 		rawConnectorStore.addMany(new RawConnectorStore(getSubDirectory("connectors", false)).getStore());
 
-		// Add user's connectors if the connectors patch path is specified.
+		// Add user's connectors if the connectors patch path is specified. Each patch
+		// connector is flagged with "patched: true" in its raw definition so the compiled
+		// Connector carries the flag through to the Web UI — for both plain and template
+		// (variable) connectors, since the flag rides through the normal deserialization.
 		if (connectorsPatchPath != null) {
-			rawConnectorStore.addMany(new RawConnectorStore(Path.of(connectorsPatchPath)).getStore());
+			final Map<String, RawConnector> patchStore = new RawConnectorStore(Path.of(connectorsPatchPath)).getStore();
+			patchStore.values().forEach(ConfigHelper::flagRawConnectorAsPatched);
+			rawConnectorStore.addMany(patchStore);
+			log.info("Applying connectors patch directory: {}.", connectorsPatchPath);
+			log.debug(
+				"Applying connectors patch directory: {}. Number of patched connectors: {}.",
+				connectorsPatchPath,
+				patchStore.size()
+			);
 		}
 
 		// Generate the connector store from the raw connector store.
@@ -1306,6 +1321,27 @@ public class ConfigHelper {
 		log.info("Global Raw Connector Store size: {}", connectorStore.getRawConnectorStore().getStore().size());
 
 		return connectorStore;
+	}
+
+	/**
+	 * Sets {@code patched: true} on a raw connector's node so the compiled {@link Connector}
+	 * is flagged as patched. Applied to connectors loaded from the patch directory; the flag
+	 * survives connector compilation (including variable/template resolution) because it is
+	 * carried in the connector definition itself.
+	 *
+	 * @param rawConnector the raw connector to flag; unchanged if its node cannot be read
+	 */
+	private static void flagRawConnectorAsPatched(final RawConnector rawConnector) {
+		try {
+			final ObjectMapper mapper = JsonHelper.buildYamlMapper();
+			final JsonNode node = mapper.readTree(rawConnector.getByteConnector());
+			if (node instanceof ObjectNode objectNode) {
+				objectNode.put("patched", true);
+				rawConnector.setByteConnector(mapper.writeValueAsBytes(objectNode));
+			}
+		} catch (IOException e) {
+			log.debug("Unable to flag a patch-directory connector as patched: {}", e.getMessage());
+		}
 	}
 
 	/**

--- a/metricshub-agent/src/main/java/org/metricshub/web/dto/uiconfig/UiConnectorSummaryDto.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/dto/uiconfig/UiConnectorSummaryDto.java
@@ -68,6 +68,9 @@ public class UiConnectorSummaryDto {
 
 	private boolean autoDetectionDisabled;
 
+	/** True when the connector comes from the connectors patch directory (user-supplied / overriding a built-in). */
+	private boolean patched;
+
 	private boolean compatible;
 
 	@Builder.Default

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/UiConnectorCompatibilityService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/UiConnectorCompatibilityService.java
@@ -325,6 +325,7 @@ public class UiConnectorCompatibilityService {
 			.connectionTypes(connectionTypes)
 			.requiredProtocols(requiredProtocols.stream().sorted().toList())
 			.autoDetectionDisabled(autoDetectionDisabled)
+			.patched(connector.isPatched())
 			.compatible(false)
 			.incompatibilityReasons(List.of())
 			.hasVariables(hasVariables)

--- a/metricshub-agent/src/test/java/org/metricshub/web/service/UiConnectorCompatibilityServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/service/UiConnectorCompatibilityServiceTest.java
@@ -171,6 +171,27 @@ class UiConnectorCompatibilityServiceTest {
 	}
 
 	@Test
+	void testGetConnectorCatalogFlagsPatchedConnectors() {
+		connectorStore.getStore().get(WINDOWS_CONNECTOR_ID).setPatched(true);
+
+		final List<UiConnectorSummaryDto> catalog = service.getConnectorCatalog(connectorStore, extensionManager);
+
+		final UiConnectorSummaryDto windows = catalog
+			.stream()
+			.filter(item -> WINDOWS_CONNECTOR_ID.equals(item.getId()))
+			.findFirst()
+			.orElseThrow();
+		assertTrue(windows.isPatched(), "Connector from the patch directory should be flagged as patched");
+
+		final UiConnectorSummaryDto linux = catalog
+			.stream()
+			.filter(item -> LINUX_CONNECTOR_ID.equals(item.getId()))
+			.findFirst()
+			.orElseThrow();
+		assertFalse(linux.isPatched(), "Built-in connector should not be flagged as patched");
+	}
+
+	@Test
 	void testListConnectorsReturnsOnlyCompatibleEntriesByDefault() {
 		final List<UiConnectorSummaryDto> compatible = service.listConnectors(
 			"linux",

--- a/metricshub-engine/src/main/java/org/metricshub/engine/connector/model/Connector.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/connector/model/Connector.java
@@ -70,6 +70,14 @@ public class Connector implements Serializable {
 	private ConnectorIdentity connectorIdentity;
 
 	/**
+	 * Whether this connector is patched. It is {@code true} when the connector declares
+	 * {@code patched: true} in its YAML, or when it is loaded from the connectors patch
+	 * directory. Defaults to {@code false}. Surfaced in the Web UI as a "Patched" badge.
+	 */
+	@JsonSetter(nulls = SKIP)
+	private boolean patched;
+
+	/**
 	 * Set of connector names that the current connector extends.
 	 */
 	@JsonProperty("extends")

--- a/metricshub-engine/src/test/java/org/metricshub/engine/connector/parser/ConnectorStoreComposerTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/connector/parser/ConnectorStoreComposerTest.java
@@ -1,8 +1,10 @@
 package org.metricshub.engine.connector.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -71,6 +73,22 @@ class ConnectorStoreComposerTest {
 		// All connectors containing a variable in their JsonNode or in their embedded files should be found
 		assertEquals(2, connectorsWithVariables.size());
 		assertTrue(connectorsWithVariables.containsAll(List.of("ConnectorVariables", "EmbeddedConnectorVariables")));
+	}
+
+	@Test
+	void testConnectorDeserializesPatchedFlag() throws Exception {
+		final ObjectMapper mapper = JsonHelper.buildYamlMapper();
+		final ConnectorDeserializer deserializer = new ConnectorDeserializer(mapper);
+
+		// A connector declaring "patched: true" in its YAML is flagged as patched.
+		final Connector patched = deserializer.deserialize(
+			mapper.readTree("connector:\n  displayName: Patched Connector\npatched: true\n")
+		);
+		assertTrue(patched.isPatched(), "patched: true in the connector YAML must set Connector.patched");
+
+		// A connector that does not declare it defaults to not patched.
+		final Connector plain = deserializer.deserialize(mapper.readTree("connector:\n  displayName: Plain Connector\n"));
+		assertFalse(plain.isPatched(), "A connector without the patched flag must default to false");
 	}
 
 	@Test

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/OsCommandExtension.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/OsCommandExtension.java
@@ -106,8 +106,8 @@ public class OsCommandExtension implements IProtocolExtension {
 	@Override
 	public Map<Class<? extends IConfiguration>, Set<Class<? extends Source>>> getConfigurationToSourceMapping() {
 		return Map.ofEntries(
-			Map.entry(SshConfiguration.class, Set.of(CommandLineSource.class)),
-			Map.entry(OsCommandConfiguration.class, Set.of(CommandLineSource.class))
+			Map.entry(SshConfiguration.class, Set.of(CommandLineSource.class, FileSource.class)),
+			Map.entry(OsCommandConfiguration.class, Set.of(CommandLineSource.class, FileSource.class))
 		);
 	}
 

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/OsCommandExtensionTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/OsCommandExtensionTest.java
@@ -41,6 +41,7 @@ import org.metricshub.engine.connector.model.ConnectorStore;
 import org.metricshub.engine.connector.model.common.DeviceKind;
 import org.metricshub.engine.connector.model.identity.criterion.CommandLineCriterion;
 import org.metricshub.engine.connector.model.monitor.task.source.CommandLineSource;
+import org.metricshub.engine.connector.model.monitor.task.source.FileSource;
 import org.metricshub.engine.strategy.detection.CriterionTestResult;
 import org.metricshub.engine.strategy.source.SourceTable;
 import org.metricshub.engine.strategy.utils.OsCommandResult;
@@ -116,7 +117,14 @@ class OsCommandExtensionTest {
 
 	@Test
 	void testGetConfigurationToSourceMapping() {
-		assertFalse(osCommandExtension.getConfigurationToSourceMapping().isEmpty());
+		final var mapping = osCommandExtension.getConfigurationToSourceMapping();
+		assertFalse(mapping.isEmpty());
+		// SSH and OS command must be able to process both CommandLineSource and FileSource,
+		// so FileSource connectors are compatible with ssh/oscommand-configured hosts.
+		assertTrue(mapping.get(SshConfiguration.class).contains(CommandLineSource.class));
+		assertTrue(mapping.get(SshConfiguration.class).contains(FileSource.class));
+		assertTrue(mapping.get(OsCommandConfiguration.class).contains(CommandLineSource.class));
+		assertTrue(mapping.get(OsCommandConfiguration.class).contains(FileSource.class));
 	}
 
 	@Test

--- a/metricshub-web/react/src/components/hosts/HostConfigConnectorsSection.jsx
+++ b/metricshub-web/react/src/components/hosts/HostConfigConnectorsSection.jsx
@@ -399,6 +399,19 @@ const CONFIGURABLE_CONNECTOR_CHIP_SX = {
 	"& .MuiChip-label": { px: 0.75, py: 0 },
 };
 
+const PATCHED_CONNECTOR_CHIP_SX = {
+	height: 20,
+	fontSize: "0.625rem",
+	fontWeight: 700,
+	letterSpacing: "0.04em",
+	borderRadius: 0.75,
+	bgcolor: (theme) =>
+		alpha(theme.palette.warning.main, theme.palette.mode === "dark" ? 0.22 : 0.12),
+	color: "warning.main",
+	border: "none",
+	"& .MuiChip-label": { px: 0.75, py: 0 },
+};
+
 const CONNECTOR_LABEL_CONTAINER_SX = {
 	height: "100%",
 	width: "100%",
@@ -456,6 +469,7 @@ const ConnectorRowLabel = ({ item }) => {
 	const title = String(item?.displayName || "").trim() || id;
 	const description = getConnectorListDescription(item);
 	const hasVariables = Boolean(item?.hasVariables);
+	const patched = Boolean(item?.patched);
 	return (
 		<ConnectorTableRowLabel
 			icon={
@@ -468,8 +482,13 @@ const ConnectorRowLabel = ({ item }) => {
 			title={title}
 			description={description || "—"}
 			titleAdornment={
-				hasVariables ? (
-					<Chip size="small" label="CONFIGURABLE" sx={CONFIGURABLE_CONNECTOR_CHIP_SX} />
+				hasVariables || patched ? (
+					<>
+						{hasVariables ? (
+							<Chip size="small" label="CONFIGURABLE" sx={CONFIGURABLE_CONNECTOR_CHIP_SX} />
+						) : null}
+						{patched ? <Chip size="small" label="PATCHED" sx={PATCHED_CONNECTOR_CHIP_SX} /> : null}
+					</>
 				) : null
 			}
 		/>

--- a/metricshub-web/react/src/components/hosts/HostConnectorsCatalogDialog.jsx
+++ b/metricshub-web/react/src/components/hosts/HostConnectorsCatalogDialog.jsx
@@ -385,9 +385,33 @@ const HostConnectorsCatalogDialog = ({
 														>
 															<ConnectorDocumentationLink connectorId={id} iconOnly />
 															<Box sx={{ minWidth: 0, flex: 1 }}>
-																<Typography variant="body2" noWrap title={item.displayName || id}>
-																	{item.displayName || id}
-																</Typography>
+																<Stack
+																	direction="row"
+																	spacing={0.5}
+																	alignItems="center"
+																	sx={{ minWidth: 0 }}
+																>
+																	<Typography variant="body2" noWrap title={item.displayName || id}>
+																		{item.displayName || id}
+																	</Typography>
+																	{item.patched && (
+																		<Chip
+																			label="Patched"
+																			size="small"
+																			color="warning"
+																			variant="outlined"
+																			sx={{
+																				height: 18,
+																				flexShrink: 0,
+																				"& .MuiChip-label": {
+																					px: 0.75,
+																					fontSize: "0.65rem",
+																					fontWeight: 600,
+																				},
+																			}}
+																		/>
+																	)}
+																</Stack>
 																{!item.compatible && reasons.length > 0 && (
 																	<Typography
 																		variant="caption"


### PR DESCRIPTION

- Added patched flag on connectors, which is by default set to false, but is forced to true if the connector comes from patched directory.
- Added unit tests.
- Tested in the UI.

# Tests
<img width="612" height="131" alt="image" src="https://github.com/user-attachments/assets/df18f285-cad1-4486-9263-a25ed98af200" />
<img width="1664" height="582" alt="image" src="https://github.com/user-attachments/assets/a711d1a6-3da3-4f4c-ac7f-58ecc83d7a26" />

# Important
- This Pull request needs to be merged in Main after #1257
